### PR TITLE
V2 : Enable coverage reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules/
 components/
-converage/
+coverage/
 .DS_Store
 .nyc_output
 packages/web/examples

--- a/coverage_reports.html
+++ b/coverage_reports.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Links to Coverage Reports</title>
+  </head>
+
+  <body>
+    <h1>Links to Coverage Reports</h1>
+    <p>The following coverage reports are available after running 'npm run coverage'</p>
+    <table class="summary">
+      <tr><td class="link"><a href="packages/core/coverage/index.html">core</a></td></tr>
+      <tr><td class="link"><a href="packages/io/amf-deserializer/coverage/index.html">io/amf-deserializer</a></td></tr>
+      <tr><td class="link"><a href="packages/io/amf-serializer/coverage/index.html">io/amf-serializer</a></td></tr>
+      <tr><td class="link"><a href="packages/io/dxf-deserializer/coverage/index.html">io/dxf-deserializer</a></td></tr>
+      <tr><td class="link"><a href="packages/io/dxf-serializer/coverage/index.html">io/dxf-serializer</a></td></tr>
+      <tr><td class="link"><a href="packages/io/io-utils/coverage/index.html">io/io-utils</a></td></tr>
+      <tr><td class="link"><a href="packages/io/json-deserializer/coverage/index.html">io/json-deserializer</a></td></tr>
+      <tr><td class="link"><a href="packages/io/json-serializer/coverage/index.html">io/json-serializer</a></td></tr>
+      <tr><td class="link"><a href="packages/io/obj-deserializer/coverage/index.html">io/obj-deserializer</a></td></tr>
+      <tr><td class="link"><a href="packages/io/stl-deserializer/coverage/index.html">io/stl-deserializer</a></td></tr>
+      <tr><td class="link"><a href="packages/io/stl-serializer/coverage/index.html">io/stl-serializer</a></td></tr>
+      <tr><td class="link"><a href="packages/io/svg-deserializer/coverage/index.html">io/svg-deserializer</a></td></tr>
+      <tr><td class="link"><a href="packages/io/svg-serializer/coverage/index.html">io/svg-serializer</a></td></tr>
+      <tr><td class="link"><a href="packages/io/x3d-serializer/coverage/index.html">io/x3d-serialize</a></td></tr>
+      <tr><td class="link"><a href="packages/modeling/coverage/index.html">modeling</a></td></tr></tr>
+    </table>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "coverage": "lerna run --concurrency 1 --stream coverage",
     "test": "npm run bootstrap && lerna run --stream test",
     "lint": "standard 'packages/**/*.js'",
-    "bootstrap": "lerna bootstrap --hoist nyc --ignore-prepublish --no-ci --ignore @jscad/scad-deserializer --ignore @jscad/desktop"
+    "bootstrap": "lerna bootstrap --hoist nyc --ignore-prepublish --no-ci --ignore @jscad/scad-deserializer --ignore @jscad/desktop",
     "list": "lerna ls",
     "clean": "lerna clean",
     "cli": "npm run bootstrap && cd ./packages/cli",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "@jscad/sample-files": "github:jscad/sample-files#master",
     "ava": "1.4.0",
     "lerna": "3.19.0",
