### PR TITLE
V2 : fix fromFakePolygons

### DIFF
--- a/packages/modeling/src/operations/booleans/fromFakePolygons.js
+++ b/packages/modeling/src/operations/booleans/fromFakePolygons.js
@@ -27,6 +27,8 @@ const fromFakePolygon = (epsilon, polygon) => {
     return vec2.fromValues(x, y)
   })
 
+  if (vec2.equals(points2D[0], points2D[1])) return null
+
   const d = vert1Indices[1] - vert1Indices[0]
   if (d === 1 || d === 3) {
     if (d === 1) {


### PR DESCRIPTION
There was a issue within fromFakePolygons() as the dynamic EPS (snaping of points) was producing sides with the same points, e.g. [[1, 2], [1, 2]]. This causes the geom2 to have a zero (0) length side, and subsequent functions using the geom2 fail.

**This is a small fix but IMPORTANT.**

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Does your submission pass tests?