### PR TITLE
V2 : Updated to require specific files, eliminating circular dependencies

### DIFF
--- a/packages/modeling/src/connectors/transformationBetween.js
+++ b/packages/modeling/src/connectors/transformationBetween.js
@@ -1,4 +1,7 @@
-const { mat4, plane, vec2, vec3 } = require('../math/')
+const mat4 = require('../math/mat4')
+const plane = require('../math/plane')
+const vec2 = require('../math/vec2')
+const vec3 = require('../math/vec3')
 
 const OrthoNormalBasis = require('../math/OrthoNormalBasis')
 

--- a/packages/modeling/src/geometry/path2/appendArc.js
+++ b/packages/modeling/src/geometry/path2/appendArc.js
@@ -1,4 +1,4 @@
-const { vec2 } = require('../../math')
+const vec2 = require('../../math/vec2')
 
 const fromPoints = require('./fromPoints')
 const toPoints = require('./toPoints')

--- a/packages/modeling/src/geometry/path2/appendBezier.js
+++ b/packages/modeling/src/geometry/path2/appendBezier.js
@@ -1,4 +1,4 @@
-const { vec2 } = require('../../math')
+const vec2 = require('../../math/vec2')
 
 const appendPoints = require('./appendPoints')
 const toPoints = require('./toPoints')

--- a/packages/modeling/src/operations/booleans/fromFakePolygons.js
+++ b/packages/modeling/src/operations/booleans/fromFakePolygons.js
@@ -1,6 +1,6 @@
-const { vec2 } = require('../../math')
+const vec2 = require('../../math/vec2')
 
