### PR TITLE
chore(pkg): desktop: pinned electron builder to avoid building issues for windows

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -63,7 +63,7 @@
     "browserify": "^14.5.0",
     "cpy-cli": "^1.0.1",
     "electron": "^1.8.3",
-    "electron-builder": "^20.21.1"
+    "electron-builder": "20.21.1"
   },
   "build": {
     "appId": "org.jscad.desktop",


### PR DESCRIPTION
For desktop: Pins electron builder version, to avoid build issues for windows release
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?


> Note: please do NOT include build files (those generate by the build-xxx commands) with your PR,

Thank you for your help in advance, much appreciated !
