### PR TITLE
feat(dxf input support): add Dxf deserializer to support dxf input files

### DIFF
--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -41,7 +41,7 @@
 const fs = require('fs')
 const env = require('./env')
 const version = require('./package.json').version
-const { formats } = require('@jscad/core/io/formats')
+const { formats, conversionFormats } = require('@jscad/core/io/formats')
 const { getDesignEntryPoint } = require('@jscad/core/code-loading/requireDesignUtilsFs')
 const generateOutputData = require('./generateOutputData')
 
@@ -79,6 +79,7 @@ generateOutputData(src, params, {outputFile, outputFormat, inputFile, inputForma
   }).catch(error => console.error(error))
 
 // -- helper functions ---------------------------------------------------------------------------------------
+
 function parseArgs (args) {
   // hint: https://github.com/substack/node-optimist
   //       https://github.com/visionmedia/commander.js
@@ -100,6 +101,15 @@ function parseArgs (args) {
   let outputFormat
   let params = {}
 
+  // let supportedInputFormats = conversionFormats.join('|')
+  // console.log('supportedInputFormats', supportedInputFormats)
+  const isValidInputFileFormat = input => {
+    return conversionFormats.reduce(function (acc, format) {
+      return input.endsWith(format) || acc
+    }, false)
+  }
+  const getFileExtensionFromString = input => input.substring(input.lastIndexOf('.') + 1)
+
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '-of') { // -of <format>
       outputFormat = args[++i]
@@ -114,9 +124,9 @@ function parseArgs (args) {
       params[RegExp.$1] = args[++i]
     } else if (args[i].match(/^--(\w+)$/)) { // params for main()
       params[RegExp.$1] = args[++i]
-    } else if (args[i].match(/.+\.(jscad|js|scad|stl|amf|obj|gcode|svg|json)$/i)) {
+    } else if (isValidInputFileFormat(args[i])) {
       inputFile = args[i]
-      inputFormat = RegExp.$1
+      inputFormat = getFileExtensionFromString(args[i])// RegExp.$1
       if (!fs.statSync(inputFile).isFile()) {
         console.log('ERROR: cannot open input file/directory <' + inputFile + '>')
         process.exit(1)

--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -105,10 +105,10 @@ function parseArgs (args) {
   // console.log('supportedInputFormats', supportedInputFormats)
   const isValidInputFileFormat = input => {
     return conversionFormats.reduce(function (acc, format) {
-      return input.endsWith(format) || acc
+      return input.endsWith(format.toLowerCase()) || acc
     }, false)
   }
-  const getFileExtensionFromString = input => input.substring(input.lastIndexOf('.') + 1)
+  const getFileExtensionFromString = input => (input.substring(input.lastIndexOf('.') + 1)).toLowerCase()
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '-of') { // -of <format>

--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -104,6 +104,9 @@ function parseArgs (args) {
   // let supportedInputFormats = conversionFormats.join('|')
   // console.log('supportedInputFormats', supportedInputFormats)
   const isValidInputFileFormat = input => {
+    if (input === undefined || input === null || !(typeof input === 'string')) {
+      return false
+    }
     return conversionFormats.reduce(function (acc, format) {
       return input.endsWith(format.toLowerCase()) || acc
     }, false)

--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -108,7 +108,7 @@ function parseArgs (args) {
       return false
     }
     return conversionFormats.reduce(function (acc, format) {
-      return input.endsWith(format.toLowerCase()) || acc
+      return input.toLowerCase().endsWith(format.toLowerCase()) || acc
     }, false)
   }
   const getFileExtensionFromString = input => (input.substring(input.lastIndexOf('.') + 1)).toLowerCase()

--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -45,20 +45,11 @@ const { formats, conversionFormats } = require('@jscad/core/io/formats')
 const { getDesignEntryPoint } = require('@jscad/core/code-loading/requireDesignUtilsFs')
 const generateOutputData = require('./generateOutputData')
 
-/*
-const getExtension = filename => {
-  const ext = extname(filename || '').split('.')
-  return ext[ext.length - 1]
-} */
-
-// var csg = sphere(1);          // -- basic test
-// var csg = require(file).main; // -- treating .jscad as module? later perhaps
-
 const args = process.argv.splice(2)
 
 // handle arguments
 // inputs, outputs
-let {inputFile, inputFormat, outputFile, outputFormat, params} = parseArgs(args)
+let {inputFile, inputFormat, outputFile, outputFormat, params, addMetaData} = parseArgs(args)
 
 // outputs
 const output = determineOutputNameAndFormat(outputFormat, outputFile)
@@ -73,7 +64,7 @@ let src = fs.readFileSync(inputFile, inputFile.match(/\.stl$/i) ? 'binary' : 'UT
 // const outputData = generateOutputData(src, params, {outputFormat})
 // -- and write it to disk
 // writeOutputDataToFile(outputFile, outputData)
-generateOutputData(src, params, {outputFile, outputFormat, inputFile, inputFormat, version})
+generateOutputData(src, params, {outputFile, outputFormat, inputFile, inputFormat, version, addMetaData})
   .then(function (outputData) {
     writeOutputDataToFile(outputFile, outputData)
   }).catch(error => console.error(error))
@@ -89,7 +80,7 @@ function parseArgs (args) {
   // })
   if (args.length < 1) {
     console.log('USAGE:\n\nopenjscad [-v] <file> [-of <format>] [-o <output>]')
-    console.log('\t<file>  :\tinput file (Supported types: .jscad, .js, .scad, .stl, .amf, .obj, .gcode, .svg, .json)')
+    console.log('\t<file>  :\tinput file (Supported types: .jscad, .js, .scad, .stl, .amf, .obj, .gcode, .svg, .json, .dxf)')
     console.log('\t<output>:\toutput file (Supported types: .jscad, .stl, .amf, .dxf, .svg, .json)')
     console.log("\t<format>:\t'jscad', 'stla' (STL ASCII, default), 'stlb' (STL Binary), 'amf', 'dxf', 'svg', 'json'")
     process.exit(1)
@@ -99,7 +90,8 @@ function parseArgs (args) {
   let inputFormat
   let outputFile
   let outputFormat
-  let params = {}
+  let params = {} // parameters to feed the script if applicable
+  let addMetaData = false // wether to add metadata to outputs or not : ie version info, timestamp etc
 
   // let supportedInputFormats = conversionFormats.join('|')
   // console.log('supportedInputFormats', supportedInputFormats)
@@ -113,6 +105,8 @@ function parseArgs (args) {
   }
   const getFileExtensionFromString = input => (input.substring(input.lastIndexOf('.') + 1)).toLowerCase()
 
+  const parseBool = input => input.toLowerCase() === "true"
+
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '-of') { // -of <format>
       outputFormat = args[++i]
@@ -121,6 +115,8 @@ function parseArgs (args) {
       outputFile = outputFile.replace(/^\-o(\S+)$/, '$1')
     } else if (args[i] === '-o') { // -o <output>
       outputFile = args[++i]
+    } else if (args[i] === '-add-metadata') { // -metadata true/false
+      addMetaData = parseBool(args[++i])
     } else if (args[i].match(/^--(\w+)=(.*)/)) { // params for main()
       params[RegExp.$1] = RegExp.$2
     } else if (args[i].match(/^--(\w+)$/)) { // params for main()
@@ -129,7 +125,7 @@ function parseArgs (args) {
       params[RegExp.$1] = args[++i]
     } else if (isValidInputFileFormat(args[i])) {
       inputFile = args[i]
-      inputFormat = getFileExtensionFromString(args[i])// RegExp.$1
+      inputFormat = getFileExtensionFromString(args[i])
       if (!fs.statSync(inputFile).isFile()) {
         console.log('ERROR: cannot open input file/directory <' + inputFile + '>')
         process.exit(1)
@@ -163,7 +159,9 @@ function parseArgs (args) {
     inputFormat,
     outputFile,
     outputFormat,
-    params}
+    params,
+    addMetaData
+  }
 }
 
 function determineOutputNameAndFormat (outputFormat, outputFile) {

--- a/packages/cli/cli.test.js
+++ b/packages/cli/cli.test.js
@@ -25,6 +25,7 @@ test.beforeEach(t => {
     jscadPath: path.resolve(__dirname, jscadPath)
   }
 })
+//   console.log('stl', fs.statSync(outputPath).size)
 
 test('require() support', t => {
   const jscadPath = t.context.jscadPath
@@ -36,7 +37,7 @@ test('require() support', t => {
   // first install the module's dependencies, just in case
   execSync('npm install', {cwd: designPath})
   // note that in this case, we pass a FOLDER to the CLI, not a file
-  const cmd = `node ${jscadPath} ${designPath} --size 12.4 -o ${outputPath} -of stla`
+  const cmd = `node ${jscadPath} ${designPath} --size 12.4 -o ${outputPath} -of stla -add-metadata false`
   execSync(cmd, {stdio: [0, 1, 2]})
   t.deepEqual(true, fs.existsSync(expPath))
   almostEquals(t, fs.statSync(outputPath).size, 1121, 2)
@@ -48,7 +49,7 @@ test('jscad (basic, input file only)', t => {
   const expPath = path.join(examplesPath, '/logo.stl')
   t.context = {outputPath: expPath}
 
-  const cmd = `node ${jscadPath} ${inputPath}`
+  const cmd = `node ${jscadPath} ${inputPath} -add-metadata false`
   execSync(cmd, {stdio: [0, 1, 2]})
   t.deepEqual(true, fs.existsSync(expPath))
   almostEquals(t, fs.statSync(expPath).size, 338371, 2) // this has to be set this large because of the cross platform differences
@@ -60,7 +61,7 @@ test('jscad with parameters', t => {
   const outputPath = 'JustMe_Geek_name_plate.amf'
   const expPath = outputPath
   t.context = {outputPath}
-  const cmd = `node ${jscadPath} ${inputPath} --name "Just Me" --title "Geek" -o ${outputPath} `
+  const cmd = `node ${jscadPath} ${inputPath} --name "Just Me" --title "Geek" -o ${outputPath} -add-metadata false`
   execSync(cmd, {stdio: [0, 1, 2]})
   t.deepEqual(true, fs.existsSync(expPath))
   almostEquals(t, fs.statSync(expPath).size, 655732, 50)
@@ -72,7 +73,7 @@ test('jscad with complex/ multiple type of parameters', t => {
   const outputPath = 'grille.stl'
   const expPath = outputPath
   t.context = {outputPath}
-  const cmd = `node ${jscadPath} ${inputPath} --outerwidth 176.25 --outerdepth 15.2 --numdividers 4 --addlooseners "Yes" --show "grille" --mouseears 0 --quality 0 -o ${outputPath} `
+  const cmd = `node ${jscadPath} ${inputPath} --outerwidth 176.25 --outerdepth 15.2 --numdividers 4 --addlooseners "Yes" --show "grille" --mouseears 0 --quality 0 -o ${outputPath} -add-metadata false`
   execSync(cmd, {stdio: [0, 1, 2]})
   t.deepEqual(true, fs.existsSync(expPath))
   almostEquals(t, fs.statSync(expPath).size, 216484, 50)
@@ -85,7 +86,7 @@ test('jscad to stl (ascii)', t => {
   const expPath = 'test.stl'
   t.context = {outputPath}
 
-  const cmd = `node ${jscadPath} ${inputPath} -o ${outputPath} -of stla`
+  const cmd = `node ${jscadPath} ${inputPath} -o ${outputPath} -of stla -add-metadata false`
   execSync(cmd, {stdio: [0, 1, 2]})
   t.deepEqual(true, fs.existsSync(expPath))
   almostEquals(t, fs.statSync(expPath).size, 338371, 2)
@@ -97,7 +98,7 @@ test('jscad to stl(binary)', t => {
   const outputPath = 'test.stl'
   t.context = {outputPath}
 
-  const cmd = `node ${jscadPath} ${inputPath} -o ${outputPath} -of stlb`
+  const cmd = `node ${jscadPath} ${inputPath} -o ${outputPath} -of stlb -add-metadata false`
   execSync(cmd, {stdio: [0, 1, 2]})
   t.deepEqual(true, fs.existsSync(outputPath))
   // t.deepEqual(fs.readFileSync(expPath), fs.readFileSync(outputPath))
@@ -110,7 +111,7 @@ test('jscad to amf', t => {
   const outputPath = 'test.amf'
   t.context = {outputPath}
 
-  const cmd = `node ${jscadPath} ${inputPath} -o ${outputPath} -of amf`
+  const cmd = `node ${jscadPath} ${inputPath} -o ${outputPath} -of amf -add-metadata false`
   execSync(cmd, {stdio: [0, 1, 2]})
   t.deepEqual(true, fs.existsSync(outputPath))
   almostEquals(t, fs.statSync(outputPath).size, 397341, 50)
@@ -123,7 +124,7 @@ test('jscad to amf(with transparency)', t => {
   const expPath = outputPath
   t.context = {outputPath}
 
-  const cmd = `node ${jscadPath} ${inputPath} -o ${outputPath} -of amf`
+  const cmd = `node ${jscadPath} ${inputPath} -o ${outputPath} -of amf -add-metadata false`
   execSync(cmd, {stdio: [0, 1, 2]})
   t.deepEqual(true, fs.existsSync(expPath))
   almostEquals(t, fs.statSync(outputPath).size, 240108, 50)
@@ -136,7 +137,7 @@ test('openscad to stl (ascii)', t => {
   const expPath = 'test.stl'
   t.context = {outputPath}
 
-  const cmd = `node ${jscadPath} ${inputPath} -o ${outputPath} -of stla`
+  const cmd = `node ${jscadPath} ${inputPath} -o ${outputPath} -of stla -add-metadata false`
   execSync(cmd, {stdio: [0, 1, 2]})
   t.deepEqual(true, fs.existsSync(expPath))
   almostEquals(t, fs.statSync(outputPath).size, 629242, 100)
@@ -149,7 +150,7 @@ test('openscad to stl(binary)', t => {
   // const expPath = path.join(examplesPath, '/logo-binary.stl')
   t.context = {outputPath}
 
-  const cmd = `node ${jscadPath} ${inputPath} -o ${outputPath} -of stlb`
+  const cmd = `node ${jscadPath} ${inputPath} -o ${outputPath} -of stlb -add-metadata false`
   execSync(cmd, {stdio: [0, 1, 2]})
   t.deepEqual(true, fs.existsSync(outputPath))
   // t.deepEqual(fs.readFileSync(expPath), fs.readFileSync(outputPath))
@@ -163,7 +164,7 @@ test('openscad to amf', t => {
   const expPath = outputPath
   t.context = {outputPath}
 
-  const cmd = `node ${jscadPath} ${inputPath} -o ${outputPath} -of amf`
+  const cmd = `node ${jscadPath} ${inputPath} -o ${outputPath} -of amf -add-metadata false`
   execSync(cmd, {stdio: [0, 1, 2]})
   t.deepEqual(true, fs.existsSync(expPath))
   almostEquals(t, fs.statSync(outputPath).size, 626177, 120)
@@ -176,7 +177,7 @@ test('openscad to openjscad', t => {
   const expPath = outputPath
   t.context = {outputPath}
 
-  const cmd = `node ${jscadPath} ${inputPath} -o ${outputPath} -of jscad`
+  const cmd = `node ${jscadPath} ${inputPath} -o ${outputPath} -of jscad -add-metadata false`
   execSync(cmd, {stdio: [0, 1, 2]})
   t.deepEqual(true, fs.existsSync(expPath))
   almostEquals(t, fs.statSync(outputPath).size, 646, 2)
@@ -190,7 +191,7 @@ test('openscad to openjscad to stl', t => {
   const expPath = outputPath
   t.context = {outputPath}
 
-  const cmd = `node ${jscadPath} ${inputPath} -o ${jscadOutputPath} -of jscad`
+  const cmd = `node ${jscadPath} ${inputPath} -o ${jscadOutputPath} -of jscad -add-metadata false`
   execSync(cmd, {stdio: [0, 1, 2]})
 
   const cmd2 = `node ${jscadPath} ${jscadOutputPath} -o ${outputPath}`
@@ -208,7 +209,7 @@ test('echo() support', t => {
   const expPath = outputPath
   t.context = {outputPath}
 
-  const cmd = `node ${jscadPath} ${inputPath} -o ${outputPath} -of jscad`
+  const cmd = `node ${jscadPath} ${inputPath} -o ${outputPath} -of jscad -add-metadata false`
   execSync(cmd, {stdio: [0, 1, 2]})
   t.deepEqual(true, fs.existsSync(expPath))
   almostEquals(t, fs.statSync(outputPath).size, 683, 2)
@@ -221,7 +222,7 @@ test('include support', t => {
   const expPath = outputPath
   t.context = {outputPath}
 
-  const cmd = `node ${jscadPath} ${inputPath} -o ${outputPath} -of stla`
+  const cmd = `node ${jscadPath} ${inputPath} -o ${outputPath} -of stla -add-metadata false`
   execSync(cmd, {stdio: [0, 1, 2]})
   t.deepEqual(true, fs.existsSync(expPath))
   almostEquals(t, fs.statSync(outputPath).size, 19681, 60)
@@ -234,7 +235,7 @@ test('include support, with sub folders', t => {
   const expPath = outputPath
   t.context = {outputPath}
 
-  const cmd = `node ${jscadPath} ${inputPath} -o ${outputPath} -of stla`
+  const cmd = `node ${jscadPath} ${inputPath} -o ${outputPath} -of stla -add-metadata false`
   execSync(cmd, {stdio: [0, 1, 2]})
   t.deepEqual(true, fs.existsSync(expPath))
   almostEquals(t, fs.statSync(outputPath).size, 281479, 2)
@@ -247,11 +248,11 @@ test('stl to openjscad', t => {
   const expPath = outputPath
   t.context = {outputPath}
 
-  const cmd = `node ${jscadPath} ${inputPath} -o ${outputPath}`
+  const cmd = `node ${jscadPath} ${inputPath} -o ${outputPath} -add-metadata false`
   execSync(cmd, {stdio: [0, 1, 2]})
 
   t.deepEqual(true, fs.existsSync(expPath))
-  almostEquals(t, fs.statSync(outputPath).size, 3707734, 2)
+  almostEquals(t, fs.statSync(outputPath).size, 3780879, 2)
 })
 
 test('amf to openjscad', t => {
@@ -261,11 +262,12 @@ test('amf to openjscad', t => {
   const expPath = outputPath
   t.context = {outputPath}
 
-  const cmd = `node ${jscadPath} ${inputPath} -o ${outputPath}`
+  const cmd = `node ${jscadPath} ${inputPath} -o ${outputPath} -add-metadata false`
   execSync(cmd, {stdio: [0, 1, 2]})
 
   t.deepEqual(true, fs.existsSync(expPath))
-  almostEquals(t, fs.statSync(outputPath).size, 1870, 2)
+
+  almostEquals(t, fs.statSync(outputPath).size, 1754, 2)
 })
 
 // FIXME: DXF not working

--- a/packages/cli/generateOutputData.js
+++ b/packages/cli/generateOutputData.js
@@ -53,6 +53,7 @@ function generateOutputData (source, params, options) {
       gcode: data => require('@jscad/io').gcodeDeSerializer.deserialize(data.source, data.inputFile, options),
       stl: data => require('@jscad/io').stlDeSerializer.deserialize(data.source, data.inputFile, options),
       svg: data => require('@jscad/io').svgDeSerializer.deserialize(data.source, data.inputFile, options),
+      dxf: data => require('@jscad/io').dxfDeSerializer.deserialize(data.source, data.inputFile, options),
       json: data => require('@jscad/io').jsonDeSerializer.deserialize(data.source, data.inputFile, options),
       jscad: data => data.source,
       js: data => data.source,

--- a/packages/cli/generateOutputData.js
+++ b/packages/cli/generateOutputData.js
@@ -24,7 +24,8 @@ function generateOutputData (source, params, options) {
     outputFile: undefined,
     outputFormat: 'stl',
     inputFile: '',
-    version: ''
+    version: '',
+    addMetaData: true
   }
   options = Object.assign({}, defaults, options)
   const {implicitGlobals, outputFile, outputFormat, inputFile, inputFormat, version} = options

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,7 +35,7 @@
     "@jscad/core": "^0.1.0",
     "@jscad/csg": "0.5.2",
     "@jscad/examples": "^1.7.0",
-    "@jscad/io": "0.3.7",
+    "@jscad/io": "0.4.0",
     "@jscad/openscad-openjscad-translator": "0.0.10"
   },
   "devDependencies": {

--- a/packages/core/io/formats.js
+++ b/packages/core/io/formats.js
@@ -90,6 +90,7 @@ const conversionFormats = [
   'obj',
   'scad',
   'stl',
+  'dxf',
 // 2D file formats
   'svg'
 ]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "dependencies": {
     "@jscad/csg": "0.5.2",
-    "@jscad/io": "0.3.7",
+    "@jscad/io": "0.4.0",
     "@jscad/openscad-openjscad-translator": "0.0.10",
     "astring": "^1.0.2",
     "esprima": "^3.1.3",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -36,7 +36,7 @@
     "@jscad/core": "^0.1.0",
     "@jscad/csg": "0.5.2",
     "@jscad/examples": "^1.7.0",
-    "@jscad/io": "0.3.7",
+    "@jscad/io": "0.4.0",
     "@jscad/openscad-openjscad-translator": "0.0.10",
     "astring": "^1.0.2",
     "brace": "0.10.0",

--- a/packages/web/src/io/conversionWorker.js
+++ b/packages/web/src/io/conversionWorker.js
@@ -23,8 +23,6 @@
 //
 // NOTE: Additional scripts (libraries) are imported only if necessary
 
-
-
 module.exports = function (self) {
   self.onmessage = function (e) {
     var r = { source: '', converted: '', filename: '', baseurl: '', cache: false }
@@ -81,6 +79,10 @@ module.exports = function (self) {
             case 'json':
               const deserializeJson = require('@jscad/io').jsonDeSerializer.deserialize
               r.source = r.converted = deserializeJson(data.source, data.filename, options)
+              break
+            case 'dxf':
+              const deserializeDXF = require('@jscad/io').dxfDeSerializer.deserialize
+              r.source = r.converted = deserializeDXF(data.source, data.filename, options)
               break
             default:
               r.source = r.converted = '// Invalid file type in conversion (' + e + ')'


### PR DESCRIPTION
This PR adds support for dxf files as inputs, thanks to the great work in @jscad/io by @z3dev !
It also adds minor tweaks to the CLI to make handling of input formats easier 

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?

