### PR TITLE
push to meshes only if there is sth to render

### DIFF
--- a/openjscad.js
+++ b/openjscad.js
@@ -359,12 +359,16 @@ OpenJsCad.Viewer.csgToMeshes = function(initial_csg) {
       mesh.colors = colors;
       mesh.computeWireframe();
       mesh.computeNormals();
+
+      if ( mesh.vertices.length ) {
+        meshes.push(mesh);
+      }
+
       // start a new mesh
       mesh = new GL.Mesh({ normals: true, colors: true });
       triangles = [];
       colors = [];
       vertices = [];
-      meshes.push(mesh);	
     }
   }
   // finalize last mesh
@@ -373,6 +377,11 @@ OpenJsCad.Viewer.csgToMeshes = function(initial_csg) {
   mesh.colors = colors;
   mesh.computeWireframe();
   mesh.computeNormals();
+
+  if ( mesh.vertices.length ) {
+    meshes.push(mesh);
+  }
+
   return meshes;
 };
 


### PR DESCRIPTION
prevents "WebGL: INVALID_VALUE: vertexAttribPointer: bad size, stride or
offset lightgl.js:1059" warning when light.gl tries to render empty mesh
and size is zero.
