### PR TITLE
Error uploading file on Chrome OS #331

### DIFF
--- a/packages/web/src/ui/dragDrop/walkFileTree.js
+++ b/packages/web/src/ui/dragDrop/walkFileTree.js
@@ -44,7 +44,7 @@ export function pseudoArraytoArray (pseudoArray) {
   let array = []
   for (var i = 0; i < pseudoArray.length; i++) {
     const item = pseudoArray[i]
-    array.push(item.webkitGetAsEntry ? item.webkitGetAsEntry() : item)
+    if (item) array.push(item.webkitGetAsEntry ? item.webkitGetAsEntry() : item)
   }
   return array
 }


### PR DESCRIPTION
Chrome, at least on ChromOS, puts null's in the DataTransferItem array. This causes "Uncaught TypeError: Cannot read property 'webkitGetAsEntry' of null" when you drag a file on to the drop zone. I'm not sure why, but the nulls need to be skipped.

Signed-off-by: James Hightower <jamesh@qtime.com>

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [ ] Does your submission pass tests?


> Note: please do NOT include build files (those generate by the build-xxx commands) with your PR,

Thank you for your help in advance, much appreciated !