-const { geom2 } = require('../../geometry')
+const geom2 = require('../../geometry/geom2')
 
 const fromFakePolygon = (polygon) => {
   // this can happen based on union, seems to be residuals -

--- a/packages/modeling/src/operations/booleans/intersect.js
+++ b/packages/modeling/src/operations/booleans/intersect.js
@@ -1,10 +1,10 @@
 const flatten = require('../../utils/flatten')
 const areAllShapesTheSameType = require('../../utils/areAllShapesTheSameType')
 
-const { geom2, geom3 } = require('../../geometry')
+const geom2 = require('../../geometry/geom2')
+const geom3 = require('../../geometry/geom3')
 
 const intersectGeom2 = require('./intersectGeom2')
-
 const intersectGeom3 = require('./intersectGeom3')
 
 /**

--- a/packages/modeling/src/operations/booleans/intersectGeom2.js
+++ b/packages/modeling/src/operations/booleans/intersectGeom2.js
@@ -1,6 +1,6 @@
 const flatten = require('../../utils/flatten')
 
-const { geom3 } = require('../../geometry')
+const geom3 = require('../../geometry/geom3')
 
 const fromFakePolygons = require('./fromFakePolygons')
 const to3DWalls = require('./to3DWalls')

--- a/packages/modeling/src/operations/booleans/intersectGeom3Sub.js
+++ b/packages/modeling/src/operations/booleans/intersectGeom3Sub.js
@@ -1,4 +1,4 @@
-const { geom3 } = require('../../geometry')
+const geom3 = require('../../geometry/geom3')
 
 const mayOverlap = require('./mayOverlap')
 const { Tree } = require('./trees')

--- a/packages/modeling/src/operations/booleans/reTesselateCoplanarPolygons.js
+++ b/packages/modeling/src/operations/booleans/reTesselateCoplanarPolygons.js
@@ -1,11 +1,12 @@
 const { EPS } = require('../../math/constants')
 
-const { line2, vec2 } = require('../../math')
+const line2 = require('../../math/line2')
+const vec2 = require('../../math/vec2')
 const OrthoNormalBasis = require('../../math/OrthoNormalBasis')
 
 const { interpolateBetween2DPointsForY, insertSorted, fnNumberSort } = require('../../utils')
 
-const { poly3 } = require('../../geometry')
+const poly3 = require('../../geometry/poly3')
 
 /*
  * Retesselation for a set of COPLANAR polygons.

--- a/packages/modeling/src/operations/booleans/retessellate.js
+++ b/packages/modeling/src/operations/booleans/retessellate.js
@@ -1,6 +1,6 @@
-const { vec3 } = require('../../math')
+const vec3 = require('../../math/vec3')
 
-const { geom3 } = require('../../geometry')
+const geom3 = require('../../geometry/geom3')
 
 const reTesselateCoplanarPolygons = require('./reTesselateCoplanarPolygons')
 

--- a/packages/modeling/src/operations/booleans/subtract.js
+++ b/packages/modeling/src/operations/booleans/subtract.js
@@ -1,10 +1,10 @@
 const flatten = require('../../utils/flatten')
 const areAllShapesTheSameType = require('../../utils/areAllShapesTheSameType')
 
-const { geom2, geom3 } = require('../../geometry')
+const geom2 = require('../../geometry/geom2')
+const geom3 = require('../../geometry/geom3')
 
 const subtractGeom2 = require('./subtractGeom2')
-
 const subtractGeom3 = require('./subtractGeom3')
 
 /**

--- a/packages/modeling/src/operations/booleans/subtractGeom2.js
+++ b/packages/modeling/src/operations/booleans/subtractGeom2.js
@@ -1,6 +1,6 @@
 const flatten = require('../../utils/flatten')
 
-const { geom3 } = require('../../geometry')
+const geom3 = require('../../geometry/geom3')
 
 const fromFakePolygons = require('./fromFakePolygons')
 const to3DWalls = require('./to3DWalls')

--- a/packages/modeling/src/operations/booleans/subtractGeom3Sub.js
+++ b/packages/modeling/src/operations/booleans/subtractGeom3Sub.js
@@ -1,4 +1,4 @@
-const { geom3 } = require('../../geometry')
+const geom3 = require('../../geometry/geom3')
 
 const mayOverlap = require('./mayOverlap')
 const { Tree } = require('./trees')

--- a/packages/modeling/src/operations/booleans/to3DWalls.js
+++ b/packages/modeling/src/operations/booleans/to3DWalls.js
@@ -1,6 +1,8 @@
-const { vec3 } = require('../../math')
+const vec3 = require('../../math/vec3')
 
-const { geom2, geom3, poly3 } = require('../../geometry')
+const geom2 = require('../../geometry/geom2')
+const geom3 = require('../../geometry/geom3')
+const poly3 = require('../../geometry/poly3')
 
 /*
  * Create a polygon (wall) from the given Z values and side.

--- a/packages/modeling/src/operations/booleans/trees/Node.js
+++ b/packages/modeling/src/operations/booleans/trees/Node.js
@@ -1,4 +1,4 @@
-const { plane } = require('../../../math')
+const plane = require('../../../math/plane')
 
 // # class Node
 // Holds a node in a BSP tree. A BSP tree is built from a collection of polygons

--- a/packages/modeling/src/operations/booleans/trees/PolygonTreeNode.js
+++ b/packages/modeling/src/operations/booleans/trees/PolygonTreeNode.js
@@ -1,8 +1,8 @@
 const { EPS } = require('../../../math/constants')
 
-const { vec3 } = require('../../../math')
+const vec3 = require('../../../math/vec3')
 
-const { poly3 } = require('../../../geometry')
+const poly3 = require('../../../geometry/poly3')
 
 const splitPolygonByPlane = require('./splitPolygonByPlane')
 

--- a/packages/modeling/src/operations/booleans/trees/splitLineSegmentByPlane.js
+++ b/packages/modeling/src/operations/booleans/trees/splitLineSegmentByPlane.js
@@ -1,4 +1,4 @@
-const { vec3 } = require('../../../math')
+const vec3 = require('../../../math/vec3')
 
 const splitLineSegmentByPlane = (plane, p1, p2) => {
   const direction = vec3.subtract(p2, p1)

--- a/packages/modeling/src/operations/booleans/trees/splitPolygonByPlane.js
+++ b/packages/modeling/src/operations/booleans/trees/splitPolygonByPlane.js
@@ -1,8 +1,9 @@
 const { EPS } = require('../../../math/constants')
 
-const { plane, vec3 } = require('../../../math')
+const plane = require('../../../math/plane')
+const vec3 = require('../../../math/vec3')
 
-const { poly3 } = require('../../../geometry')
+const poly3 = require('../../../geometry/poly3')
 
 const splitLineSegmentByPlane = require('./splitLineSegmentByPlane')
 

--- a/packages/modeling/src/operations/booleans/union.js
+++ b/packages/modeling/src/operations/booleans/union.js
@@ -1,7 +1,8 @@
 const flatten = require('../../utils/flatten')
 const areAllShapesTheSameType = require('../../utils/areAllShapesTheSameType')
 
-const { geom2, geom3 } = require('../../geometry')
+const geom2 = require('../../geometry/geom2')
+const geom3 = require('../../geometry/geom3')
 
 const unionGeom2 = require('./unionGeom2')
 const unionGeom3 = require('./unionGeom3')

--- a/packages/modeling/src/operations/booleans/unionGeom2.js
+++ b/packages/modeling/src/operations/booleans/unionGeom2.js
@@ -1,6 +1,6 @@
 const flatten = require('../../utils/flatten')
 
-const { geom3 } = require('../../geometry')
+const geom3 = require('../../geometry/geom3')
 
 const fromFakePolygons = require('./fromFakePolygons')
 const to3DWalls = require('./to3DWalls')

--- a/packages/modeling/src/operations/booleans/unionGeom3Sub.js
+++ b/packages/modeling/src/operations/booleans/unionGeom3Sub.js
@@ -1,4 +1,4 @@
-const { geom3 } = require('../../geometry')
+const geom3 = require('../../geometry/geom3')
 
 const mayOverlap = require('./mayOverlap')
 const { Tree } = require('./trees')

--- a/packages/modeling/src/operations/expansions/expand.js
+++ b/packages/modeling/src/operations/expansions/expand.js
@@ -1,6 +1,8 @@
 const flatten = require('../../utils/flatten')
 
-const { geom2, geom3, path2 } = require('../../geometry')
+const geom2 = require('../../geometry/geom2')
+const geom3 = require('../../geometry/geom3')
+const path2 = require('../../geometry/path2')
 
 const expandGeom2 = require('./expandGeom2')
 const expandGeom3 = require('./expandGeom3')

--- a/packages/modeling/src/operations/expansions/expandGeom2.js
+++ b/packages/modeling/src/operations/expansions/expandGeom2.js
@@ -1,4 +1,4 @@
-const { geom2 } = require('../../geometry')
+const geom2 = require('../../geometry/geom2')
 
 const offsetFromPoints = require('./offsetFromPoints')
 

--- a/packages/modeling/src/operations/expansions/expandGeom3.js
+++ b/packages/modeling/src/operations/expansions/expandGeom3.js
@@ -1,4 +1,4 @@
-const { geom3 } = require('../../geometry')
+const geom3 = require('../../geometry/geom3')
 
 const union = require('../booleans/union')
 

--- a/packages/modeling/src/operations/expansions/expandPath2.js
+++ b/packages/modeling/src/operations/expansions/expandPath2.js
@@ -1,8 +1,9 @@
-const { area } = require('../../math/utils')
+const area = require('../../math/utils/area')
 
-const { vec2 } = require('../../math')
+const vec2 = require('../../math/vec2')
 
-const { geom2, path2 } = require('../../geometry')
+const geom2 = require('../../geometry/geom2')
+const path2 = require('../../geometry/path2')
 
 const offsetFromPoints = require('./offsetFromPoints')
 

--- a/packages/modeling/src/operations/expansions/expandShell.js
+++ b/packages/modeling/src/operations/expansions/expandShell.js
@@ -1,12 +1,14 @@
 const { EPS } = require('../../math/constants')
 
-const { mat4, vec3 } = require('../../math')
+const mat4 = require('../../math/mat4')
+const vec3 = require('../../math/vec3')
 
-const { fnNumberSort } = require('../../utils')
+const fnNumberSort = require('../../utils/fnNumberSort')
 
-const { geom3, poly3 } = require('../../geometry')
+const geom3 = require('../../geometry/geom3')
+const poly3 = require('../../geometry/poly3')
 
-const { sphere } = require('../../primitives')
+const { sphere } = require('../../primitives/ellipsoid')
 
 const retessellate = require('../booleans/retessellate')
 const unionGeom3Sub = require('../booleans/unionGeom3Sub')

--- a/packages/modeling/src/operations/expansions/extrudePolygon.js
+++ b/packages/modeling/src/operations/expansions/extrudePolygon.js
@@ -1,6 +1,8 @@
-const { mat4, vec3 } = require('../../math')
+const mat4 = require('../../math/mat4')
+const vec3 = require('../../math/vec3')
 
-const { geom3, poly3 } = require('../../geometry')
+const geom3 = require('../../geometry/geom3')
+const poly3 = require('../../geometry/poly3')
 
 // Extrude a polygon in the direction of the offsetvector.
 // Returns (geom3) a new geometry

--- a/packages/modeling/src/operations/expansions/offset.js
+++ b/packages/modeling/src/operations/expansions/offset.js
@@ -1,6 +1,7 @@
 const flatten = require('../../utils/flatten')
 
-const { geom2, path2 } = require('../../geometry')
+const geom2 = require('../../geometry/geom2')
+const path2 = require('../../geometry/path2')
 
 const offsetGeom2 = require('./offsetGeom2')
 const offsetPath2 = require('./offsetPath2')

--- a/packages/modeling/src/operations/expansions/offsetFromPoints.js
+++ b/packages/modeling/src/operations/expansions/offsetFromPoints.js
@@ -1,10 +1,11 @@
 const { EPS } = require('../../math/constants')
 
-const { intersect } = require('../../math/utils')
+const intersect = require('../../math/utils/intersect')
 
-const { line2, vec2 } = require('../../math')
+const line2 = require('../../math/line2')
+const vec2 = require('../../math/vec2')
 
-const { poly2 } = require('../../geometry')
+const poly2 = require('../../geometry/poly2')
 
 /*
  * Create a set of offset points from the given points using the given options (if any).

--- a/packages/modeling/src/operations/expansions/offsetGeom2.js
+++ b/packages/modeling/src/operations/expansions/offsetGeom2.js
@@ -1,4 +1,5 @@
-const { geom2, poly2 } = require('../../geometry')
+const geom2 = require('../../geometry/geom2')
+const poly2 = require('../../geometry/poly2')
 
 const offsetFromPoints = require('./offsetFromPoints')
 

--- a/packages/modeling/src/operations/expansions/offsetPath2.js
+++ b/packages/modeling/src/operations/expansions/offsetPath2.js
@@ -1,4 +1,4 @@
-const { path2 } = require('../../geometry')
+const path2 = require('../../geometry/path2')
 
 const offsetFromPoints = require('./offsetFromPoints')
 

--- a/packages/modeling/src/operations/extrusions/extrudeFromSlices.js
+++ b/packages/modeling/src/operations/extrusions/extrudeFromSlices.js
@@ -1,6 +1,8 @@
-const { mat4 } = require('../../math')
+const mat4 = require('../../math/mat4')
 
-const { geom2, geom3, poly3 } = require('../../geometry')
+const geom2 = require('../../geometry/geom2')
+const geom3 = require('../../geometry/geom3')
+const poly3 = require('../../geometry/poly3')
 
 const slice = require('./slice')
 

--- a/packages/modeling/src/operations/extrusions/extrudeLinear.js
+++ b/packages/modeling/src/operations/extrusions/extrudeLinear.js
@@ -1,6 +1,6 @@
 const flatten = require('../../utils/flatten')
 
-const { geom2 } = require('../../geometry')
+const geom2 = require('../../geometry/geom2')
 
 const extrudeLinearGeom2 = require('./extrudeLinearGeom2')
 

--- a/packages/modeling/src/operations/extrusions/extrudeLinearGeom2.js
+++ b/packages/modeling/src/operations/extrusions/extrudeLinearGeom2.js
@@ -1,6 +1,7 @@
-const { mat4, vec3 } = require('../../math')
+const mat4 = require('../../math/mat4')
+const vec3 = require('../../math/vec3')
 
-const { geom2 } = require('../../geometry')
+const geom2 = require('../../geometry/geom2')
 
 const slice = require('./slice')
 

--- a/packages/modeling/src/operations/extrusions/extrudeRectangular.js
+++ b/packages/modeling/src/operations/extrusions/extrudeRectangular.js
@@ -1,6 +1,7 @@
 const flatten = require('../../utils/flatten')
 
-const { geom2, path2 } = require('../../geometry')
+const geom2 = require('../../geometry/geom2')
+const path2 = require('../../geometry/path2')
 
 const extrudeRectangularPath2 = require('./extrudeRectangularPath2')
 const extrudeRectangularGeom2 = require('./extrudeRectangularGeom2')

--- a/packages/modeling/src/operations/extrusions/extrudeRectangularGeom2.js
+++ b/packages/modeling/src/operations/extrusions/extrudeRectangularGeom2.js
@@ -1,8 +1,9 @@
 const { area } = require('../../math/utils')
 
-const { geom2, path2 } = require('../../geometry')
+const geom2 = require('../../geometry/geom2')
+const path2 = require('../../geometry/path2')
 
-const { expand } = require('../expansions')
+const expand = require('../expansions/expand')
 
 const extrudeLinearGeom2 = require('./extrudeLinearGeom2')
 

--- a/packages/modeling/src/operations/extrusions/extrudeRectangularPath2.js
+++ b/packages/modeling/src/operations/extrusions/extrudeRectangularPath2.js
@@ -1,6 +1,6 @@
-const { path2 } = require('../../geometry')
+const path2 = require('../../geometry/path2')
 
-const { expand } = require('../expansions')
+const expand = require('../expansions/expand')
 
 const extrudeLinearGeom2 = require('./extrudeLinearGeom2')
 

--- a/packages/modeling/src/operations/extrusions/extrudeRotate.js
+++ b/packages/modeling/src/operations/extrusions/extrudeRotate.js
@@ -1,6 +1,6 @@
-const { mat4 } = require('../../math')
+const mat4 = require('../../math/mat4')
 
-const { geom2 } = require('../../geometry')
+const geom2 = require('../../geometry/geom2')
 
 const slice = require('./slice')
 

--- a/packages/modeling/src/operations/extrusions/extrudeWalls.js
+++ b/packages/modeling/src/operations/extrusions/extrudeWalls.js
@@ -1,6 +1,6 @@
-const { vec3 } = require('../../math')
+const vec3 = require('../../math/vec3')
 
-const { poly3 } = require('../../geometry')
+const poly3 = require('../../geometry/poly3')
 
 const slice = require('./slice')
 

--- a/packages/modeling/src/operations/extrusions/slice/calculatePlane.js
+++ b/packages/modeling/src/operations/extrusions/slice/calculatePlane.js
@@ -1,4 +1,5 @@
-const { plane, vec3 } = require('../../../math')
+const plane = require('../../../math/plane')
+const vec3 = require('../../../math/vec3')
 
 /**
  * Calculate the plane of the given slice.

--- a/packages/modeling/src/operations/extrusions/slice/toPolygons.js
+++ b/packages/modeling/src/operations/extrusions/slice/toPolygons.js
@@ -1,6 +1,7 @@
-const { vec3 } = require('../../../math')
+const vec3 = require('../../../math/vec3')
 
-const { geom3, poly3 } = require('../../../geometry')
+const geom3 = require('../../../geometry/geom3')
+const poly3 = require('../../../geometry/poly3')
 
 const intersectGeom3Sub = require('../../booleans/intersectGeom3Sub')
 

--- a/packages/modeling/src/operations/extrusions/slice/toString.js
+++ b/packages/modeling/src/operations/extrusions/slice/toString.js
@@ -1,4 +1,4 @@
-const vec3 = require('../../../math/vec3/')
+const vec3 = require('../../../math/vec3')
 
 const edgesToString = (edges) => edges.reduce((result, edge) => result += `[${vec3.toString(edge[0])}, ${vec3.toString(edge[1])}], `, '')
 

--- a/packages/modeling/src/operations/extrusions/slice/transform.js
+++ b/packages/modeling/src/operations/extrusions/slice/transform.js
@@ -1,4 +1,4 @@
-const { vec3 } = require('../../../math')
+const vec3 = require('../../../math/vec3')
 
 const create = require('./create')
 

--- a/packages/modeling/src/operations/hulls/hull.js
+++ b/packages/modeling/src/operations/hulls/hull.js
@@ -1,7 +1,9 @@
 const flatten = require('../../utils/flatten')
 const areAllShapesTheSameType = require('../../utils/areAllShapesTheSameType')
 
-const { geom2, geom3, path2 } = require('../../geometry')
+const geom2 = require('../../geometry/geom2')
+const geom3 = require('../../geometry/geom3')
+const path2 = require('../../geometry/poly3')
 
 const hullPath2 = require('./hullPath2')
 const hullGeom2 = require('./hullGeom2')

--- a/packages/modeling/src/operations/hulls/hull.js
+++ b/packages/modeling/src/operations/hulls/hull.js
@@ -3,7 +3,7 @@ const areAllShapesTheSameType = require('../../utils/areAllShapesTheSameType')
 
 const geom2 = require('../../geometry/geom2')
 const geom3 = require('../../geometry/geom3')
-const path2 = require('../../geometry/poly3')
+const path2 = require('../../geometry/path2')
 
 const hullPath2 = require('./hullPath2')
 const hullGeom2 = require('./hullGeom2')

--- a/packages/modeling/src/operations/hulls/hullGeom2.js
+++ b/packages/modeling/src/operations/hulls/hullGeom2.js
@@ -1,8 +1,8 @@
 const flatten = require('../../utils/flatten')
 
-const { vec2 } = require('../../math')
+const vec2 = require('../../math/vec2')
 
-const { geom2 } = require('../../geometry')
+const geom2 = require('../../geometry/geom2')
 
 const hullPoints2 = require('./hullPoints2')
 

--- a/packages/modeling/src/operations/hulls/hullGeom3.js
+++ b/packages/modeling/src/operations/hulls/hullGeom3.js
@@ -1,6 +1,7 @@
 const flatten = require('../../utils/flatten')
 
-const { geom3, poly3 } = require('../../geometry')
+const geom3 = require('../../geometry/geom3')
+const poly3 = require('../../geometry/poly3')
 
 const quickhull = require('./quickhull')
 

--- a/packages/modeling/src/operations/hulls/hullPath2.js
+++ b/packages/modeling/src/operations/hulls/hullPath2.js
@@ -1,8 +1,8 @@
 const flatten = require('../../utils/flatten')
 
-const { vec2 } = require('../../math')
+const vec2 = require('../../math/vec2')
 
-const { path2 } = require('../../geometry')
+const path2 = require('../../geometry/path2')
 
 const hullPoints2 = require('./hullPoints2')
 

--- a/packages/modeling/src/operations/hulls/hullPoints2.js
+++ b/packages/modeling/src/operations/hulls/hullPoints2.js
@@ -1,4 +1,4 @@
-const { vec2 } = require('../../math')
+const vec2 = require('../../math/vec2')
 
 const angleBetweenPoints = (p0, p1) => {
   return Math.atan2((p1[1] - p0[1]), (p1[0] - p0[0]))

--- a/packages/modeling/src/operations/measurements/measureArea.js
+++ b/packages/modeling/src/operations/measurements/measureArea.js
@@ -1,6 +1,9 @@
 const flatten = require('../../utils/flatten')
 
-const { geom2, geom3, path2, poly3 } = require('../../geometry')
+const geom2 = require('../../geometry/geom2')
+const geom3 = require('../../geometry/geom3')
+const path2 = require('../../geometry/path2')
+const poly3 = require('../../geometry/poly3')
 
 /*
  * Measure the area of the given geometry.

--- a/packages/modeling/src/operations/measurements/measureBounds.js
+++ b/packages/modeling/src/operations/measurements/measureBounds.js
@@ -1,8 +1,12 @@
 const flatten = require('../../utils/flatten')
 
-const { vec2, vec3 } = require('../../math')
+const vec2 = require('../../math/vec2')
+const vec3 = require('../../math/vec3')
 
-const { geom2, geom3, path2, poly3 } = require('../../geometry')
+const geom2 = require('../../geometry/geom2')
+const geom3 = require('../../geometry/geom3')
+const path2 = require('../../geometry/path2')
+const poly3 = require('../../geometry/poly3')
 
 /*
  * Measure the min and max bounds of the given (path2) geometry.

--- a/packages/modeling/src/operations/measurements/measureVolume.js
+++ b/packages/modeling/src/operations/measurements/measureVolume.js
@@ -1,6 +1,9 @@
 const flatten = require('../../utils/flatten')
 
-const { geom2, geom3, path2, poly3 } = require('../../geometry')
+const geom2 = require('../../geometry/geom2')
+const geom3 = require('../../geometry/geom3')
+const path2 = require('../../geometry/path2')
+const poly3 = require('../../geometry/poly3')
 
 /*
  * Measure the volume of the given geometry.

--- a/packages/modeling/src/operations/transforms/center.js
+++ b/packages/modeling/src/operations/transforms/center.js
@@ -1,8 +1,10 @@
 const flatten = require('../../utils/flatten')
 
-const { geom2, geom3, path2 } = require('../../geometry')
+const geom2 = require('../../geometry/geom2')
+const geom3 = require('../../geometry/geom3')
+const path2 = require('../../geometry/path2')
 
-const { measureBounds } = require('../measurements')
+const measureBounds = require('../measurements/measureBounds')
 
 const { translate } = require('./translate')
 

--- a/packages/modeling/src/operations/transforms/mirror.js
+++ b/packages/modeling/src/operations/transforms/mirror.js
@@ -1,8 +1,11 @@
 const flatten = require('../../utils/flatten')
 
-const { mat4, plane } = require('../../math')
+const mat4 = require('../../math/mat4')
+const plane = require('../../math/plane')
 
-const { geom2, geom3, path2 } = require('../../geometry')
+const geom2 = require('../../geometry/geom2')
+const geom3 = require('../../geometry/geom3')
+const path2 = require('../../geometry/path2')
 
 /**
  * Mirror the given object(s) using the given options (if any)

--- a/packages/modeling/src/operations/transforms/rotate.js
+++ b/packages/modeling/src/operations/transforms/rotate.js
@@ -2,7 +2,9 @@ const flatten = require('../../utils/flatten')
 
 const mat4 = require('../../math/mat4')
 
-const { geom2, geom3, path2 } = require('../../geometry')
+const geom2 = require('../../geometry/geom2')
+const geom3 = require('../../geometry/geom3')
+const path2 = require('../../geometry/path2')
 
 /**
  * Rotate the given object(s) using the given options (if any)

--- a/packages/modeling/src/operations/transforms/scale.js
+++ b/packages/modeling/src/operations/transforms/scale.js
@@ -2,7 +2,9 @@ const flatten = require('../../utils/flatten')
 
 const mat4 = require('../../math/mat4')
 
-const { geom2, geom3, path2 } = require('../../geometry')
+const geom2 = require('../../geometry/geom2')
+const geom3 = require('../../geometry/geom3')
+const path2 = require('../../geometry/path2')
 
 /**
  * Scale the given object(s) using the given options (if any)

--- a/packages/modeling/src/operations/transforms/transform.js
+++ b/packages/modeling/src/operations/transforms/transform.js
@@ -1,6 +1,8 @@
 const flatten = require('../../utils/flatten')
 
-const { geom2, geom3, path2 } = require('../../geometry')
+const geom2 = require('../../geometry/geom2')
+const geom3 = require('../../geometry/geom3')
+const path2 = require('../../geometry/path2')
 
 /**
  * Transform the given object(s) using the given matrix

--- a/packages/modeling/src/operations/transforms/translate.js
+++ b/packages/modeling/src/operations/transforms/translate.js
@@ -2,7 +2,9 @@ const flatten = require('../../utils/flatten')
 
 const mat4 = require('../../math/mat4')
 
-const { geom2, geom3, path2 } = require('../../geometry')
+const geom2 = require('../../geometry/geom2')
+const geom3 = require('../../geometry/geom3')
+const path2 = require('../../geometry/path2')
 
 /**
  * Translate the given object(s) using the given options (if any)

--- a/packages/modeling/src/primitives/cuboid.js
+++ b/packages/modeling/src/primitives/cuboid.js
@@ -1,4 +1,5 @@
-const {geom3, poly3} = require('../geometry')
+const geom3 = require('../geometry/geom3')
+const poly3 = require('../geometry/poly3')
 
 /**
  * Construct an axis-aligned solid cuboid.

--- a/packages/modeling/src/primitives/cylinderElliptic.js
+++ b/packages/modeling/src/primitives/cylinderElliptic.js
@@ -1,8 +1,9 @@
 const {EPS} = require('../math/constants')
 
-const {vec3} = require('../math')
+const vec3 = require('../math/vec3')
 
-const {geom3, poly3} = require('../geometry')
+const geom3 = require('../geometry/geom3')
+const poly3 = require('../geometry/poly3')
 
 /** Construct an elliptic cylinder.
  * @param {Object} [options] - options for construction

--- a/packages/modeling/src/primitives/roundedCuboid.js
+++ b/packages/modeling/src/primitives/roundedCuboid.js
@@ -1,8 +1,10 @@
 const {EPS} = require('../math/constants')
 
-const {vec2, vec3} = require('../math')
+const vec2 = require('../math/vec2')
+const vec3 = require('../math/vec3')
 
-const {geom3, poly3} = require('../geometry')
+const geom3 = require('../geometry/geom3')
+const poly3 = require('../geometry/poly3')
 
 const createCorners = (center, size, radius, segments, slice, positive) => {
   let pitch = (Math.PI / 2) * slice / segments

--- a/packages/modeling/src/primitives/roundedCylinder.js
+++ b/packages/modeling/src/primitives/roundedCylinder.js
@@ -1,8 +1,9 @@
 const {EPS} = require('../math/constants')
 
-const {vec3} = require('../math')
+const vec3 = require('../math/vec3')
 
-const {geom3, poly3} = require('../geometry')
+const geom3 = require('../geometry/geom3')
+const poly3 = require('../geometry/poly3')
 
 /** Construct a cylinder with rounded ends.
  * @param {Object} [options] - options for construction

--- a/packages/modeling/src/primitives/roundedRectangle.js
+++ b/packages/modeling/src/primitives/roundedRectangle.js
@@ -2,7 +2,7 @@ const {EPS} = require('../math/constants')
 
 const vec2 = require('../math/vec2')
 
-const {geom2} = require('../geometry')
+const geom2 = require('../geometry/geom2')
 
 /**
  * Construct a rounded rectangle.

--- a/packages/modeling/src/primitives/torus.js
+++ b/packages/modeling/src/primitives/torus.js
@@ -1,5 +1,5 @@
-const {extrudeRotate} = require('../operations/extrusions')
-const {rotateZ} = require('../operations/transforms')
+const extrudeRotate = require('../operations/extrusions/extrudeRotate')
+const {rotate} = require('../operations/transforms/rotate')
 
 const {circle} = require('./ellipse')
 
@@ -33,7 +33,7 @@ const torus = (options) => {
 
   let innerCircle = circle({radius: innerRadius, center: [outerRadius, 0], segments: innerSegments})
 
-  if (innerRotation !== 0) innerCircle = rotateZ(innerRotation, innerCircle)
+  if (innerRotation !== 0) innerCircle = rotate([0, 0, innerRotation], innerCircle)
 
   options = {
     startAngle: 0,

--- a/packages/modeling/src/utils/areAllShapesTheSameType.js
+++ b/packages/modeling/src/utils/areAllShapesTheSameType.js
@@ -1,5 +1,7 @@
 // list of supported geometries
-const {geom2, geom3, path2} = require('../geometry')
+const geom2 = require('../geometry/geom2')
+const geom3 = require('../geometry/geom3')
+const path2 = require('../geometry/path2')
 
 const areAllShapesTheSameType = (shapes) => {
   let previousType


### PR DESCRIPTION
Background... During the creation of some designs, I ran into a circular dependency on sphere(), which is used internally by expandShell() when expanding 3D geometries.

Solution... In order to eliminate (as much as possible) circular dependencies, all general require statements that use indexes have been replaced with specific require statements.

```
-const {vec2, vec3} = require('../math')
+const vec2 = require('../math/vec2')
+const vec3 = require('../math/vec3')
 
-const {geom3, poly3} = require('../geometry')
+const geom3 = require('../geometry/geom3')
+const poly3 = require('../geometry/poly3')

```

Only the modeling module has been updated.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Does your submission pass tests?