### PR TITLE
Add support for HTML5 number spinner as parameter input.

### DIFF
--- a/openjscad.js
+++ b/openjscad.js
@@ -1211,10 +1211,10 @@ OpenJsCad.Processor.prototype = {
       }
       var control = this.paramControls[i];
       var value = null;
-      if( (type == "text") || (type == "float") || (type == "int") )
+      if( (type == "text") || (type == "float") || (type == "int") || (type == "number") )
       {
         value = control.value;
-        if( (type == "float") || (type == "int") )
+        if( (type == "float") || (type == "int") || (type == "number") )
         {
           var isnumber = !isNaN(parseFloat(value)) && isFinite(value);
           if(!isnumber)
@@ -1506,15 +1506,18 @@ OpenJsCad.Processor.prototype = {
       {
         type = paramdef.type;
       }
-      if( (type !== "text") && (type !== "int") && (type !== "float") && (type !== "choice") )
+      if( (type !== "text") && (type !== "int") && (type !== "float") && (type !== "choice") && (type !== "number") )
       {
         throw new Error(errorprefix + "Unknown parameter type '"+type+"'");
       }
       var control;
-      if( (type == "text") || (type == "int") || (type == "float") )
+      if( (type == "text") || (type == "int") || (type == "float") || (type == "number") )
       {
         control = document.createElement("input");
-        control.type = "text";
+        if (type == "number")
+            control.type = "number";
+        else
+            control.type = "text";
         if('default' in paramdef)
         {
           control.value = paramdef["default"];
@@ -1523,7 +1526,7 @@ OpenJsCad.Processor.prototype = {
           control.value = paramdef.initial;
         else
         {
-          if( (type == "int") || (type == "float") )
+          if( (type == "int") || (type == "float") || (type == "number") )
           {
             control.value = "0";
           }
@@ -1534,6 +1537,10 @@ OpenJsCad.Processor.prototype = {
         }
         if(paramdef.size!==undefined) 
            control.size = paramdef.size;
+        for (var property in paramdef)
+            if (paramdef.hasOwnProperty (property))
+                if ((property != "name") && (property != "type") && (property != "default") && (property != "initial") && (property != "caption"))
+                    control.setAttribute (property, paramdef[property]);
       }
       else if(type == "choice")
       {


### PR DESCRIPTION
Small request from Kurt Meister. He actually wanted a slider, but a slider with a rebuildSolid() call would suck.

I'm not sure where the documentation lives, but here's some text and an example usage:

A float, int, number or text parameter is created by including the following object in the array returned by getParameterDefinitions():

``` javascript
{
  name: 'width',
  type: 'float',                      // or 'text' or 'int'
  initial: 1.23,                      // optional, sets the initial value
                                      // NOTE: parameter "default" is deprecated
  caption: 'Width of the thingy:',    // optional, displayed left of the input field
                                      // if omitted, the 'name' is displayed (i.e. 'width')

}
```

The number parameter type will only work in HTML5 browsers and you should probably also include the standard attributes min, max and step, as in this example:

``` javascript
// -- OpenJSCAD.org logo
function getParameterDefinitions() {
  return [
    { name: 'size', type: 'number', initial: 3, caption: "Size of the cube:", min: 2.0, max: 3.5, step: 0.1 }
  ];
}

function main(params) {
   return union(
      difference(
         cube({size: params.size, center: true}),
         sphere({r:2, center: true})
      ),
      intersection(
          sphere({r: 1.3, center: true}),
          cube({size: 2.1, center: true})
      )
   ).translate([0,0,1.5]).scale(10);
}
```
