### PR TITLE
plumb GL options through viewer

### DIFF
--- a/src/ui/viewer/jscad-viewer-lightgl.js
+++ b/src/ui/viewer/jscad-viewer-lightgl.js
@@ -43,7 +43,7 @@ LightGLEngine.prototype = {
   },
   createRenderer: function () {
     // Set up WebGL state
-    var gl = GL.create()
+    var gl = GL.create(this.options.glOptions)
     this.gl = gl
     this.gl.lineWidth(1) // don't let the library choose
 

--- a/src/ui/viewer/jscad-viewer.js
+++ b/src/ui/viewer/jscad-viewer.js
@@ -15,7 +15,8 @@ function Viewer (containerelement, options) {
   if ('plate' in options) { this.setPlateOptions(options['plate']) }
   if ('axis' in options) { this.setAxisOptions(options['axis']) }
   if ('solid' in options) { this.setSolidOptions(options['solid']) }
-
+  if ('glOptions' in options) { this.options.glOptions = options.glOptions }
+  
   var engine
 
   // select drawing engine from options


### PR DESCRIPTION
My goal is to be able to use canvas.toDataURL() from the viewer. 

To do that, we need to be able to pass `{preserveDrawingBuffer: true}` as the `options` to

```gl = canvas.getContext('webgl', options);``` [here](https://github.com/jscad/OpenJSCAD.org/blob/master/src/ui/viewer/lightgl.js#L1137)

This PR is the plumbing which passes the gl options through. So we can create a `new Viewer(viewerdiv, { glOptions: {preserveDrawingBuffer: true} })`