### PR TITLE
V2 : Fix Deserializers

### DIFF
--- a/packages/core/code-loading/transformSources.js
+++ b/packages/core/code-loading/transformSources.js
@@ -26,40 +26,41 @@ const createJscadEntry = (entry, source) => {
 const transformAmfToJscad = (options, entry) => {
   // console.log('***** transformAmfToJscad',options,entry)
   const deserialize = require('@jscad/io').amfDeSerializer.deserialize
-  const source = deserialize(entry.source, entry.name, options)
+  const source = deserialize(options, entry.source)
   return createJscadEntry(entry, source)
 }
 
 const transformDxfToJscad = (options, entry) => {
   // console.log('***** transformDxfToJscad',options,entry)
   const deserialize = require('@jscad/io').dxfDeSerializer.deserialize
-  const source = deserialize(entry.source, entry.name, options)
+  const source = deserialize(options, entry.source)
   return createJscadEntry(entry, source)
 }
 
 const transformObjToJscad = (options, entry) => {
   // console.log('***** transformObjToJscad',options,entry)
   const deserialize = require('@jscad/io').objDeSerializer.deserialize
-  const source = deserialize(entry.source, entry.name, options)
+  const source = deserialize(options, entry.source)
   return createJscadEntry(entry, source)
 }
 
 const transformStlToJscad = (options, entry) => {
   // console.log('***** transformStlToJscad',options,entry)
   const deserialize = require('@jscad/io').stlDeSerializer.deserialize
-  const source = deserialize(entry.source, entry.name, options)
+  const source = deserialize(options, entry.source)
   return createJscadEntry(entry, source)
 }
 
 const transformSvgToJscad = (options, entry) => {
   // console.log('***** transformSvgToJscad',options,entry)
   const deserialize = require('@jscad/io').svgDeSerializer.deserialize
-  const source = deserialize(entry.source, entry.name, options)
+  const source = deserialize(options, entry.source)
   return createJscadEntry(entry, source)
 }
 
 const transformSources = (options, filesAndFolders) => {
   // console.log('***** transformSources', options, filesAndFolders)
+  // FIXME this table should come from IO
   const transformsPerFormat = {
     'js': [modulifyTransform],
     'jscad': [modulifyTransform],
@@ -73,9 +74,10 @@ const transformSources = (options, filesAndFolders) => {
 
   function updateEntry (entry) {
     if (entry.source) {
+      const transformOptions = Object.assign({}, options, {filename: entry.name})
       const transforms = transformsPerFormat[entry.ext] ? transformsPerFormat[entry.ext] : [passThroughTransform]
       const transformedEntry = transforms.reduce((entry, transform) => {
-        return transform(options, entry)
+        return transform(transformOptions, entry)
       }, entry)
 
       return transformedEntry

--- a/packages/core/code-loading/webRequire.test.js
+++ b/packages/core/code-loading/webRequire.test.js
@@ -198,7 +198,7 @@ test('webRequire: should allow using require.extensions like the native node req
     const deserializer = require('@jscad/io').stlDeSerializer
     _require.extensions['.stl'] = (module, filename) => {
       const content = fs.readFileSync(filename, 'utf8')
-      const parsed = deserializer.deserialize(content, filename, { output: 'geometry' })
+      const parsed = deserializer.deserialize({ filename, output: 'geometry' }, content)
       module.exports = parsed
     }
   }

--- a/packages/core/io/registerExtensions.js
+++ b/packages/core/io/registerExtensions.js
@@ -14,7 +14,7 @@ const registerStlExtension = (fs, _require) => {
   const deserializer = require('@jscad/io').stlDeSerializer
   _require.extensions['.stl'] = (module, filename) => {
     const content = fs.readFileSync(filename, 'utf8')
-    const parsed = deserializer.deserialize(content, filename, { output: 'geometry' })
+    const parsed = deserializer.deserialize({ filename, output: 'geometry' }, content)
     module.exports = parsed
   }
 }
@@ -26,7 +26,7 @@ const registerAmfExtension = (fs, _require) => {
   const deserializer = require('@jscad/io').amfDeSerializer
   _require.extensions['.amf'] = (module, filename) => {
     const content = fs.readFileSync(filename, 'utf8')
-    const parsed = deserializer.deserialize(content, filename, { output: 'geometry' })
+    const parsed = deserializer.deserialize({ filename, output: 'geometry' }, content)
     module.exports = parsed
   }
 }
@@ -38,7 +38,7 @@ const registerDxfExtension = (fs, _require) => {
   const deserializer = require('@jscad/io').dxfDeSerializer
   _require.extensions['.dxf'] = (module, filename) => {
     const content = fs.readFileSync(filename, 'utf8')
-    const parsed = deserializer.deserialize(content, filename, { output: 'geometry' })
+    const parsed = deserializer.deserialize({ filename, output: 'geometry' }, content)
     module.exports = parsed
   }
 }

--- a/packages/io/amf-deserializer/deserialize.js
+++ b/packages/io/amf-deserializer/deserialize.js
@@ -3,7 +3,7 @@ const createObject = require('./objectBuilder')
 
 const parse = require('./parse')
 
-const instantiate = (src, filename, options) => {
+const instantiate = (src, options) => {
   const defaults = {
     pxPmm: require('./constants').pxPmm
   }

--- a/packages/io/amf-deserializer/deserialize.js
+++ b/packages/io/amf-deserializer/deserialize.js
@@ -3,7 +3,7 @@ const createObject = require('./objectBuilder')
 
 const parse = require('./parse')
 
-const instantiate = (src, options) => {
+const instantiate = (options, src) => {
   const defaults = {
     pxPmm: require('./constants').pxPmm
   }

--- a/packages/io/amf-deserializer/index.js
+++ b/packages/io/amf-deserializer/index.js
@@ -42,7 +42,7 @@ const deserialize = (options, input) => {
   }
   options = Object.assign({}, defaults, options)
 
-  return options.output === 'script' ? translate(input, options) : instantiate(input, options)
+  return options.output === 'script' ? translate(options, input) : instantiate(options, input)
 }
 
 const extension = 'amf'

--- a/packages/io/amf-deserializer/index.js
+++ b/packages/io/amf-deserializer/index.js
@@ -25,27 +25,29 @@ const instantiate = require('./deserialize')
 
 /**
  * Deserialize the given AMF source (xml) into either a script or an array of geometry
- * @param {String} input - AMF source data
- * @param {String} [filename] - original filename of AMF source
  * @param {Object} [options] - options used during deserializing
- * @param {String} [options.output='jscad'] - either 'jscad' or 'object' to set desired output
+ * @param {String} [options.filename='amf'] - filename of original AMF source
+ * @param {String} [options.output='script'] - either 'script' or 'geometry' to set desired output
  * @param {String} [options.version='0.0.0'] - version number to add to the metadata
  * @param {Boolean} [options.addMetadata=true] - toggle injection of metadata at the start of the script
- * @return {[geometry]/String} either an array of geometry (object) or a string (jscad)
+ * @param {String} input - AMF source data
+ * @return {[geometry]/String} either an array of objects (geometry) or a string (script)
  */
-const deserialize = (input, filename, options) => {
+const deserialize = (options, input) => {
   const defaults = {
-    output: 'jscad',
+    filename: 'amf',
+    output: 'script',
     version,
     addMetaData: true
   }
   options = Object.assign({}, defaults, options)
 
-  filename = filename || 'amf'
-
-  return options.output === 'jscad' ? translate(input, filename, options) : instantiate(input, filename, options)
+  return options.output === 'script' ? translate(input, options) : instantiate(input, options)
 }
 
+const extension = 'amf'
+
 module.exports = {
-  deserialize
+  deserialize,
+  extension
 }

--- a/packages/io/amf-deserializer/tests/instantiate.test.js
+++ b/packages/io/amf-deserializer/tests/instantiate.test.js
@@ -14,7 +14,7 @@ test('deserialize simple amf to geometry', function (t) {
   const inputPath = path.resolve(samplesPath, 'amf/Amf_Cube.amf')
   const inputFile = fs.readFileSync(inputPath, 'utf8')
 
-  const observed = deserializer.deserialize(inputFile, undefined, { output: 'csg', addMetaData: false })
+  const observed = deserializer.deserialize({ output: 'geometry', addMetaData: false }, inputFile)
   t.is(observed.length, 1)
   const polygons = geometry.geom3.toPolygons(observed[0])
   t.deepEqual(polygons.length, 12)

--- a/packages/io/amf-deserializer/tests/translate.test.js
+++ b/packages/io/amf-deserializer/tests/translate.test.js
@@ -16,21 +16,21 @@ const countOf = (search, string) => {
   return count
 }
 
-test('deserialize simple amf file to jscad code', function (t) {
+test('deserialize simple amf file to jscad script', function (t) {
   const inputPath = path.resolve(samplesPath, 'amf/Amf_Cube.amf')
   const inputFile = fs.readFileSync(inputPath)
 
-  const observed = deserializer.deserialize(inputFile, undefined, { output: 'jscad', addMetaData: false })
+  const observed = deserializer.deserialize({ output: 'script', addMetaData: false }, inputFile)
   t.is(countOf('poly3.fromPoints', observed), 12)
   t.is(countOf('color.color', observed), 12)
   t.is(countOf('geom3.create', observed), 1)
 })
 
-test('deserialize amf file with materials to jscad code', function (t) {
+test('deserialize amf file with materials to jscad script', function (t) {
   const inputPath = path.resolve(samplesPath, 'amf/cube-with-hole.amf')
   const inputFile = fs.readFileSync(inputPath)
 
-  const observed = deserializer.deserialize(inputFile, undefined, { output: 'jscad', addMetaData: false })
+  const observed = deserializer.deserialize({ output: 'script', addMetaData: false }, inputFile)
   t.is(countOf('poly3.fromPoints', observed), 144)
   t.is(countOf('color.color', observed), 144)
   t.is(countOf('geom3.create', observed), 1)

--- a/packages/io/amf-deserializer/translate.js
+++ b/packages/io/amf-deserializer/translate.js
@@ -1,7 +1,7 @@
 const createObject = require('./objectBuilder')
 const parse = require('./parse')
 
-const translate = (src, options) => {
+const translate = (options, src) => {
   const defaults = {
     pxPmm: require('./constants').pxPmm
   }

--- a/packages/io/amf-deserializer/translate.js
+++ b/packages/io/amf-deserializer/translate.js
@@ -1,12 +1,12 @@
 const createObject = require('./objectBuilder')
 const parse = require('./parse')
 
-const translate = (src, filename, options) => {
+const translate = (src, options) => {
   const defaults = {
     pxPmm: require('./constants').pxPmm
   }
   options = Object.assign({}, defaults, options)
-  const { version, pxPmm, addMetaData } = options
+  const { version, pxPmm, addMetaData, filename } = options
 
   options && options.statusCallback && options.statusCallback({ progress: 0 })
 

--- a/packages/io/dxf-deserializer/index.js
+++ b/packages/io/dxf-deserializer/index.js
@@ -546,7 +546,7 @@ const createReader = (src, options) => {
 //
 // instantiate the give DXF definition (src) into a set of CSG library objects
 //
-const instantiate = (src, filename, options) => {
+const instantiate = (src, options) => {
   const reader = createReader(src, options)
   const objs = instantiateAsciiDxf(reader, options)
   return objs
@@ -555,33 +555,34 @@ const instantiate = (src, filename, options) => {
 //
 // translate the give DXF definition (src) into a  JSCAD script
 //
-const translate = (src, filename, options) => {
+const translate = (src, options) => {
   const reader = createReader(src, options)
 
   let code = `// Produced by JSCAD IO Library : DXF Deserializer (${options.version})
 
 `
   // code += '// date: ' + (new Date()) + '\n'
-  // code += '// source: ' + filename + '\n'
+  // code += '// source: ' + options.filename + '\n'
   code += translateAsciiDxf(reader, options)
   return code
 }
 
 /**
  * Deserialize the given source and return the requested 'output'
- * @param {string} src DXF data stream
- * @param {string} filename (optional) original filename of DXF data stream if any
  * @param {object} options (optional) anonymous object with:
+ * @param {string} [options.filename='dxf'] filename of original DXF data stream
  * @param {string} [options.version='0.0.1'] version number to add to the metadata
- * @param {string} [options.output='jscad'] either jscad or geometry to set desired output
+ * @param {string} [options.output='script'] either script or geometry to set desired output
  * @param {boolean} [options.strict=true] obey strict DXF specifications
  * @param {array} [options.colorindex=[]] list of colors (256) for use during rendering
- * @return {string|[objects]} a string (jscad script) or array of objects
+ * @param {string} src DXF data stream
+ * @return {string|[objects]} a string (script) or array of objects (geometry)
  */
-const deserialize = (src, filename, options) => {
+const deserialize = (options, src) => {
   const defaults = {
+    filename: 'dxf',
     version,
-    output: 'jscad',
+    output: 'script',
     strict: true,
     colorindex: colorIndex,
     dxf: {
@@ -591,9 +592,12 @@ const deserialize = (src, filename, options) => {
     }
   }
   options = Object.assign({}, defaults, options)
-  return options.output === 'jscad' ? translate(src, filename, options) : instantiate(src, filename, options)
+  return options.output === 'script' ? translate(src, options) : instantiate(src, options)
 }
 
+const extension = 'dxf'
+
 module.exports = {
-  deserialize
+  deserialize,
+  extension
 }

--- a/packages/io/dxf-deserializer/tests/test-2d-entities.js
+++ b/packages/io/dxf-deserializer/tests/test-2d-entities.js
@@ -16,7 +16,7 @@ test('ASCII DXF 2D Entities from JSCAD to Object Conversion', t => {
   t.deepEqual(true, fs.existsSync(dxfPath))
 
   let dxf = fs.readFileSync(dxfPath, 'UTF8')
-  let objs = deserialize(dxf, 'square10x10', { output: 'geometry' })
+  let objs = deserialize({ filename: 'square10x10', output: 'geometry' }, dxf)
 
   // expect one layer, containing 1 objects (path2)
   t.true(Array.isArray(objs))
@@ -28,7 +28,7 @@ test('ASCII DXF 2D Entities from JSCAD to Object Conversion', t => {
   t.deepEqual(true, fs.existsSync(dxfPath))
 
   dxf = fs.readFileSync(dxfPath, 'UTF8')
-  objs = deserialize(dxf, 'circle10', { output: 'geometry' })
+  objs = deserialize({ filename: 'circle10', output: 'geometry' }, dxf)
 
   // expect one layer, containing 1 objects (path2)
   t.true(Array.isArray(objs))
@@ -43,7 +43,7 @@ test('ASCII DXF 2D Lines from Autocad 2017 to Object Conversion', t => {
   t.deepEqual(true, fs.existsSync(dxfPath))
 
   const dxf = fs.readFileSync(dxfPath, 'UTF8')
-  const objs = deserialize(dxf, '2Dlines', { output: 'geometry' })
+  const objs = deserialize({ filename: '2Dlines', output: 'geometry' }, dxf)
 
   // expect array containing 23 objects (20 path2 from page layout, 3 path2 from entities)
   t.true(Array.isArray(objs))
@@ -62,7 +62,7 @@ test('ASCII DXF 2D Circles from Autocad 2017 to Object Conversion', t => {
   t.deepEqual(true, fs.existsSync(dxfPath))
 
   const dxf = fs.readFileSync(dxfPath, 'UTF8')
-  const objs = deserialize(dxf, '2Dcircles', { output: 'geometry' })
+  const objs = deserialize({ filename: '2Dcircles', output: 'geometry' }, dxf)
 
   // expect array containing 23 objects (1 path2, 2 geom2)
   t.true(Array.isArray(objs))
@@ -80,7 +80,7 @@ test('ASCII DXF 2D Rectangles from Autocad 2017 to Object Conversion', t => {
   t.deepEqual(true, fs.existsSync(dxfPath))
 
   const dxf = fs.readFileSync(dxfPath, 'UTF8')
-  const objs = deserialize(dxf, '2Drectangles', { output: 'geometry' })
+  const objs = deserialize({ filename: '2Drectangles', output: 'geometry' }, dxf)
 
   // expect array containing 23 objects (3 path3)
   t.true(Array.isArray(objs))
@@ -102,7 +102,7 @@ test('ASCII DXF 2D Donuts from Autocad 2017 to Object Conversion', t => {
   t.deepEqual(true, fs.existsSync(dxfPath))
 
   const dxf = fs.readFileSync(dxfPath, 'UTF8')
-  const objs = deserialize(dxf, '2Ddonuts', { output: 'geometry' })
+  const objs = deserialize({ filename: '2Ddonuts', output: 'geometry' }, dxf)
 
   // expect array containing 23 objects (3 path2)
   t.true(Array.isArray(objs))
@@ -121,7 +121,7 @@ test('ASCII DXF 2D Ellipses from Autocad 2017 to Object Conversion', t => {
   t.deepEqual(true, fs.existsSync(dxfPath))
 
   const dxf = fs.readFileSync(dxfPath, 'UTF8')
-  const objs = deserialize(dxf, '2Dellipses', { output: 'geometry' })
+  const objs = deserialize({ filename: '2Dellipses', output: 'geometry' }, dxf)
 
   // expect array containing 23 objects (3 CAG)
   t.true(Array.isArray(objs))
@@ -137,7 +137,7 @@ test('ASCII DXF 2D Arcs from Autocad 2017 to Object Conversion', t => {
   t.deepEqual(true, fs.existsSync(dxfPath))
 
   const dxf = fs.readFileSync(dxfPath, 'UTF8')
-  const objs = deserialize(dxf, '2Darcs', { output: 'geometry' })
+  const objs = deserialize({ filename: '2Darcs', output: 'geometry' }, dxf)
 
   // expect array containing 23 objects (9 path2, 14 path2)
   t.true(Array.isArray(objs))

--- a/packages/io/dxf-deserializer/tests/test-2d-translation.js
+++ b/packages/io/dxf-deserializer/tests/test-2d-translation.js
@@ -8,7 +8,7 @@ const { deserialize } = require('../index')
 test('ASCII DXF 2D Entities translated to JSCAD Scripts', t => {
 // DXF empty source, translate to main and helper functions and layer0
   const dxf1 = ''
-  const src1 = deserialize(dxf1, 'dxf1 test', { output: 'jscad' })
+  const src1 = deserialize({ filename: 'dxf1 test', output: 'script' }, dxf1)
   const ss1 = src1.split('\n')
   t.is(ss1.length, 16)
   t.true(src1.indexOf('main = ()') > 0)
@@ -33,7 +33,7 @@ CIRCLE
 2.5
   0
 ENDSEC`
-  const src2 = deserialize(dxf2, 'dxf2 test', { output: 'jscad' })
+  const src2 = deserialize({ filename: 'dxf2 test', output: 'script' }, dxf2)
   const ss2 = src2.split('\n')
   t.is(ss2.length, 20)
   t.true(src2.indexOf('main = ()') > 0)
@@ -60,7 +60,7 @@ LINE
 0.0
 0
 ENDSEC`
-  const src3 = deserialize(dxf3, 'dxf3-test', { output: 'jscad' })
+  const src3 = deserialize({ filename: 'dxf3-test', output: 'script' }, dxf3)
   const ss3 = src3.split('\n')
   t.is(ss3.length, 20)
   t.true(src3.indexOf('main = ()') > 0)
@@ -97,7 +97,7 @@ AcDbArc
 225.0
 0
 ENDSEC`
-  const src4 = deserialize(dxf4, 'dxf4-test', { output: 'jscad' })
+  const src4 = deserialize({ filename: 'dxf4-test', output: 'script' }, dxf4)
   const ss4 = src4.split('\n')
   t.is(ss4.length, 20)
   t.true(src4.indexOf('main = ()') > 0)
@@ -134,7 +134,7 @@ LWPOLYLINE
 21.75
 0
 ENDSEC`
-  const src5 = deserialize(dxf5, 'dxf5-test', { output: 'jscad' })
+  const src5 = deserialize({ filename: 'dxf5-test', output: 'script' }, dxf5)
   const ss5 = src5.split('\n')
   t.is(ss5.length, 25)
   t.true(src5.indexOf('main = ()') > 0)
@@ -181,7 +181,7 @@ LWPOLYLINE
 5.00
 0
 ENDSEC`
-  const src6 = deserialize(dxf6, 'dxf6-test', { output: 'jscad' })
+  const src6 = deserialize({ filename: 'dxf6-test', output: 'script' }, dxf6)
   const ss6 = src6.split('\n')
   t.is(ss6.length, 26)
   t.true(src6.indexOf('main = ()') > 0)
@@ -226,7 +226,7 @@ ELLIPSE
 6.283185307179586
 0
 ENDSEC`
-  const src7 = deserialize(dxf7, 'dxf7-test', { output: 'jscad' })
+  const src7 = deserialize({ filename: 'dxf7-test', output: 'script' }, dxf7)
   const ss7 = src7.split('\n')
   t.is(ss7.length, 22)
   t.true(src7.indexOf('main = ()') > 0)
@@ -285,7 +285,7 @@ ED
 SEQEND
 0
 ENDSEC`
-  const src1 = deserialize(dxf1, 'dxf1-test', { output: 'jscad' })
+  const src1 = deserialize({ filename: 'dxf1-test', output: 'script' }, dxf1)
   const ss1 = src1.split('\n')
   t.is(ss1.length, 23)
   t.true(src1.indexOf('path2.create(') > 0)
@@ -332,7 +332,7 @@ VERTEX
 SEQEND
 0
 ENDSEC`
-  const src2 = deserialize(dxf2, 'dxf2-test', { output: 'jscad' })
+  const src2 = deserialize({ filename: 'dxf2-test', output: 'script' }, dxf2)
   const ss2 = src2.split('\n')
   t.is(ss2.length, 24)
   t.true(src2.indexOf('path2.create(') > 0)
@@ -384,7 +384,7 @@ CIRCLE
 SEQEND
 0
 ENDSEC`
-  const src3 = deserialize(dxf3, 'dxf3-test', { output: 'jscad' })
+  const src3 = deserialize({ filename: 'dxf3-test', output: 'script' }, dxf3)
   const ss3 = src3.split('\n')
   t.is(ss3.length, 23)
   t.true(src3.indexOf('function layer0(') > 0)

--- a/packages/io/dxf-deserializer/tests/test-3d-entities.js
+++ b/packages/io/dxf-deserializer/tests/test-3d-entities.js
@@ -16,7 +16,7 @@ test('ASCII DXF from Bourke 3D Entities to Object Conversion', t => {
   t.deepEqual(true, fs.existsSync(dxfPath))
 
   const dxf = fs.readFileSync(dxfPath, 'UTF8')
-  const objs = deserialize(dxf, 'aaa', { output: 'geometry' })
+  const objs = deserialize({ output: 'geometry' }, dxf)
 
   // expect one layer, containing 2 objects (geom3 and line3)
   t.true(Array.isArray(objs))
@@ -31,7 +31,7 @@ test('ASCII DXF from JSCAD 3D Shapes to Object Conversion', t => {
   t.deepEqual(true, fs.existsSync(dxfPath))
 
   let dxf = fs.readFileSync(dxfPath, 'UTF8')
-  let objs = deserialize(dxf, 'pyramid', { output: 'geometry' })
+  let objs = deserialize({ filename: 'pyramid', output: 'geometry' }, dxf)
 
   // expect one layer, containing one solid (geom3)
   t.true(Array.isArray(objs))
@@ -44,7 +44,7 @@ test('ASCII DXF from JSCAD 3D Shapes to Object Conversion', t => {
   t.deepEqual(true, fs.existsSync(dxfPath))
 
   dxf = fs.readFileSync(dxfPath, 'UTF8')
-  objs = deserialize(dxf, 'cube', { output: 'geometry' })
+  objs = deserialize({ filename: 'cube', output: 'geometry' }, dxf)
 
   // expect one layer, containing one solid (geom3)
   t.true(Array.isArray(objs))
@@ -57,7 +57,7 @@ test('ASCII DXF from JSCAD 3D Shapes to Object Conversion', t => {
   t.deepEqual(true, fs.existsSync(dxfPath))
 
   dxf = fs.readFileSync(dxfPath, 'UTF8')
-  objs = deserialize(dxf, 'sphere', { output: 'geometry' })
+  objs = deserialize({ filename: 'sphere', output: 'geometry' }, dxf)
 
   // expect one layer, containing one solid (geom3)
   t.true(Array.isArray(objs))
@@ -70,7 +70,7 @@ test('ASCII DXF from JSCAD 3D Shapes to Object Conversion', t => {
   t.deepEqual(true, fs.existsSync(dxfPath))
 
   dxf = fs.readFileSync(dxfPath, 'UTF8')
-  objs = deserialize(dxf, 'cylinder', { output: 'geometry' })
+  objs = deserialize({ filename: 'cylinder', output: 'geometry' }, dxf)
 
   // expect one layer, containing one solid (geom3)
   t.true(Array.isArray(objs))
@@ -84,7 +84,7 @@ test('ASCII DXF from Autocad2017 3D Lines to Object Conversion', t => {
   t.deepEqual(true, fs.existsSync(dxfPath))
 
   const dxf = fs.readFileSync(dxfPath, 'UTF8')
-  const objs = deserialize(dxf, '3Dlines', { output: 'geometry' })
+  const objs = deserialize({ filename: '3Dlines', output: 'geometry' }, dxf)
 
   // expect one layer, containing three objects (Path2D,Path2D,Line3D)
   t.true(Array.isArray(objs))
@@ -103,7 +103,7 @@ test('ASCII DXF from Autocad2017 3D Boxes to Object Conversion', t => {
   t.deepEqual(true, fs.existsSync(dxfPath))
 
   const dxf = fs.readFileSync(dxfPath, 'UTF8')
-  const objs = deserialize(dxf, '3Dboxes', { output: 'geometry' })
+  const objs = deserialize({ filename: '3Dboxes', output: 'geometry' }, dxf)
 
   // expect nothing as 3DSOLID entities cannot be converted
   t.true(Array.isArray(objs))
@@ -115,7 +115,7 @@ test('ASCII DXF from Autocad2017 3D Drawing Shapes to Object Conversion', t => {
   t.deepEqual(true, fs.existsSync(dxfPath))
 
   const dxf = fs.readFileSync(dxfPath, 'UTF8')
-  const objs = deserialize(dxf, '3Ddraw', { output: 'geometry' })
+  const objs = deserialize({ filename: '3Ddraw', output: 'geometry' }, dxf)
 
   // expect nothing as 3DSOLID entities cannot be converted
   t.true(Array.isArray(objs))
@@ -127,7 +127,7 @@ test('ASCII DXF from exdxf 3D Mesh to Object Conversion', t => {
   t.deepEqual(true, fs.existsSync(dxfPath))
 
   const dxf = fs.readFileSync(dxfPath, 'UTF8')
-  const objs = deserialize(dxf, '3Dmesh01', { output: 'geometry' })
+  const objs = deserialize({ filename: '3Dmesh01', output: 'geometry' }, dxf)
 
   // expect 2D and 3D objects
   t.true(Array.isArray(objs))
@@ -143,7 +143,7 @@ test('ASCII DXF from Autocad2017 3D Mesh to Object Conversion', t => {
   t.deepEqual(true, fs.existsSync(dxfPath))
 
   const dxf = fs.readFileSync(dxfPath, 'UTF8')
-  const objs = deserialize(dxf, '3Dmesh01', { output: 'geometry' })
+  const objs = deserialize({ filename: '3Dmesh01', output: 'geometry' }, dxf)
 
   // expect 3D objects
   t.true(Array.isArray(objs))

--- a/packages/io/dxf-deserializer/tests/test-3d-translation.js
+++ b/packages/io/dxf-deserializer/tests/test-3d-translation.js
@@ -211,7 +211,7 @@ VERTEX
 SEQEND
 0
 ENDSEC`
-  const src3 = deserialize(dxf3, 'dxf3-test', { output: 'jscad' })
+  const src3 = deserialize({ filename: 'dxf3-test', output: 'script' }, dxf3)
   const ss3 = src3.split('\n')
   t.is(ss3.length, 28)
   t.true(src3.indexOf('geom3.create') > 0)
@@ -287,7 +287,7 @@ ENTITIES
 0
 ENDSEC`
   // expect a script which calls createPolygon for each 3DFACE, and creates a new 3D geometry
-  const src1 = deserialize(dxf1, 'dxf1-test', { output: 'jscad' })
+  const src1 = deserialize({ filename: 'dxf1-test', output: 'script' }, dxf1)
   const ss1 = src1.split('\n')
   t.is(ss1.length, 24)
   t.true(src1.indexOf('createPolygon(') > 0)

--- a/packages/io/dxf-deserializer/tests/test-dxf-versions.js
+++ b/packages/io/dxf-deserializer/tests/test-dxf-versions.js
@@ -16,7 +16,7 @@ test('ASCII DXF R13 to Object Conversion', t => {
   t.deepEqual(true, fs.existsSync(dxfPath))
 
   const dxf = fs.readFileSync(dxfPath, 'UTF8')
-  const objs = deserialize(dxf, 'aaa', { output: 'geometry' })
+  const objs = deserialize({ filename: 'r13', output: 'geometry' }, dxf)
 
   t.true(Array.isArray(objs))
   t.is(objs.length, 16)
@@ -30,7 +30,7 @@ test('ASCII DXF R14 to Object Conversion', t => {
   t.deepEqual(true, fs.existsSync(dxfPath))
 
   const dxf = fs.readFileSync(dxfPath, 'UTF8')
-  const objs = deserialize(dxf, 'aaa', { output: 'geometry' })
+  const objs = deserialize({ filename: 'r14', output: 'geometry' }, dxf)
 
   t.true(Array.isArray(objs))
   t.is(objs.length, 0)
@@ -41,7 +41,7 @@ test('ASCII DXF ANSI to Object Conversion', t => {
   t.deepEqual(true, fs.existsSync(dxfPath))
 
   const dxf = fs.readFileSync(dxfPath, 'UTF8')
-  const objs = deserialize(dxf, 'aaa', { output: 'geometry' })
+  const objs = deserialize({ filename: 'ansi', output: 'geometry' }, dxf)
 
   t.true(Array.isArray(objs))
   t.is(objs.length, 1)
@@ -54,7 +54,7 @@ test('ASCII DXF ISO to Object Conversion', t => {
   t.deepEqual(true, fs.existsSync(dxfPath))
 
   const dxf = fs.readFileSync(dxfPath, 'UTF8')
-  const objs = deserialize(dxf, 'aaa', { output: 'geometry' })
+  const objs = deserialize({ filename: 'iso', output: 'geometry' }, dxf)
 
   t.true(Array.isArray(objs))
   t.is(objs.length, 14)

--- a/packages/io/dxf-deserializer/tests/test-dxf.js
+++ b/packages/io/dxf-deserializer/tests/test-dxf.js
@@ -15,7 +15,7 @@ test('ASCII DXF from Bourke 3D Entities to Object Conversion', t => {
   t.deepEqual(true, fs.existsSync(dxfPath))
 
   const dxf = fs.readFileSync(dxfPath, 'UTF8')
-  const objs = deserialize(dxf, 'aaa', { output: 'objects' })
+  const objs = deserialize({ output: 'geometry' }, dxf)
 
   // expect one layer, containing 2 objects (CSG, and Line3D)
   t.true(Array.isArray(objs))

--- a/packages/io/obj-deserializer/index.js
+++ b/packages/io/obj-deserializer/index.js
@@ -6,16 +6,17 @@ const version = require('./package.json').version
  * Parse the given OBJ data and return either a JSCAD script or a set of geometry
  * @see http://en.wikipedia.org/wiki/Wavefront_.obj_file
  * @param  {string} input obj data
- * @param {string} filename (optional) original filename of the obj data
  * @param {object} options options (optional) anonymous object with:
+ * @param {string} [options.filename='obj'] filename of the original obj data
  * @param {string} [options.version='0.0.0'] version number to add to the metadata
  * @param {boolean} [options.addMetadata=true] toggle injection of metadata (producer, date, source) at the start of the file
- * @param {string} [options.output='jscad'] {String} either jscad or geometry to set desired output
- * @return {[geometry]/string} either a JSCAD script or a set of geometry
+ * @param {string} [options.output='script'] either script or geometry to set desired output
+ * @return {[object]/string} either a script (script) or a set of objects (geometry)
  */
-const deserialize = (input, filename, options) => {
+const deserialize = (options, input) => {
   const defaults = {
-    output: 'jscad',
+    filename: 'obj',
+    output: 'script',
     orientation: 'outward',
     version,
     addMetaData: true
@@ -23,13 +24,11 @@ const deserialize = (input, filename, options) => {
   options = Object.assign({}, defaults, options)
   const { output } = options
 
-  options.filename = filename || 'obj'
-
   options && options.statusCallback && options.statusCallback({ progress: 0 })
 
   const { positions, groups } = getGroups(input, options)
 
-  const result = output === 'jscad' ? stringify(positions, groups, options) : objectify(positions, groups, options)
+  const result = output === 'script' ? stringify(positions, groups, options) : objectify(positions, groups, options)
 
   options && options.statusCallback && options.statusCallback({ progress: 100 })
 
@@ -207,6 +206,9 @@ module.exports = {main}
   return code
 }
 
+const extension = 'obj'
+
 module.exports = {
-  deserialize
+  deserialize,
+  extension
 }

--- a/packages/io/obj-deserializer/tests/instantiate.test.js
+++ b/packages/io/obj-deserializer/tests/instantiate.test.js
@@ -14,7 +14,7 @@ test('deserialize simple obj to geometry', function (t) {
   const inputPath = path.resolve(samplesPath, 'obj/cube.obj')
   const inputFile = fs.readFileSync(inputPath, 'utf8')
 
-  const observed = deserializer.deserialize(inputFile, undefined, { output: 'geometry', addMetaData: false })
+  const observed = deserializer.deserialize({ output: 'geometry', addMetaData: false }, inputFile)
   t.is(observed.length, 1)
   const polygons = geometry.geom3.toPolygons(observed[0])
   t.deepEqual(polygons.length, 6)

--- a/packages/io/obj-deserializer/tests/translate.test.js
+++ b/packages/io/obj-deserializer/tests/translate.test.js
@@ -6,11 +6,11 @@ const samplesPath = path.dirname(require.resolve('@jscad/sample-files/package.js
 
 const deserializer = require('../index.js')
 
-test('translate simple obj file to jscad code', function (t) {
+test('translate simple obj file to jscad script', function (t) {
   const inputPath = path.resolve(samplesPath, 'obj/cube.obj')
   const inputFile = fs.readFileSync(inputPath, 'utf8')
 
-  const observed = deserializer.deserialize(inputFile, undefined, { output: 'jscad', addMetaData: false })
+  const observed = deserializer.deserialize({ output: 'script', addMetaData: false }, inputFile)
   const expected = `const {primitives} = require('@jscad/modeling')
 
 // groups: 1
@@ -63,7 +63,7 @@ module.exports = {main}
   t.deepEqual(observed, expected)
 })
 
-test('translate absolute face references to jscad code', function (t) {
+test('translate absolute face references to jscad script', function (t) {
   const data = `
 v 0.000000 2.000000 2.000000
 v 0.000000 0.000000 2.000000
@@ -82,7 +82,7 @@ f 5 1 4 8
 f 5 6 2 1
 f 2 6 7 3
 `
-  let observed = deserializer.deserialize(data, undefined, { output: 'jscad', addMetaData: false })
+  let observed = deserializer.deserialize({ filename: 'absolute', output: 'script', addMetaData: false }, data)
   let expected = `const {primitives} = require('@jscad/modeling')
 
 // groups: 1
@@ -135,7 +135,7 @@ module.exports = {main}
   t.deepEqual(observed, expected)
 })
 
-test('translate relative face references to jscad code', function (t) {
+test('translate relative face references to jscad script', function (t) {
   const data = `
 v 0.000000 2.000000 2.000000
 v 0.000000 0.000000 2.000000
@@ -168,7 +168,7 @@ v 2.000000 0.000000 0.000000
 v 2.000000 0.000000 2.000000
 f -4 -3 -2 -1
 `
-  const observed = deserializer.deserialize(data, undefined, { output: 'jscad', addMetaData: false })
+  const observed = deserializer.deserialize({ output: 'script', addMetaData: false }, data)
   const expected = `const {primitives} = require('@jscad/modeling')
 
 // groups: 1

--- a/packages/io/stl-deserializer/index.js
+++ b/packages/io/stl-deserializer/index.js
@@ -13,25 +13,25 @@ const { BinaryReader } = require('@jscad/io-utils')
 /**
 * Parse the given stl data and return either a JSCAD script OR a list of geometries
 * @param {string} input stl data
-* @param {string} filename (optional) original filename of AMF source
 * @param {object} options options (optional) anonymous object with:
+* @param {string} [options.filename='stl'] filename of original STL source
 * @param {string} [options.version='0.0.0'] version number to add to the metadata
 * @param {boolean} [options.addMetadata=true] toggle injection of metadata (producer, date, source) at the start of the file
-* @param {string} [options.output='jscad'] {String} either jscad or geometry to set desired output
-* @return {[geometries]|string} a list of geometries OR a jscad script (string)
+* @param {string} [options.output='script'] either script or geometry to set desired output
+* @return {[objects]|string} a list of objects (geometry) or a string (script)
 */
-const deserialize = (stl, filename, options) => {
-  // console.log('***** deserialize', stl.length, filename, options)
+const deserialize = (options, stl) => {
   const defaults = {
+    filename: 'stl',
     version: '0.0.0',
     addMetaData: true,
-    output: 'jscad'
+    output: 'script'
   }
   options = Object.assign({}, defaults, options)
 
   options && options.statusCallback && options.statusCallback({ progress: 0 })
 
-  const { version, output, addMetaData } = options
+  const { filename, version, output, addMetaData } = options
 
   const isBinary = isDataBinaryRobust(stl)
 
@@ -45,8 +45,8 @@ const deserialize = (stl, filename, options) => {
   options && options.statusCallback && options.statusCallback({ progress: 66 })
 
   const deserializer = isBinary ? deserializeBinarySTL : deserializeAsciiSTL
-  const elementFormatter = output === 'jscad' ? elementFormatterJscad : elementFormatterObject
-  const outputFormatter = output === 'jscad' ? formatAsJscad : formatAsCsg
+  const elementFormatter = output === 'script' ? elementFormatterJscad : elementFormatterObject
+  const outputFormatter = output === 'script' ? formatAsJscad : formatAsCsg
 
   const result = outputFormatter(deserializer(stl, filename, version, elementFormatter), addMetaData, version, filename)
 
@@ -400,6 +400,9 @@ const solid${index} = () => {
   return src
 }
 
+const extension = 'stl'
+
 module.exports = {
-  deserialize
+  deserialize,
+  extension
 }

--- a/packages/io/stl-deserializer/tests/instantiate.test.js
+++ b/packages/io/stl-deserializer/tests/instantiate.test.js
@@ -14,7 +14,7 @@ test('instantiate simple ascii stl to geometry', function (t) {
   const inputPath = path.resolve(samplesPath, 'stl/testcube_ascii.stl')
   const inputFile = fs.readFileSync(inputPath, 'utf8')
 
-  const observed = deserializer.deserialize(inputFile, undefined, { output: 'geometry', addMetaData: false })
+  const observed = deserializer.deserialize({ output: 'geometry', addMetaData: false }, inputFile)
   t.is(observed.length, 1)
   const polygons = geometry.geom3.toPolygons(observed[0])
   t.deepEqual(polygons.length, 12) // 6 faces, 12 polygons
@@ -41,7 +41,7 @@ test('instantiate simple binary stl to geometry', function (t) {
   const inputPath = path.resolve(samplesPath, 'stl/testcube_10mm.stl')
   const inputFile = fs.readFileSync(inputPath)
 
-  const observed = deserializer.deserialize(inputFile, undefined, { output: 'geometry', addMetaData: false })
+  const observed = deserializer.deserialize({ output: 'geometry', addMetaData: false }, inputFile)
   t.is(observed.length, 1)
   const polygons = geometry.geom3.toPolygons(observed[0])
   t.deepEqual(polygons.length, 12) // 6 faces, 12 polygons
@@ -68,7 +68,7 @@ test('instantiate medium complexity binary stl to geometry', function (t) {
   const inputPath = path.resolve(samplesPath, 'stl/pr2_head_tilt.stl')
   const inputFile = fs.readFileSync(inputPath)
 
-  const observed = deserializer.deserialize(inputFile, undefined, { output: 'geometry', addMetaData: false })
+  const observed = deserializer.deserialize({ output: 'geometry', addMetaData: false }, inputFile)
   t.is(observed.length, 1)
   const polygons = geometry.geom3.toPolygons(observed[0])
   t.deepEqual(polygons.length, 1052)
@@ -78,7 +78,7 @@ test('instantiate complex ascii stl to geometry', function (t) {
   const inputPath = path.resolve(samplesPath, 'stl/herringbone-gear-large.stl')
   const inputFile = fs.readFileSync(inputPath, 'utf8')
 
-  const observed = deserializer.deserialize(inputFile, undefined, { output: 'geometry', addMetaData: false })
+  const observed = deserializer.deserialize({ output: 'geometry', addMetaData: false }, inputFile)
   t.is(observed.length, 1)
   const polygons = geometry.geom3.toPolygons(observed[0])
   t.deepEqual(polygons.length, 17742)
@@ -88,7 +88,7 @@ test('instantiate complex binary stl to geometry', function (t) {
   const inputPath = path.resolve(samplesPath, 'stl/UM2CableChain_BedEnd.STL')
   const inputFile = fs.readFileSync(inputPath)
 
-  const observed = deserializer.deserialize(inputFile, undefined, { output: 'geometry', addMetaData: false })
+  const observed = deserializer.deserialize({ output: 'geometry', addMetaData: false }, inputFile)
   t.is(observed.length, 1)
   const polygons = geometry.geom3.toPolygons(observed[0])
   t.deepEqual(polygons.length, 12744)

--- a/packages/io/stl-deserializer/tests/translate.test.js
+++ b/packages/io/stl-deserializer/tests/translate.test.js
@@ -89,11 +89,11 @@ const main = () => {
 module.exports = {main}
 `
 
-  const observed = deserializer.deserialize(inputFile, undefined, { output: 'jscad', addMetaData: false })
+  const observed = deserializer.deserialize({ filename: 'ascii', output: 'script', addMetaData: false }, inputFile)
   t.deepEqual(observed, expected)
 })
 
-test('translate simple binary stl to jscad code', function (t) {
+test('translate simple binary stl to jscad script', function (t) {
   const inputPath = path.resolve(samplesPath, 'stl/testcube_10mm.stl')
   const inputFile = fs.readFileSync(inputPath)
 
@@ -166,15 +166,15 @@ const main = () => {
 module.exports = {main}
 `
 
-  const observed = deserializer.deserialize(inputFile, undefined, { output: 'jscad', addMetaData: false })
+  const observed = deserializer.deserialize({ output: 'script', addMetaData: false }, inputFile)
   t.deepEqual(observed, expected)
 })
 
-test('translate stl with colors to jscad code', function (t) {
+test('translate stl with colors to jscad script', function (t) {
   const inputPath = path.resolve(samplesPath, 'stl/colors.stl')
   const inputFile = fs.readFileSync(inputPath)
 
-  const observed = deserializer.deserialize(inputFile, undefined, { output: 'jscad', addMetaData: false })
+  const observed = deserializer.deserialize({ output: 'script', addMetaData: false }, inputFile)
   t.is(countOf('points', observed), 3) // comment, definition, useage
   t.is(countOf('faces', observed), 3)
   t.is(countOf('colors', observed), 3)

--- a/packages/io/svg-deserializer/index.js
+++ b/packages/io/svg-deserializer/index.js
@@ -23,16 +23,17 @@ const shapesMapJscad = require('./shapesMapJscad')
 /**
  * Parse the given svg data and return either a JSCAD script or a set of geometries
  * @param {string} input svg data
- * @param {string} filename (optional) original filename of AMF source
  * @param {object} options options (optional) anonymous object with:
+ * @param {string} [options.filename='svg'] filename of original SVG source
  * @param {string} [options.version='0.0.0'] version number to add to the metadata
  * @param {boolean} [options.addMetadata=true] toggle injection of metadata (producer, date, source) at the start of the file
- * @param {string} [options.output='script'] {String} either 'script' or 'geometry' to set desired output
+ * @param {string} [options.output='script'] either 'script' or 'geometry' to set desired output
  * @param {float} [options.pxPmm] custom pixels per mm unit
- * @return {string|[geometry]} either a string (jscad script) or a set of geometries
+ * @return {string|[object]} either a string (script) or a set of objects (geometry)
  */
-const deserialize = (input, filename, options) => {
+const deserialize = (options, input) => {
   const defaults = {
+    filename: 'svg',
     addMetaData: true,
     output: 'script',
     pxPmm: require('./constants').pxPmm,
@@ -40,23 +41,21 @@ const deserialize = (input, filename, options) => {
     version: '0.0.0'
   }
   options = Object.assign({}, defaults, options)
-  return options.output === 'script' ? translate(input, filename, options) : instantiate(input, filename, options)
+  return options.output === 'script' ? translate(input, options) : instantiate(input, options)
 }
 
 /**
  * Parse the given SVG source and return a set of geometries.
  * @param  {string} src svg data as text
- * @param  {string} filename (optional) original filename of SVG source
  * @param  {object} options options (optional) anonymous object with:
- *  pxPmm {number: pixels per milimeter for calcuations
+ *  pxPmm {number} pixels per milimeter for calcuations
  *  version: {string} version number to add to the metadata
  *  addMetadata: {boolean} flag to enable/disable injection of metadata (producer, date, source)
  *
  * @return {[geometry]} a set of geometries
  */
-const instantiate = (src, filename, options) => {
+const instantiate = (src, options) => {
   const { pxPmm, target } = options
-  filename = filename || 'svg'
 
   options && options.statusCallback && options.statusCallback({ progress: 0 })
 
@@ -77,7 +76,6 @@ const instantiate = (src, filename, options) => {
 /**
  * Parse the given SVG source and return a JSCAD script
  * @param  {string} src svg data as text
- * @param  {string} filename (optional) original filename of SVG source
  * @param  {object} options options (optional) anonymous object with:
  *  pxPmm {number: pixels per milimeter for calcuations
  *  version: {string} version number to add to the metadata
@@ -85,9 +83,8 @@ const instantiate = (src, filename, options) => {
  *    at the start of the file
  * @return {string} a string (JSCAD script)
  */
-const translate = (src, filename, options) => {
-  const { version, pxPmm, addMetaData, target } = options
-  filename = filename || 'svg'
+const translate = (src, options) => {
+  const { filename, version, pxPmm, addMetaData, target } = options
 
   options && options.statusCallback && options.statusCallback({ progress: 0 })
 
@@ -390,4 +387,9 @@ const createSvgParser = (src, pxPmm) => {
   return parser
 }
 
-module.exports = { deserialize }
+const extension = 'svg'
+
+module.exports = {
+  deserialize,
+  extension
+}

--- a/packages/io/svg-deserializer/tests/inkscape.test.js
+++ b/packages/io/svg-deserializer/tests/inkscape.test.js
@@ -61,11 +61,11 @@ test('deserialize : translate svg produced by inkscape to script', function (t) 
 </svg>
 `
 
-  let obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', addMetaData: false })
+  let obs = deserializer.deserialize({ filename: 'inkscape', output: 'script', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('path2.fromPoints', obs), 2)
   t.is(countOf('path2.close', obs), 2)
   t.is(countOf('color', obs), 1) // no colors, but color is part of require
 
-  obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'path', addMetaData: false })
+  obs = deserializer.deserialize({ output: 'script', target: 'path', addMetaData: false }, sourceSvg)
 })

--- a/packages/io/svg-deserializer/tests/instantiate.test.js
+++ b/packages/io/svg-deserializer/tests/instantiate.test.js
@@ -12,12 +12,12 @@ test('deserialize : instantiate svg (rect) to objects', function (t) {
   <rect x="140" y="120" width="250" height="250" rx="40"/>
 </svg>`
 
-  let observed = deserializer.deserialize(sourceSvg, undefined, { output: 'geometry', addMetaData: false })
+  let observed = deserializer.deserialize({ output: 'geometry', addMetaData: false }, sourceSvg)
   t.is(observed.length, 2)
   let shape = observed[0]
   // t.is(shape.sides.length, 16)
 
-  observed = deserializer.deserialize(sourceSvg, undefined, { output: 'geometry', target: 'path', addMetaData: false })
+  observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 2)
   shape = observed[0]
   t.is(shape.points.length, 20) // rounded rectangle
@@ -31,12 +31,12 @@ test('deserialize : instantiate svg (circle) to objects', function (t) {
 </svg>
 `
 
-  let observed = deserializer.deserialize(sourceSvg, undefined, { output: 'geometry', addMetaData: false })
+  let observed = deserializer.deserialize({ output: 'geometry', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   let shape = observed[0]
   // t.is(shape.sides.length, 16)
 
-  observed = deserializer.deserialize(sourceSvg, undefined, { output: 'geometry', target: 'path', addMetaData: false })
+  observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
   t.is(shape.points.length, 16)
@@ -52,12 +52,12 @@ test('deserialize : instantiate svg (ellipse) to objects', function (t) {
 </svg>
 `
 
-  let observed = deserializer.deserialize(sourceSvg, undefined, { output: 'geometry', addMetaData: false })
+  let observed = deserializer.deserialize({ output: 'geometry', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   let shape = observed[0]
   // t.is(shape.sides.length, 16)
 
-  observed = deserializer.deserialize(sourceSvg, undefined, { output: 'geometry', target: 'path', addMetaData: false })
+  observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
   t.is(shape.points.length, 16)
@@ -72,12 +72,12 @@ test('deserialize : instantiate svg (polyline) to objects', function (t) {
         points="20,100 40,60 70,80 100,20"/>
   </svg>`
 
-  let observed = deserializer.deserialize(sourceSvg, undefined, { output: 'geometry', addMetaData: false })
+  let observed = deserializer.deserialize({ output: 'geometry', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   let shape = observed[0]
   // t.is(shape.sides.length, 16)
 
-  observed = deserializer.deserialize(sourceSvg, undefined, { output: 'geometry', target: 'path', addMetaData: false })
+  observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
   t.is(shape.points.length, 4)
@@ -92,12 +92,12 @@ test('deserialize : instantiate svg (polygon) to objects', function (t) {
   <polygon points="60,20 100,40 100,80 60,100 20,80 20,40"/>
 </svg>`
 
-  let observed = deserializer.deserialize(sourceSvg, undefined, { output: 'geometry', addMetaData: false })
+  let observed = deserializer.deserialize({ output: 'geometry', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   let shape = observed[0]
   // t.is(shape.sides.length, 6)
 
-  observed = deserializer.deserialize(sourceSvg, undefined, { output: 'geometry', target: 'path', addMetaData: false })
+  observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
   t.is(shape.points.length, 6)
@@ -112,12 +112,12 @@ test('deserialize : instantiate svg (line) to objects', function (t) {
   </svg>
 `
 
-  let observed = deserializer.deserialize(sourceSvg, undefined, { output: 'geometry', addMetaData: false })
+  let observed = deserializer.deserialize({ output: 'geometry', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   let shape = observed[0]
   // t.is(shape.sides.length, 6)
 
-  observed = deserializer.deserialize(sourceSvg, undefined, { output: 'geometry', target: 'path', addMetaData: false })
+  observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
   t.is(shape.points.length, 2)
@@ -131,12 +131,12 @@ test('deserialize : instantiate svg (path: simple) to objects', function (t) {
 </svg>
 `
 
-  let observed = deserializer.deserialize(sourceSvg, undefined, { output: 'geometry', addMetaData: false })
+  let observed = deserializer.deserialize({ output: 'geometry', addMetaData: false }, sourceSvg)
   // t.is(observed.length, 1)
   let shape = observed[0]
   // t.is(shape.sides.length, 6)
 
-  observed = deserializer.deserialize(sourceSvg, undefined, { output: 'geometry', target: 'path', addMetaData: false })
+  observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
   t.is(shape.points.length, 3)
@@ -156,12 +156,12 @@ test('deserialize : instantiate svg (path: with bezier) to objects', function (t
   </svg>
 `
 
-  let observed = deserializer.deserialize(sourceSvg, undefined, { output: 'geometry', addMetaData: false })
+  let observed = deserializer.deserialize({ output: 'geometry', addMetaData: false }, sourceSvg)
   // t.is(observed.length, 1)
   let shape = observed[0]
   // t.is(shape.sides.length, 6)
 
-  observed = deserializer.deserialize(sourceSvg, undefined, { output: 'geometry', target: 'path', addMetaData: false })
+  observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
   t.is(shape.points.length, 11)
@@ -217,12 +217,12 @@ test('deserialize : instantiate svg produced by inkscape to objects', function (
 </svg>
 `
 
-  let observed = deserializer.deserialize(sourceSvg, undefined, { output: 'geometry', addMetaData: false })
+  let observed = deserializer.deserialize({ filename: 'inkscape', output: 'geometry', addMetaData: false }, sourceSvg)
   // t.is(observed.length, 1)
   let shape = observed[0]
   // t.is(shape.sides.length, 6)
 
-  observed = deserializer.deserialize(sourceSvg, undefined, { output: 'geometry', target: 'path', addMetaData: false })
+  observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 2)
   shape = observed[0]
   t.is(shape.points.length, 19)
@@ -237,12 +237,12 @@ test('deserialize : instantiate shape with a hole to objects', function (t) {
   </svg>
 `
 
-  let observed = deserializer.deserialize(sourceSvg, undefined, { output: 'geometry', addMetaData: false })
+  let observed = deserializer.deserialize({ output: 'geometry', addMetaData: false }, sourceSvg)
   // t.is(observed.length, 1)
   let shape = observed[0]
   // t.is(shape.sides.length, 6)
 
-  observed = deserializer.deserialize(sourceSvg, undefined, { output: 'geometry', target: 'path', addMetaData: false })
+  observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 2)
   shape = observed[0]
   t.is(shape.points.length, 23)
@@ -257,12 +257,12 @@ test('deserialize : instantiate shape with a nested hole to objects', function (
   </svg>
 `
 
-  let observed = deserializer.deserialize(sourceSvg, undefined, { output: 'geometry', addMetaData: false })
+  let observed = deserializer.deserialize({ output: 'geometry', addMetaData: false }, sourceSvg)
   // t.is(observed.length, 1)
   let shape = observed[0]
   // t.is(shape.sides.length, 6)
 
-  observed = deserializer.deserialize(sourceSvg, undefined, { output: 'geometry', target: 'path', addMetaData: false })
+  observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 4)
   shape = observed[0]
   t.is(shape.points.length, 23)

--- a/packages/io/svg-deserializer/tests/translate.test.js
+++ b/packages/io/svg-deserializer/tests/translate.test.js
@@ -24,14 +24,14 @@ test('deserialize : translate svg (rect) to script', function (t) {
   <rect x="40" y="20" width="250" height="250" rx="40" ry="40"/>
 </svg>`
 
-  let obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'path', addMetaData: false })
+  let obs = deserializer.deserialize({ output: 'script', target: 'path', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('rectangle', obs), 1)
   t.is(countOf('roundedRectangle', obs), 3)
   t.is(countOf('color.color', obs), 3) // color
   t.is(countOf('path2.fromPoints', obs), 4)
 
-  obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'geom2', addMetaData: false })
+  obs = deserializer.deserialize({ output: 'script', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('rectangle', obs), 1)
   t.is(countOf('roundedRectangle', obs), 3)
@@ -46,13 +46,13 @@ test('deserialize : translate svg (circle) to script', function (t) {
   <circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red" />
 </svg>`
 
-  let obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'path', addMetaData: false })
+  let obs = deserializer.deserialize({ output: 'script', target: 'path', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('circle', obs), 1)
   t.is(countOf('color.color', obs), 1) // stroke
   t.is(countOf('path2.fromPoints', obs), 1)
 
-  obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'geom2', addMetaData: false })
+  obs = deserializer.deserialize({ output: 'script', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('circle', obs), 1)
   t.is(countOf('color.color', obs), 1) // fill
@@ -67,13 +67,13 @@ test('deserialize : translate svg (ellipse) to script', function (t) {
 </svg>
 `
 
-  let obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'path', addMetaData: false })
+  let obs = deserializer.deserialize({ output: 'script', target: 'path', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('ellipse', obs), 1)
   t.is(countOf('color.color', obs), 0)
   t.is(countOf('path2.fromPoints', obs), 1)
 
-  obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'geom2', addMetaData: false })
+  obs = deserializer.deserialize({ output: 'script', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('ellipse', obs), 1)
   t.is(countOf('color.color', obs), 0)
@@ -87,11 +87,11 @@ test('deserialize : translate svg (line) to script', function (t) {
   <line x1="20" y1="100" x2="100" y2="20" stroke-width="2" stroke="black"/>
 </svg>`
 
-  let obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'path', addMetaData: false })
+  let obs = deserializer.deserialize({ output: 'script', target: 'path', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('line', obs), 2) // line, and line position
 
-  obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'geom2', addMetaData: false })
+  obs = deserializer.deserialize({ output: 'script', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   // TODO
 
@@ -102,7 +102,7 @@ test('deserialize : translate svg (line) to script', function (t) {
   </g>
 </svg>`
 
-  obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'path', addMetaData: false })
+  obs = deserializer.deserialize({ output: 'script', target: 'path', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('line', obs), 2) // line, and line position
 })
@@ -114,12 +114,12 @@ test('deserialize : translate svg (polygon) to script', function (t) {
   <polygon points="60,20 100,40 100,80 60,100 20,80 20,40"/>
 </svg>`
 
-  let obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'path', addMetaData: false })
+  let obs = deserializer.deserialize({ output: 'script', target: 'path', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('polygon', obs), 1)
   t.is(countOf('path2.fromPoints', obs), 1)
 
-  obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'geom2', addMetaData: false })
+  obs = deserializer.deserialize({ output: 'script', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('polygon', obs), 1)
   t.is(countOf('path2.fromPoints', obs), 0)
@@ -132,11 +132,11 @@ test('deserialize : translate svg (polyline) to script', function (t) {
   <polyline fill="none" stroke="black" stroke-width="2" points="20,100 40,60 70,80 100,20"/>
 </svg>`
 
-  let obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'path', addMetaData: false })
+  let obs = deserializer.deserialize({ output: 'script', target: 'path', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('path2.fromPoints', obs), 1)
 
-  obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'geom2', addMetaData: false })
+  obs = deserializer.deserialize({ output: 'script', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   // FIXME t.is(countOf('path2.fromPoints', obs), 1)
 
@@ -147,7 +147,7 @@ test('deserialize : translate svg (polyline) to script', function (t) {
   </g>
 </svg>`
 
-  obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'path', addMetaData: false })
+  obs = deserializer.deserialize({ output: 'script', target: 'path', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('path2.fromPoints', obs), 1)
 })
@@ -159,7 +159,7 @@ test('deserialize : translate svg (path: simple) to script', function (t) {
   <path stroke="black" stroke-width="2" d="M150 0 L75 200 L225 200 Z" />
 </svg>`
 
-  let obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'path', addMetaData: false })
+  let obs = deserializer.deserialize({ output: 'script', target: 'path', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('path2.fromPoints', obs), 1)
   t.is(countOf('path2.appendPoints', obs), 2)
@@ -167,7 +167,7 @@ test('deserialize : translate svg (path: simple) to script', function (t) {
   t.is(countOf('color.color', obs), 1) // stroke
   t.is(countOf('geom2.fromPoints', obs), 0)
 
-  obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'geom2', addMetaData: false })
+  obs = deserializer.deserialize({ output: 'script', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('path2.fromPoints', obs), 1)
   t.is(countOf('path2.appendPoints', obs), 2)
@@ -182,7 +182,7 @@ test('deserialize : translate svg (path: simple) to script', function (t) {
   </g>
 </svg>`
 
-  obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'path', addMetaData: false })
+  obs = deserializer.deserialize({ output: 'script', target: 'path', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('path2.fromPoints', obs), 1)
   t.is(countOf('path2.appendPoints', obs), 2)
@@ -191,7 +191,7 @@ test('deserialize : translate svg (path: simple) to script', function (t) {
   <path d="m 150 0 l 75 200 l -225 0 z" />
 </svg>`
 
-  obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'path', addMetaData: false })
+  obs = deserializer.deserialize({ output: 'script', target: 'path', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('path2.fromPoints', obs), 1)
   t.is(countOf('path2.appendPoints', obs), 2)
@@ -202,7 +202,7 @@ test('deserialize : translate svg (path: simple) to script', function (t) {
   <path fill="#ff8000" d="m 240.00000 190.00000 h 30.00000 v 30.00000 h 30.00000 v 30.00000 h 30.00000 v 30.00000 h -90.00000 v -90.00000 z"/>
 </svg>`
 
-  obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'geom2', addMetaData: false })
+  obs = deserializer.deserialize({ output: 'script', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('path2.fromPoints', obs), 1)
   t.is(countOf('path2.appendPoints', obs), 8)
@@ -214,7 +214,7 @@ test('deserialize : translate svg (path: simple) to script', function (t) {
   <path d="M 240.00000 56.00000 H 270.00000 V 86.00000 H 300.00000 V 116.00000 H 330.00000 V 146.00000 H 240.00000 V 56.00000 Z"/>
 </svg>`
 
-  obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'path', addMetaData: false })
+  obs = deserializer.deserialize({ output: 'script', target: 'path', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('path2.fromPoints', obs), 1)
   t.is(countOf('path2.appendPoints', obs), 8)
@@ -229,7 +229,7 @@ test('deserialize : translate svg (path: arc) to script', function (t) {
   <path d="M 230 230 A 45 45 0 1 1 275 275 L 275 230 Z"/>
 </svg>`
 
-  let obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'path', addMetaData: false })
+  let obs = deserializer.deserialize({ output: 'script', target: 'path', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('path2.fromPoints', obs), 1)
   t.is(countOf('path2.appendArc', obs), 1)
@@ -241,7 +241,7 @@ test('deserialize : translate svg (path: arc) to script', function (t) {
   <path d="M100,100 L150,100 a50,25 0 0,0 150,100 q50,-50 70,-170 Z"/>
 </svg>`
 
-  obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'geom2', addMetaData: false })
+  obs = deserializer.deserialize({ output: 'script', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('path2.fromPoints', obs), 1)
   t.is(countOf('path2.appendArc', obs), 1)
@@ -257,7 +257,7 @@ test('deserialize : translate svg (path: bezier) to script', function (t) {
   <path d="M100,100 L150,100 a50,25 0 0,0 150,100 q50,-50 70,-170 Z" style="stroke: #006666; fill: none;"/>
 </svg>`
 
-  let obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'path', addMetaData: false })
+  let obs = deserializer.deserialize({ output: 'script', target: 'path', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('path2.fromPoints', obs), 1)
   t.is(countOf('path2.appendPoints', obs), 1)
@@ -266,7 +266,7 @@ test('deserialize : translate svg (path: bezier) to script', function (t) {
   t.is(countOf('path2.close', obs), 1)
   t.is(countOf('geom2.fromPoints', obs), 0)
 
-  obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'geom2', addMetaData: false })
+  obs = deserializer.deserialize({ output: 'script', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('path2.fromPoints', obs), 1)
   t.is(countOf('path2.appendPoints', obs), 1)
@@ -281,7 +281,7 @@ test('deserialize : translate svg (path: bezier) to script', function (t) {
   <path d="M 240 90 c 0 30 7 50 50 0 c 43 -50 50 -30 50 0 c 0 83 -68 -34 -90 -30 C 240 60 240 90 240 90 z"/>
 </svg>`
 
-  obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'path', addMetaData: false })
+  obs = deserializer.deserialize({ output: 'script', target: 'path', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('path2.fromPoints', obs), 1)
   t.is(countOf('path2.appendBezier', obs), 4)
@@ -293,7 +293,7 @@ test('deserialize : translate svg (path: bezier) to script', function (t) {
   <path d="M 60 100 Q -40 150 60 200 Q 160 150 60 100 z"/>
 </svg>`
 
-  obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'path', addMetaData: false })
+  obs = deserializer.deserialize({ output: 'script', target: 'path', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('path2.fromPoints', obs), 1)
   t.is(countOf('path2.appendBezier', obs), 2)
@@ -306,7 +306,7 @@ test('deserialize : translate svg (path: bezier) to script', function (t) {
   <path d="M 210 130 C 145 130 110 80 110 80 S 75 25 10 25 m 0 105 c 65 0 100 -50 100 -50 s 35 -55 100 -55"/>
 </svg>`
 
-  obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'path', addMetaData: false })
+  obs = deserializer.deserialize({ output: 'script', target: 'path', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('path2.fromPoints', obs), 2)
   t.is(countOf('path2.appendBezier', obs), 4)
@@ -319,7 +319,7 @@ test('deserialize : translate svg (path: bezier) to script', function (t) {
   <path d="M 10 80 Q 52.5 10 95 80 T 180 80"/>
 </svg>`
 
-  obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'path', addMetaData: false })
+  obs = deserializer.deserialize({ output: 'script', target: 'path', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('path2.fromPoints', obs), 1)
   t.is(countOf('path2.appendBezier', obs), 2)
@@ -330,7 +330,7 @@ test('deserialize : translate svg (path: bezier) to script', function (t) {
   <path id="Sin_Mqttttz" fill="#FF0000" d="M240 296 q25-100 47 0 t47 0 t47 0 t47 0 t47 0 z"/>
 </svg>`
 
-  obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'geom2', addMetaData: false })
+  obs = deserializer.deserialize({ output: 'script', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('path2.fromPoints', obs), 1)
   t.is(countOf('path2.appendBezier', obs), 5)
@@ -348,7 +348,7 @@ test('deserialize : translate shape with a hole to script', function (t) {
   </svg>
 `
 
-  let obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'path', addMetaData: false })
+  let obs = deserializer.deserialize({ output: 'script', target: 'path', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('path2.fromPoints', obs), 2)
   t.is(countOf('path2.appendArc', obs), 8)
@@ -356,7 +356,7 @@ test('deserialize : translate shape with a hole to script', function (t) {
   t.is(countOf('geom2.fromPoints', obs), 0)
   t.is(countOf('color.color', obs), 1) // stroke
 
-  obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'geom2', addMetaData: false })
+  obs = deserializer.deserialize({ output: 'script', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('path2.fromPoints', obs), 2)
   t.is(countOf('path2.appendArc', obs), 8)
@@ -371,7 +371,7 @@ test('deserialize : translate shape with a nested hole to script', function (t) 
   </svg>
 `
 
-  let obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', addMetaData: false })
+  let obs = deserializer.deserialize({ output: 'script', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('path2.fromPoints', obs), 4)
   t.is(countOf('path2.appendArc', obs), 8)
@@ -379,7 +379,7 @@ test('deserialize : translate shape with a nested hole to script', function (t) 
   t.is(countOf('path2.close', obs), 4)
   t.is(countOf('geom2.fromPoints', obs), 0)
 
-  obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'geom2', addMetaData: false })
+  obs = deserializer.deserialize({ output: 'script', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('path2.fromPoints', obs), 4)
   t.is(countOf('path2.appendArc', obs), 8)
@@ -402,7 +402,7 @@ test('deserialize : translate svg with simple defs to script', function (t) {
   </g>
 </svg>`
 
-  const obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'path', addMetaData: false })
+  const obs = deserializer.deserialize({ output: 'script', target: 'path', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('ellipse', obs), 1)
   t.is(countOf('path2.fromPoints', obs), 1)
@@ -430,7 +430,7 @@ test('deserialize : translate svg with defs using defs to script', function (t) 
   </g>
 </svg>`
 
-  const obs = deserializer.deserialize(sourceSvg, undefined, { output: 'script', target: 'path', addMetaData: false })
+  const obs = deserializer.deserialize({ output: 'script', target: 'path', addMetaData: false }, sourceSvg)
   t.is(typeof obs, 'string')
   t.is(countOf('ellipse', obs), 1)
   t.is(countOf('path2.fromPoints', obs), 1)


### PR DESCRIPTION
These changes update the various deserializers to:
  - deserialize(options, source)
  - new options.filename
  - corrected options.output to accept only 'script' or 'geometry'

And of course, updating CLI and CORE code to use these new standards.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Does your submission pass tests?