### PR TITLE
V2 : enhanced polyhedron to accept an array of colors

### DIFF
--- a/packages/io/stl-deserializer/index.js
+++ b/packages/io/stl-deserializer/index.js
@@ -353,6 +353,7 @@ const deserializeAsciiSTL = (stl, filename, version, elementFormatter) => {
  * Convert the given points, faces(triangles), normals, colors to geometry (polyhedron).
  */
 const toPolyhedron = (points, faces, normals, colors) => {
+  if (colors && faces.length !== colors.length) colors = undefined
   const options = {
     orientation: 'inward',
     points,

--- a/packages/modeling/src/primitives/polyhedron.js
+++ b/packages/modeling/src/primitives/polyhedron.js
@@ -39,7 +39,9 @@ const polyhedron = (options) => {
     if (!Array.isArray(colors)) {
       throw new Error('colors must be an array')
     }
-    if (colors.length !== faces.length) colors = undefined
+    if (colors.length !== faces.length) {
+      throw new Error('faces and colors must have the same length')
+    }
   }
 
   // invert the faces if orientation is inwards, as all internals expect outwarding facing polygons
@@ -47,12 +49,11 @@ const polyhedron = (options) => {
     faces.forEach((face) => face.reverse())
   }
 
-  let polygons = faces.map((face) => poly3.fromPoints(face.map((idx) => points[idx])))
-
-  if (colors) {
-    // add color to each polygon
-    polygons.forEach((polygon, idx) => { if (colors[idx]) polygon.color = colors[idx] })
-  }
+  let polygons = faces.map((face, findex) => {
+    let polygon = poly3.fromPoints(face.map((pindex) => points[pindex]))
+    if (colors && colors[findex]) polygon.color = colors[findex]
+    return polygon
+  })
 
   return geom3.create(polygons)
 }

--- a/packages/modeling/src/primitives/polyhedron.js
+++ b/packages/modeling/src/primitives/polyhedron.js
@@ -1,12 +1,14 @@
 const geom3 = require('../geometry/geom3')
 const poly3 = require('../geometry/poly3')
 
-/** Create a polyhedron from the given set of points and faces.
+/**
+ * Create a polyhedron from the given set of points and faces.
  * The faces can define outward or inward facing polygons (orientation).
  * However, each face must define a counter clockwise rotation of points which follows the right hand rule.
  * @param {Object} options - options for construction
- * @param {Array} options.points - list of points in 3D space
- * @param {Array} options.faces - list of faces, where each face is a set of indexes into the points
+ * @param {Array} options.points=[] - list of points in 3D space
+ * @param {Array} options.faces=[] - list of faces, where each face is a set of indexes into the points
+ * @param {Array} [options.colors=undefined] - list of RGBA colors to apply to each face
  * @param {Array} [options.orientation='outward'] - orientation of faces
  * @returns {geom3} new 3D geometry
  *
@@ -19,9 +21,10 @@ const polyhedron = (options) => {
   const defaults = {
     points: [],
     faces: [],
+    colors: undefined,
     orientation: 'outward'
   }
-  const {points, faces, orientation} = Object.assign({}, defaults, options)
+  let {points, faces, colors, orientation} = Object.assign({}, defaults, options)
 
   if (!(Array.isArray(points) && Array.isArray(faces))) {
     throw new Error('points and faces must be arrays')
@@ -32,6 +35,12 @@ const polyhedron = (options) => {
   if (faces.length < 1) {
     throw new Error('one or more faces are required')
   }
+  if (colors) {
+    if (!Array.isArray(colors)) {
+      throw new Error('colors must be an array')
+    }
+    if (colors.length !== faces.length) colors = undefined
+  }
 
   // invert the faces if orientation is inwards, as all internals expect outwarding facing polygons
   if (orientation !== 'outward') {
@@ -39,6 +48,12 @@ const polyhedron = (options) => {
   }
 
   let polygons = faces.map((face) => poly3.fromPoints(face.map((idx) => points[idx])))
+
+  if (colors) {
+    // add color to each polygon
+    polygons.forEach((polygon, idx) => { if (colors[idx]) polygon.color = colors[idx] })
+  }
+
   return geom3.create(polygons)
 }
 

--- a/packages/modeling/src/primitives/polyhedron.test.js
+++ b/packages/modeling/src/primitives/polyhedron.test.js
@@ -10,7 +10,8 @@ test('polyhedron (points and faces)', t => {
   // points and faces form a cube
   let points = [ [-1, -1, -1], [-1, -1, 1], [-1, 1, 1], [-1, 1, -1], [1, -1, 1], [1, -1, -1], [1, 1, -1], [1, 1, 1] ]
   let faces = [[0, 1, 2, 3], [5, 6, 7, 4], [0, 5, 4, 1], [3, 2, 7, 6], [0, 3, 6, 5], [1, 4, 7, 2]]
-  let obs = polyhedron({points: points, faces: faces})
+  let colors = [[0, 0, 0, 1], [1, 0, 0, 1], [0, 1, 0, 1], [0, 0, 1, 1], [0.5, 0.5, 0.5, 1], [1, 1, 1, 1]]
+  let obs = polyhedron({points, faces, colors})
   let pts = geom3.toPoints(obs)
   let exp = [
     [[-1.0000000, -1.0000000, -1.0000000],


### PR DESCRIPTION
These changes add support for colors (arrays) to polyhedron. The colors are applied to each face (polygon) of the polyhedron (geom3).

The reason behind these changes is that the several deserializers use polyhedron to produce geometries.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Does your submission pass tests?