### PR TITLE
fix(remote loading)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ as well CLI (command-line interface) for server-side computations with NodeJS.
 ## Table of Contents
 
 - [Usage](#usage)
+- [Development](#development)
 - [Documentation](#documentation)
 - [Contribute](#contribute)
 - [Community](#community)
@@ -148,6 +149,42 @@ dependencies of **all** packages
 
 This will be expanded upon in the future, and is the backbone of the newer, modular Jscad
 
+## Development
+
+We offer pre-built versions of OpenJSCAD to be uses directly here :
+- [standard](./dist/index.js)
+- [minimalist](./dist/min.js)
+- [with options](./dist/options.js)
+
+but you can also rebuild them manually if you need :
+
+- standard: ```npm run build-web```
+- minimalist: ```npm run build-min```
+- with options: ```npm run build-opt```
+
+### Adding new features in CSG.js or other modules:
+Since OpenJSCAD is made up of multiple dependent modules (csg.js, openscad-openjscad-translator etc),
+the easiest method is to use ```npm link``` to have a 'live' updating development version of OpenJSCAD:
+
+For example for CSG.js
+- create a base directory
+- clone this repository ```git clone git@github.com:jscad/OpenJSCAD.org.git```
+- go into OpenJSCAD.org folder ```cd OpenJSCAD.org```
+- install dependencies ```npm install```
+- start dev server : ```npm run start-dev```
+- go back to base directory ```cd ..```
+- clone CSG.js ```git clone git@github.com:jscad/csg.js.git```
+- go into OpenJSCAD.org folder again ```cd OpenJSCAD.org```
+- now type ```npm link ../csg.js/ @jscad/csg```
+
+You can now make changes to the CSG.js code and see it impact your locally running
+copy of OpenJSCAD live.
+
+## Documentation
+
+- [OpenJSCAD User & Programming Guide](https://en.wikibooks.org/wiki/OpenJSCAD_User_Guide)
+- [OpenJSCAD Quick Reference](https://en.wikibooks.org/wiki/OpenJSCAD_Quick_Reference)
+
 ## Contribute
 
 OpenJSCAD.org is part of the JSCAD Organization, and is maintained by a group of volunteers. We welcome and encourage anyone to pitch in but please take a moment to read the following guidelines.
@@ -163,11 +200,6 @@ OpenJSCAD.org is part of the JSCAD Organization, and is maintained by a group of
 * If you have a change or new feature in mind, please start a conversation with the [Core Developers](https://plus.google.com/communities/114958480887231067224) and start contributing changes.
 
 Small Note: If editing this README, please conform to the [standard-readme](https://github.com/RichardLitt/standard-readme) specification.
-
-## Documentation
-
-- [OpenJSCAD User & Programming Guide](https://en.wikibooks.org/wiki/OpenJSCAD_User_Guide)
-- [OpenJSCAD Quick Reference](https://en.wikibooks.org/wiki/OpenJSCAD_Quick_Reference)
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,29 @@ And then access the contents via the URL of the web-site.
 
 >NOTE: You might need configuration changes to allow access to the some of the contents (examples etc).
 
+#### Use of proxies for remote file loading:
+
+if you want the capability , just like the official OpenJSCAD.org site, to load remote projects/files directly
+from the web based user interface, but without the hassle with CORS issues,
+you can use a proxy file (see [remote.pl](./remote.pl) & [remote.php](./remote.php)):
+this is a server side script that does the following
+- caches the remote file locally on the server
+- returns the local path to the downloaded file for OpenJSCAD to use
+
+use and path of the proxy can be set by:
+- changing the `proxyUrl` value in [src/ui/index.js](src/ui/index.js)
+- since this is hardcoded , if you do not use the provided dev server,
+ rebuild your main file (npm run build-web etc, see [Development](#development))
+
+
+then you can use it like so:
+https://<YOURSITE>/?uri=http://www.thingiverse.com/download:164128
+or
+https://<YOURSITE>/#http://www.thingiverse.com/download:164128
+
+>Note: a PR with a node.js based proxy would be a welcome addition :)
+
+
 ### Use as Command Line Interface (CLI)
 
 For CLI(command-line interface) use

--- a/src/ui/examples.js
+++ b/src/ui/examples.js
@@ -158,7 +158,8 @@ function loadViaProxy (url, proxyPath='remote.pl', {memFs, gProcessor, gEditor, 
   xhr.onload = function () {
     const data = JSON.parse(this.responseText)
     console.log('data from proxy', data)
-    const url = `${location.href}/${data.file}`
+    const baseUrl = location.protocol + '//' + location.host + location.pathname
+    const url = `${baseUrl}/${data.file}`
     fetchExample(data.file, url, {memFs, gProcessor, gEditor})
     // document.location = docUrl.replace(/#.*$/, '#') // this won't reload the entire web-page
   }

--- a/src/ui/examples.js
+++ b/src/ui/examples.js
@@ -148,6 +148,7 @@ function fetchUriParams (uri, paramName, defaultValue = undefined) {
 }
 
 function loadViaProxy (url, proxyPath='remote.pl', {memFs, gProcessor, gEditor, remoteUrl}) {
+  console.log('loadViaProxy', url, proxyPath)
   var xhr = new XMLHttpRequest()
   xhr.open('GET', remoteUrl + url, true)
   if (url.match(/\.(stl|gcode)$/i)) {
@@ -156,6 +157,7 @@ function loadViaProxy (url, proxyPath='remote.pl', {memFs, gProcessor, gEditor, 
   gProcessor.setStatus('loading', url)
   xhr.onload = function () {
     var data = JSON.parse(this.responseText)
+    console.log('data from proxy', data)
     fetchExample(data.file, data.url, {memFs, gProcessor, gEditor})
     // document.location = docUrl.replace(/#.*$/, '#') // this won't reload the entire web-page
   }

--- a/src/ui/examples.js
+++ b/src/ui/examples.js
@@ -183,7 +183,7 @@ function loadInitialExample (me, params) {
 
     // const proxyPath = fetchUriParams(url, 'proxyPath', undefined)
     const useProxy = params.proxyUrl !== undefined || document.URL.match(/#(https?:\/\/\S+)$/) !== null
-    const documentUri = fetchUriParams(url, 'documentUri', undefined) || nth(1, document.URL.match(/#(https?:\/\/\S+)$/)) || nth(1, document.URL.match(/#(examples\/\S+)$/))
+    const documentUri = fetchUriParams(url, 'uri', undefined) || nth(1, document.URL.match(/#(https?:\/\/\S+)$/)) || nth(1, document.URL.match(/#(examples\/\S+)$/))
     const baseUrl = location.protocol + '//' + location.host + location.pathname
 
     const isRemote = documentUri ? documentUri.match(/(https?:\/\/\S+)$/) !== null : false

--- a/src/ui/examples.js
+++ b/src/ui/examples.js
@@ -156,9 +156,10 @@ function loadViaProxy (url, proxyPath='remote.pl', {memFs, gProcessor, gEditor, 
   }
   gProcessor.setStatus('loading', url)
   xhr.onload = function () {
-    var data = JSON.parse(this.responseText)
+    const data = JSON.parse(this.responseText)
     console.log('data from proxy', data)
-    fetchExample(data.file, data.url, {memFs, gProcessor, gEditor})
+    const url = `${location.href}/${data.file}`
+    fetchExample(data.file, url, {memFs, gProcessor, gEditor})
     // document.location = docUrl.replace(/#.*$/, '#') // this won't reload the entire web-page
   }
   xhr.send()

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -14,15 +14,15 @@ const Processor = require('../jscad/processor')
 const me = document.location.toString().match(/^file:/) ? 'web-offline' : 'web-online'
 const browser = detectBrowser()
 
-var showEditor = true
-var remoteUrl = './remote.pl?url='
-// var remoteUrl = './remote.php?url='
+const showEditor = true
+const proxyUrl = './remote.pl?url='
+// const proxyUrl = './remote.php?url='
+
 var gProcessor = null
 var gEditor = null
 
 var memFs = [] // associated array, contains file content in source memFs[i].{name,source}
 var currentFiles = [] // linear array, contains files (to read)
-
 
 function getElementHeight (element) {
   return parseInt(getComputedStyle(element).height)
@@ -101,7 +101,7 @@ function init () {
     let examples = document.getElementById('examples');
     if (examples) {
       createExamples(me)
-      loadInitialExample(me, {memFs, gProcessor, gEditor, remoteUrl})
+      loadInitialExample(me, {memFs, gProcessor, gEditor, proxyUrl})
 
       // -- Examples
       examplesTitle.addEventListener('click', function (e) {


### PR DESCRIPTION
This PR adds a possible fix & upgrade for #274 
- add standard (normal) url param parsing instead of the '#' based remote document param 
- adds back and cleans up previous # + proxy
- proxy can be disabled by setting proxyURL to undefined
- removed url clearing so that parameters & uris stay and are clear
- fleshed out readme

This means you can use things like: 
- http://localhost:8081/?uri=http://www.thingiverse.com/download:164128 
- http://localhost:8081/?uri=examples/example001.jscad (works)

