### PR TITLE
feat(processor/viewer): do not clear viewer until new 3D mesh is ready

### DIFF
--- a/src/jscad/processor.js
+++ b/src/jscad/processor.js
@@ -461,8 +461,10 @@ Processor.prototype = {
   rebuildSolid: function () {
     // clear previous solid and settings
     this.abort()
+    //this clears output file cache
+    this.clearOutputFile()
+    this.enableItems()
     this.setError('')
-    this.clearViewer()
     this.enableItems()
     this.setStatus('rendering')
 
@@ -478,6 +480,8 @@ Processor.prototype = {
     let that = this
     function callback (err, objects) {
       if (err) {
+        that.clearViewer()
+
         if (err.stack) {
           let errtxt = ''
           errtxt += '\nStack trace:\n' + err.stack
@@ -485,6 +489,7 @@ Processor.prototype = {
         }
         that.setStatus('error', err)// 'Error.'
         that.state = 3 // incomplete
+
       } else {
         that.setCurrentObjects(objects)
         that.setStatus('ready')
@@ -527,7 +532,6 @@ Processor.prototype = {
     this.clearOutputFile()
     const blob = this.currentObjectsToBlob()
     const extension = this.selectedFormatInfo().extension
-    console.log('generateOutputFile', extension)
 
     function onDone (data, downloadAttribute, blobMode, noData) {
       this.hasOutputFile = true


### PR DESCRIPTION
This PR implements #291 : it makes 'live updates' for parameters much more pleasant to look at 
**BEFORE:**
![jscad-params-old](https://user-images.githubusercontent.com/623281/30781084-155b190a-a119-11e7-8389-5854df6ee89f.gif)
**AFTER:**
![jscad-params-new](https://user-images.githubusercontent.com/623281/30781083-15583a00-a119-11e7-94cc-1b6c7592845f.gif)