-    "nyc": "^15.0.0",
-    "standard": "^14.3.1"
+    "nyc": "15.0.0",
+    "standard": "14.3.1"
   },
   "collective": {
     "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "repository": "https://github.com/Spiritdude/OpenJSCAD.org",
   "scripts": {
-    "coverage": "lerna run --concurrency 1 --stream coverage",
+    "coverage": "npm run bootstrap && lerna run --concurrency 1 --stream coverage",
     "test": "npm run bootstrap && lerna run --stream test",
     "lint": "standard 'packages/**/*.js'",
     "bootstrap": "lerna bootstrap --hoist nyc --ignore-prepublish --no-ci --ignore @jscad/scad-deserializer --ignore @jscad/desktop",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "repository": "https://github.com/Spiritdude/OpenJSCAD.org",
   "scripts": {
+    "coverage": "lerna run --concurrency 1 --stream coverage",
     "test": "npm run bootstrap && lerna run --stream test",
     "lint": "standard 'packages/**/*.js'",
     "bootstrap": "lerna bootstrap  --ignore-prepublish --no-ci --ignore @jscad/scad-deserializer --ignore @jscad/desktop",
@@ -35,6 +36,7 @@
     "@jscad/sample-files": "github:jscad/sample-files#master",
     "ava": "1.4.0",
     "lerna": "3.19.0",
+    "nyc": "^15.0.0",
     "standard": "^14.3.1"
   },
   "collective": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "coverage": "lerna run --concurrency 1 --stream coverage",
     "test": "npm run bootstrap && lerna run --stream test",
     "lint": "standard 'packages/**/*.js'",
-    "bootstrap": "lerna bootstrap  --ignore-prepublish --no-ci --ignore @jscad/scad-deserializer --ignore @jscad/desktop",
+    "bootstrap": "lerna bootstrap --hoist nyc --ignore-prepublish --no-ci --ignore @jscad/scad-deserializer --ignore @jscad/desktop"
     "list": "lerna ls",
     "clean": "lerna clean",
     "cli": "npm run bootstrap && cd ./packages/cli",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/jscad/OpenJSCAD.org",
   "main": "module.js",
   "scripts": {
+    "coverage": "nyc --all --reporter=html --reporter=text npm test",
     "test": "ava './**/*.test.js' --verbose --timeout 2m",
     "preversion": "npm test",
     "version": "git add -A ",

--- a/packages/io/amf-deserializer/package.json
+++ b/packages/io/amf-deserializer/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/jscad/OpenJSCAD.org/",
   "main": "index.js",
   "scripts": {
-    "coverage": "nyc --reporter=html --reporter=text npm test",
+    "coverage": "nyc --all --reporter=html --reporter=text npm test",
     "test": "ava --verbose --timeout 2m 'tests/**/*.test.js'",
     "release-patch": "git checkout master && npm version patch && git commit -a -m 'chore(dist): built dist/'; git push origin master --tags ",
     "release-minor": "git checkout master && npm version minor && git commit -a -m 'chore(dist): built dist/'; git push origin master --tags ",
@@ -38,7 +38,6 @@
     "sax": "1.2.4"
   },
   "devDependencies": {
-   "ava": "1.4.0",
-    "nyc": "^10.3.2"
+   "ava": "1.4.0"
   }
 }

--- a/packages/io/amf-serializer/package.json
+++ b/packages/io/amf-serializer/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/jscad/OpenJSCAD.org",
   "main": "index.js",
   "scripts": {
-    "coverage": "nyc --reporter=html --reporter=text npm test",
+    "coverage": "nyc --all --reporter=html --reporter=text npm test",
     "test": "ava --verbose --timeout 2m 'tests/**/*.test.js'",
     "release-patch": "git checkout master && npm version patch && git commit -a -m 'chore(dist): built dist/'; git push origin master --tags ",
     "release-minor": "git checkout master && npm version minor && git commit -a -m 'chore(dist): built dist/'; git push origin master --tags ",
@@ -39,7 +39,6 @@
     "onml": "^0.4.1"
   },
   "devDependencies": {
-    "ava": "1.4.0",
-    "nyc": "^10.3.2"
+    "ava": "1.4.0"
   }
 }

--- a/packages/io/dxf-deserializer/package.json
+++ b/packages/io/dxf-deserializer/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/jscad/",
   "main": "index.js",
   "scripts": {
-    "coverage": "nyc --reporter=html --reporter=text npm test",
+    "coverage": "nyc --all --reporter=html --reporter=text npm test",
     "test": "ava --verbose --timeout 2m './tests/test*.js'",
     "release-patch": "git checkout master && npm version patch && git commit -a -m 'chore(dist): built dist/'; git push origin master --tags ",
     "release-minor": "git checkout master && npm version minor && git commit -a -m 'chore(dist): built dist/'; git push origin master --tags ",
@@ -33,7 +33,6 @@
     "@jscad/modeling": "0.0.1"
   },
   "devDependencies": {
-   "ava": "1.4.0",
-    "nyc": "^10.3.2"
+   "ava": "1.4.0"
   }
 }

