### PR TITLE
V2 fix core

### DIFF
--- a/packages/core/code-evaluation/instanciateDesign.js
+++ b/packages/core/code-evaluation/instanciateDesign.js
@@ -4,7 +4,7 @@ const isGeom2 = require('@jscad/modeling').geometry.geom2.isA
 const isGeom3 = require('@jscad/modeling').geometry.geom3.isA
 const isPath2 = require('@jscad/modeling').geometry.path2.isA
 
-const { toArray } = require('@jscad/array-utils')
+const { flatten, toArray } = require('@jscad/array-utils')
 
 // const toCompactBinary = require('./toCompactTest')
 const isResultSolid = (rawResults) => (rawResults.length > 0 && (isGeom3(rawResults[0]) || isGeom2(rawResults[0]) || isPath2(rawResults[0]) ))
@@ -60,7 +60,7 @@ const instanciateDesign = (rootModule, parameterValues, options) => {
   const { vtreeMode, inputLookup, inputLookupCounts, serialize } = options
   // deal with the actual solids generation
   let solids
-  let rawResults = toArray(rootModule.main(parameterValues))
+  let rawResults = flatten(toArray(rootModule.main(parameterValues)))
 
   const forcedNOVtreeMode = false // FIXME: disabling Vtree mode for now until more V2 progress is done
   if (forcedNOVtreeMode) {

--- a/packages/core/code-loading/transformSources.js
+++ b/packages/core/code-loading/transformSources.js
@@ -82,11 +82,6 @@ const transformSources = (options, filesAndFolders) => {
 
       return transformedEntry
     }
-    if (entry.children) {
-      entry.children = entry.children.map(function (childEntry) {
-        return updateEntry(childEntry)
-      })
-    }
     return entry
   }
 


### PR DESCRIPTION
This pull request contains a couple of fixes to the core library.

**instantiateDesign()** was properly converting returned solids toArray() but designs can return arrays, or even arrays of arrays. flatten() was added to handle these cases.

**transformSource()** was transforming everything found in the filesAndFolders. all the children (STL, etc. files) were being converted to scripts, causing designs to fail. the transforming of children was removed, as specific file types can be converted directly to geometry via require().

sadly, test cases are not possible for the core library. sigh.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Does your submission pass tests?