### PR TITLE
fix(instanceOf): replaced remaining instanceOF CA/SG 

### DIFF
--- a/src/core/convertToSolid.js
+++ b/src/core/convertToSolid.js
@@ -10,7 +10,7 @@ const {isCSG, isCAG} = require('./utils')
  */
 function convertToSolid (objects, params) {
   if (objects.length === undefined) {
-    if ((objects instanceof CAG) || (objects instanceof CSG)) {
+    if (isCAG(objects) || isCSG(objects)) {
       var obj = objects
       objects = [obj]
     } else {
@@ -21,7 +21,7 @@ function convertToSolid (objects, params) {
   var solid = null
   for (var i = 0; i < objects.length; i++) {
     let obj = objects[i]
-    if (obj instanceof CAG) {
+    if (isCAG(obj)) {
       obj = obj.extrude({offset: [0, 0, 0.1]}) // convert CAG to a thin solid CSG
     }
     if (solid !== null) {
@@ -55,11 +55,11 @@ function convertToSolid2 (objects, params) {
   object = !foundCSG ? new CAG() : new CSG()
 
   for (let i = 0; i < objects.length; i++) {
-    if (foundCSG === true && objects[i] instanceof CAG) {
+    if (foundCSG === true && isCAG(objects[i])) {
       object = object.union(objects[i].extrude({offset: [0, 0, 0.1]})) // convert CAG to a thin solid CSG
       continue
     }
-    if (foundCAG === true && objects[i] instanceof CSG) {
+    if (foundCAG === true && isCSG(objects[i])) {
       continue
     }
     object = object.union(objects[i])

--- a/src/io/formats.js
+++ b/src/io/formats.js
@@ -1,4 +1,5 @@
 const { CSG, CAG } = require('@jscad/csg')
+const { isCSG, isCAG } = require('../core/utils')
 
 // handled format descriptions
 const formats = {
@@ -99,8 +100,8 @@ function supportedFormatsForObjects (objects) {
   let foundCSG = false
   let foundCAG = false
   for (let i = 0; i < objects.length; i++) {
-    if (objects[i] instanceof CSG) { foundCSG = true }
-    if (objects[i] instanceof CAG) { foundCAG = true }
+    if (isCSG(objects[i])) { foundCSG = true }
+    if (isCAG(objects[i])) { foundCAG = true }
   }
   for (let format in formats) {
     if (foundCSG && formats[format].convertCSG === true) {


### PR DESCRIPTION
This replaces the last remaining instanceOf CSG/CAG calls (which are dangerous, as objects using different versions of CSG.js will end up NOT having the correct type detected) 
They now use the helper functions isCAG/isCSG which use very basic 'duck typing' (ie checking the internal fields of the objects).
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?


> Note: please do NOT include build files (those generate by the build-xxx commands) with your PR,

Thank you for your help in advance, much appreciated !