--- a/packages/io/dxf-serializer/package.json
+++ b/packages/io/dxf-serializer/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/jscad/OpenJSCAD.org",
   "main": "index.js",
   "scripts": {
-    "coverage": "nyc --reporter=html --reporter=text npm test",
+    "coverage": "nyc --all --reporter=html --reporter=text npm test",
     "test": "ava --verbose --timeout 2m './tests/*.test.js'",
     "release-patch": "git checkout master && npm version patch && git commit -a -m 'chore(dist): built dist/'; git push origin master --tags ",
     "release-minor": "git checkout master && npm version minor && git commit -a -m 'chore(dist): built dist/'; git push origin master --tags ",
@@ -38,7 +38,6 @@
     "@jscad/io-utils": "1.0.0-alpha.d0fb3056"
   },
   "devDependencies": {
-   "ava": "1.4.0",
-    "nyc": "^10.3.2"
+   "ava": "1.4.0"
   }
 }

--- a/packages/io/io-utils/package.json
+++ b/packages/io/io-utils/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/jscad/io",
   "main": "index.js",
   "scripts": {
+    "coverage": "nyc --all --reporter=html --reporter=text npm test",
     "test": "ava 'ensureManifoldness.test.js' --verbose --timeout 2m",
     "release-patch": "git checkout master && npm version patch ; git commit -a -m 'chore(dist): built dist/'; git push origin master --tags ",
     "release-minor": "git checkout master && npm version minor ; git commit -a -m 'chore(dist): built dist/'; git push origin master --tags ",

--- a/packages/io/json-deserializer/package.json
+++ b/packages/io/json-deserializer/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/jscad/io",
   "main": "index.js",
   "scripts": {
+    "coverage": "nyc --all --reporter=html --reporter=text npm test",
     "test": "ava './test.js' --verbose --timeout 2m",
     "release-patch": "git checkout master && npm version patch && git commit -a -m 'chore(dist): built dist/'; git push origin master --tags ",
     "release-minor": "git checkout master && npm version minor && git commit -a -m 'chore(dist): built dist/'; git push origin master --tags ",

--- a/packages/io/json-serializer/package.json
+++ b/packages/io/json-serializer/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/jscad/io",
   "main": "index.js",
   "scripts": {
+    "coverage": "nyc --all --reporter=html --reporter=text npm test",
     "test": "ava './test.js' --verbose --timeout 2m",
     "release-patch": "git checkout master && npm version patch && git commit -a -m 'chore(dist): built dist/'; git push origin master --tags ",
     "release-minor": "git checkout master && npm version minor && git commit -a -m 'chore(dist): built dist/'; git push origin master --tags ",

--- a/packages/io/obj-deserializer/package.json
+++ b/packages/io/obj-deserializer/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/jscad/OpenJSCAD.org",
   "main": "index.js",
   "scripts": {
-    "coverage": "nyc --reporter=html --reporter=text npm test",
+    "coverage": "nyc --all --reporter=html --reporter=text npm test",
     "test": "ava --verbose --timeout 2m './tests/*.test.js'",
     "release-patch": "git checkout master && npm version patch && git commit -a -m 'chore(dist): built dist/'; git push origin master --tags ",
     "release-minor": "git checkout master && npm version minor && git commit -a -m 'chore(dist): built dist/'; git push origin master --tags ",
@@ -37,7 +37,6 @@
     "@jscad/modeling": "0.0.1"
   },
   "devDependencies": {
-   "ava": "1.4.0",
-    "nyc": "^10.3.2"
+   "ava": "1.4.0"
   }
 }

--- a/packages/io/stl-deserializer/package.json
+++ b/packages/io/stl-deserializer/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/jscad/OpenJSCAD.org",
   "main": "index.js",
   "scripts": {
-    "coverage": "nyc --reporter=html --reporter=text npm test",
+    "coverage": "nyc --all --reporter=html --reporter=text npm test",
     "test": "ava --verbose --timeout 2m './tests/*.test.js'",
     "release-patch": "git checkout master && npm version patch && git commit -a -m 'chore(dist): built dist/'; git push origin master --tags ",
     "release-minor": "git checkout master && npm version minor && git commit -a -m 'chore(dist): built dist/'; git push origin master --tags ",
@@ -39,7 +39,6 @@
     "@jscad/io-utils": "1.0.0-alpha.d0fb3056"
   },
   "devDependencies": {
-   "ava": "1.4.0",
-    "nyc": "^10.3.2"
+   "ava": "1.4.0"
   }
 }

--- a/packages/io/stl-serializer/package.json
+++ b/packages/io/stl-serializer/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/jscad/OpenJSCAD.org",
   "main": "index.js",
   "scripts": {
-    "coverage": "nyc --reporter=html --reporter=text npm test",
+    "coverage": "nyc --all --reporter=html --reporter=text npm test",
     "test": "ava --verbose --timeout 2m './tests/*.test.js'",
     "release-patch": "git checkout master && npm version patch && git commit -a -m 'chore(dist): built dist/'; git push origin master --tags ",
     "release-minor": "git checkout master && npm version minor && git commit -a -m 'chore(dist): built dist/'; git push origin master --tags ",
@@ -38,7 +38,6 @@
     "@jscad/modeling": "0.0.1"
   },
   "devDependencies": {
-   "ava": "1.4.0",
-    "nyc": "^10.3.2"
+   "ava": "1.4.0"
   }
 }

