### PR TITLE
Upgraded to latest version of module serialize-to-js

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -52,6 +52,7 @@
     "most-gestures": "^0.3.0",
     "most-proxy": "^3.3.0",
     "on-load": "^3.4.0",
+    "serialize-to-js": "^3.0.0",
     "webworkify": "1.5.0"
   },
   "devDependencies": {

--- a/packages/web/src/ui/flow/design.js
+++ b/packages/web/src/ui/flow/design.js
@@ -14,6 +14,8 @@ const packageMetadata = require('../../../package.json')
 
 const jsonCompare = (first, second) => JSON.stringify(first) === JSON.stringify(second)
 
+const serialize = require('serialize-to-js')
+
 // what fields should we check to determine if two designs are the same
 const designEqualityFields = [
   'parameterDefinitions',
@@ -266,7 +268,6 @@ const reducers = {
 
   requestWriteCachedGeometry: ({ design }, cache) => {
     console.log('requestWriteCachedGeometry', cache)
-    const serialize = require('serialize-to-js').serialize
     let data = {}
     Object.keys(cache).forEach(function (key) {
       data[key] = cache[key]


### PR DESCRIPTION
The serialize-to-js module was missing from the dependencies, which is required as part of the web flow functionality. As such, the require also had to change, as the module has recently gone through some API changes.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Does your submission pass tests?