### PR TITLE
Fix and clarify npm link instructions in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ the easiest method is to use ```npm link``` to have a 'live' updating developmen
 - clone this repository ```git clone https://github.com/jscad/OpenJSCAD.org.git```
 - go into OpenJSCAD.org folder ```cd OpenJSCAD.org```
 - install dependencies ```npm install```
-- start dev server if desired: ```npm run start-dev```
-- make it so global ```openjscad``` refers to local code: ```npm link```
+- if desired, make the ```openjscad``` command refer to the code in this folder: ```npm link```
+- if desired, start dev server: ```npm run start-dev```
 
 Then, for example for CSG.js:
 - go back to base directory ```cd ..```

--- a/README.md
+++ b/README.md
@@ -201,17 +201,18 @@ but you can also rebuild them manually if you need :
 ### Adding new features in CSG.js or other modules:
 Since OpenJSCAD is made up of multiple dependent modules (csg.js, openscad-openjscad-translator etc),
 the easiest method is to use ```npm link``` to have a 'live' updating development version of OpenJSCAD:
-
-For example for CSG.js
 - create a base directory
-- clone this repository ```git clone git@github.com:jscad/OpenJSCAD.org.git```
+- clone this repository ```git clone https://github.com/jscad/OpenJSCAD.org.git```
 - go into OpenJSCAD.org folder ```cd OpenJSCAD.org```
 - install dependencies ```npm install```
-- start dev server : ```npm run start-dev```
+- start dev server if desired: ```npm run start-dev```
+- make it so global ```openjscad``` refers to local code: ```npm link```
+
+Then, for example for CSG.js:
 - go back to base directory ```cd ..```
-- clone CSG.js ```git clone git@github.com:jscad/csg.js.git```
+- clone CSG.js ```git clone https://github.com/jscad/csg.js.git```
 - go into OpenJSCAD.org folder again ```cd OpenJSCAD.org```
-- now type ```npm link ../csg.js/ @jscad/csg```
+- now type ```npm link ../csg.js``` to make @jscad/csg refer to local ../csg.js.
 
 You can now make changes to the CSG.js code and see it impact your locally running
 copy of OpenJSCAD live.


### PR DESCRIPTION
- Changed `npm link ../csg.js/ @jscad/csg` to `npm link ../csg.js`.
  I'm not sure what the old recipe was supposed to mean (`npm help link`
  doesn't mention that usage), but it gave me errors when I tried it
  (npm v3.10.10).  The new recipe is what the help page describes,
  and it works for me.
- Changed the `git clone` urls to the ones advertised on the respective
  github pages, which use https (the old ones weren't working for me).
- Added explicit recipe for making the main repo live-updating (`npm link`),
  and separated out the csg.js-specific commands into a distinct section
  for clarity.