--- a/packages/io/svg-deserializer/package.json
+++ b/packages/io/svg-deserializer/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/jscad/",
   "main": "index.js",
   "scripts": {
-    "coverage": "nyc --reporter=html --reporter=text npm test",
+    "coverage": "nyc --all --reporter=html --reporter=text npm test",
     "test": "ava --verbose --timeout 2m './tests/*.test.js'",
     "release-patch": "git checkout master && npm version patch && git commit -a -m 'chore(dist): built dist/'; git push origin master --tags ",
     "release-minor": "git checkout master && npm version minor && git commit -a -m 'chore(dist): built dist/'; git push origin master --tags ",
@@ -40,7 +40,6 @@
     "sax": "1.2.4"
   },
   "devDependencies": {
-   "ava": "1.4.0",
-    "nyc": "^10.3.2"
+   "ava": "1.4.0"
   }
 }

--- a/packages/io/svg-serializer/package.json
+++ b/packages/io/svg-serializer/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/jscad/OpenJSCAD.org",
   "main": "index.js",
   "scripts": {
-    "coverage": "nyc --reporter=html --reporter=text npm test",
+    "coverage": "nyc --all --reporter=html --reporter=text npm test",
     "test": "ava --verbose --timeout 2m './tests/*.test.js'",
     "release-patch": "git checkout master && npm version patch && git commit -a -m 'chore(dist): built dist/'; git push origin master --tags ",
     "release-minor": "git checkout master && npm version minor && git commit -a -m 'chore(dist): built dist/'; git push origin master --tags ",
@@ -39,7 +39,6 @@
     "onml": "^0.4.1"
   },
   "devDependencies": {
-   "ava": "1.4.0",
-    "nyc": "^10.3.2"
+   "ava": "1.4.0"
   }
 }

--- a/packages/io/x3d-serializer/package.json
+++ b/packages/io/x3d-serializer/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/jscad/OpenJSCAD.org",
   "main": "index.js",
   "scripts": {
-    "coverage": "nyc --reporter=html --reporter=text npm test",
+    "coverage": "nyc --all --reporter=html --reporter=text npm test",
     "test": "ava --verbose --timeout 2m './tests/*.test.js'",
     "release-patch": "git checkout master && npm version patch && git commit -a -m 'chore(dist): built dist/'; git push origin master --tags ",
     "release-minor": "git checkout master && npm version minor && git commit -a -m 'chore(dist): built dist/'; git push origin master --tags ",
@@ -39,7 +39,6 @@
     "onml": "^0.4.1"
   },
   "devDependencies": {
-   "ava": "1.4.0",
-    "nyc": "^10.3.2"
+   "ava": "1.4.0"
   }
 }

--- a/packages/modeling/package.json
+++ b/packages/modeling/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build-docs": "./node_modules/.bin/jsdoc -c jsdoc.json",
     "docs": "jsdoc2md src --configure jsdoc.json > docs/api.md",
+    "coverage": "nyc --all --reporter=html --reporter=text npm test",
     "test": "ava 'src/**/*.test.js' --verbose --timeout 2m",
     "changelog__": "conventional-changelog -p angular -i CHANGELOG.md -s",
     "preversion__": "npm test",
@@ -59,7 +60,6 @@
    "ava": "1.4.0",
     "conventional-changelog-cli": "^1.3.4",
     "jsdoc": "^3.4.3",
-    "jsdoc-to-markdown": "^3.0.0",
-    "nyc": "^10.3.2"
+    "jsdoc-to-markdown": "^3.0.0"
   }
 }


### PR DESCRIPTION
These changes enables coverage reports for packages with test suites.

The coverage reports can be viewed by opening the "coverage_reports.html" file in the project directory.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?