### PR TITLE
fix(svg-serializer): updated @jscad/io version to add fix for broken svg export

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,7 +35,7 @@
     "@jscad/core": "^0.2.0",
     "@jscad/csg": "0.5.2",
     "@jscad/examples": "^1.7.0",
-    "@jscad/io": "0.4.0",
+    "@jscad/io": "0.4.3",
     "@jscad/openscad-openjscad-translator": "0.0.10"
   },
   "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "dependencies": {
     "@jscad/csg": "0.5.2",
-    "@jscad/io": "0.4.0",
+    "@jscad/io": "0.4.3",
     "@jscad/openscad-openjscad-translator": "0.0.10",
     "astring": "^1.0.2",
     "esprima": "^3.1.3",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -36,7 +36,7 @@
     "@jscad/core": "^0.2.0",
     "@jscad/csg": "0.5.2",
     "@jscad/examples": "^1.7.0",
-    "@jscad/io": "0.4.0",
+    "@jscad/io": "0.4.3",
     "@jscad/openscad-openjscad-translator": "0.0.10",
     "astring": "^1.0.2",
     "brace": "0.10.0",


### PR DESCRIPTION
* bumped dependency versions to include svg export fix
