### PR TITLE
V2 : fix rebuild geometry for cli

### DIFF
--- a/packages/cli/cli.conversions.test.js
+++ b/packages/cli/cli.conversions.test.js
@@ -17,6 +17,10 @@ test.afterEach.always(t => {
   try {
     if (t.context.file3Path) fs.unlinkSync(t.context.file3Path)
   } catch (err) {}
+
+  try {
+    if (t.context.file4Path) fs.unlinkSync(t.context.file4Path)
+  } catch (err) {}
 })
 
 test.beforeEach(t => {
@@ -102,8 +106,7 @@ test('cli (conversions)', t => {
 
   t.context.file4Path = file4Path
 
-  // FIXME FAILS WITH STACK TRACE
-  // cmd = `node ${cliPath} ${file2Path} -of dxf`
-  // execSync(cmd, { stdio: [0, 1, 2] })
-  // t.true(fs.existsSync(file4Path))
+  cmd = `node ${cliPath} ${file2Path} -of dxf`
+  execSync(cmd, { stdio: [0, 1, 2] })
+  t.true(fs.existsSync(file4Path))
 })

--- a/packages/cli/src/generateOutputData.js
+++ b/packages/cli/src/generateOutputData.js
@@ -55,7 +55,9 @@ const generateOutputData = (source, params, options) => {
     }
 
     // convert any inputs
+    const prevsource = source
     source = conversionTable[inputFormat]({ source, params, options })
+    if (source === prevsource) source = null // rebuild using the file system
 
     if (outputFormat === 'jscad' || outputFormat === 'js') {
       resolve(source)

--- a/packages/cli/src/generateOutputData.js
+++ b/packages/cli/src/generateOutputData.js
@@ -22,7 +22,7 @@ const generateOutputData = (source, params, options) => {
     addMetaData: true
   }
   options = Object.assign({}, defaults, options)
-  const { outputFormat, inputFile, inputFormat, inputIsDirectory } = options
+  const { outputFormat, inputFile, inputFormat } = options
 
   options.filename = inputFile // for deserializers
 
@@ -57,7 +57,7 @@ const generateOutputData = (source, params, options) => {
     // convert any inputs
     const prevsource = source
     source = conversionTable[inputFormat]({ source, params, options })
-    if (source === prevsource) source = null // rebuild using the file system
+    const useFakeFs = (source !== prevsource) // conversion, so use a fake file system when rebuilding
 
     if (outputFormat === 'jscad' || outputFormat === 'js') {
       resolve(source)
@@ -65,7 +65,7 @@ const generateOutputData = (source, params, options) => {
       //    } else if ((inputFormat === 'jscad' || inputFormat === 'js') &&
       //               outputFormat !== 'jscad' && outputFormat !== 'js') {
       try {
-        const solids = rebuildSolids({ mainPath: inputPath, parameterValues: params, inputIsDirectory, source })
+        const solids = rebuildSolids({ mainPath: inputPath, parameterValues: params, useFakeFs, source })
         resolve(solids)
       } catch (error) {
         reject(error)

--- a/packages/core/code-evaluation/rebuildGeometryCli.js
+++ b/packages/core/code-evaluation/rebuildGeometryCli.js
@@ -3,31 +3,31 @@ const path = require('path')
 const { toArray } = require('@jscad/array-utils')
 const requireDesignFromModule = require('../code-loading/requireDesignFromModule')
 const getAllParameterDefintionsAndValues = require('../parameters/getParameterDefinitionsAndValues')
-const transformSources = require('../code-loading/transformSources')
 const makeWebRequire = require('../code-loading/webRequire')
-const makeFakeFs = require('../code-loading/makeFakeFs')
-const { registerAllExtensions } = require('../io/registerExtensions')
 
 const rebuildSolids = (data) => {
   const defaults = { vtreeMode: false, serialize: false }
-  let { mainPath, vtreeMode, parameterValues, inputIsDirectory } = Object.assign({}, defaults, data)
+  let { mainPath, vtreeMode, parameterValues, useFakeFs } = Object.assign({}, defaults, data)
   const apiMainPath = vtreeMode ? '../code-loading/vtreeApi' : '@jscad/modeling'
   // we need to update the source for our module
   let requireFn = require
 
   // source came from conversion, i.e. not from file system
-  if (data.source) {
-    let filesAndFolders = [
+  if (useFakeFs) {
+    const pathParts = path.parse(mainPath)
+    const fakeName = `${pathParts.name}.js`
+    const fakePath = `/${pathParts.name}.js`
+    const filesAndFolders = [
       {
         ext: 'js',
-        fullPath: './index.js',
-        name: 'index.js',
+        fullPath: fakePath,
+        name: fakeName,
         source: data.source
       }
     ]
     requireFn = makeWebRequire(filesAndFolders, { apiMainPath })
 
-    mainPath = './index.js' // and use the alias as the entry point
+    mainPath = fakePath // and use the alias as the entry point
   }
 
   // rootModule should contain exported main and getParameterDefinitions functions

--- a/packages/core/code-evaluation/rebuildGeometryCli.js
+++ b/packages/core/code-evaluation/rebuildGeometryCli.js
@@ -10,34 +10,27 @@ const { registerAllExtensions } = require('../io/registerExtensions')
 
 const rebuildSolids = (data) => {
   const defaults = { vtreeMode: false, serialize: false }
-  const { mainPath, vtreeMode, parameterValues, inputIsDirectory } = Object.assign({}, defaults, data)
+  let { mainPath, vtreeMode, parameterValues, inputIsDirectory } = Object.assign({}, defaults, data)
   const apiMainPath = vtreeMode ? '../code-loading/vtreeApi' : '@jscad/modeling'
   // we need to update the source for our module
   let requireFn = require
-  if (!inputIsDirectory) {
+
+  // source came from conversion, i.e. not from file system
+  if (data.source) {
     let filesAndFolders = [
       {
-        ext: path.extname(mainPath).substring(1),
-        name: path.basename(mainPath),
-        fullPath: mainPath,
+        ext: 'js',
+        fullPath: './index.js',
+        name: 'index.js',
         source: data.source
       }
     ]
-    filesAndFolders = transformSources({ apiMainPath }, filesAndFolders)
-    // console.log('filesAndFolders', filesAndFolders)
+    requireFn = makeWebRequire(filesAndFolders, { apiMainPath })
 
-    const fakeFs = makeFakeFs(filesAndFolders)
-    requireFn = makeWebRequire(filesAndFolders, { apiMainPath, fakeFs })// hasRequire() ? require : makeWebRequire(filesAndFolders, { apiMainPath })
-    // register all extension formats
-    registerAllExtensions(fakeFs, requireFn)
+    mainPath = './index.js' // and use the alias as the entry point
   }
 
-  // console.log('transformed sources', filesAndFolders)
-  // now check if we need fake require or not
-  // FIXME: we need to come up with a way to intercept node 'require' calls to be able to apply transformSources on the fly
-  // since we keep passing the 'mainPath' to the normal require which points to the NON TRANSFORMED source
-  // const requireFn = makeWebRequire(filesAndFolders, { apiMainPath })// hasRequire() ? require : makeWebRequire(filesAndFolders, { apiMainPath })
-  // rootModule SHOULD contain a main() entry and optionally a getParameterDefinitions entry
+  // rootModule should contain exported main and getParameterDefinitions functions
   const rootModule = requireDesignFromModule(mainPath, requireFn)
   // the design (module tree) has been loaded at this stage
   // now we can get our usefull data (definitions and values/defaults)


### PR DESCRIPTION
These changes adjust the logic in rebuildGeometryCli() to ONLY use webRequire() when a conversion to JSCAD source happens, e.g. STL translation. The opposite is also true, the logic ONLY uses require() in normal cases.

Fixes #504 for the CLI only.
Fixes conversions from STL to DXF, etc. (test case has been enabled)

I always wondered why webRequire() was used by rebuildGeometryCli(), and now I understand. There's a special case when external formats are converted in-memory, which webRequire() handles nicely.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Does your submission pass tests?