### PR TITLE
V2 : fix svg serialize

### DIFF
--- a/packages/io/svg-serializer/index.js
+++ b/packages/io/svg-serializer/index.js
@@ -97,8 +97,8 @@ const getBounds = (objects) => {
 }
 
 const convertObjects = (objects, bounds, options) => {
-  const xoffset = 0 - bounds[0][0]
-  const yoffset = 0 - bounds[0][1]
+  const xoffset = 0 - bounds[0][0] // offset to X=0
+  const yoffset = 0 - bounds[1][1] // offset to Y=0
 
   const contents = []
   objects.forEach((object, i) => {
@@ -114,6 +114,15 @@ const convertObjects = (objects, bounds, options) => {
   return contents
 }
 
+const reflect = (x, y, px, py) => {
+  const ox = x - px
+  const oy = y - py
+  if (x === px && y === px) return [x, y]
+  if (x === px) return [x, py - (oy)]
+  if (y === py) return [px - (-ox), y]
+  return [px - (-ox), py - (oy)]
+}
+
 const convertGeom2 = (object, offsets, options) => {
   const outlines = geometry.geom2.toOutlines(object)
   const paths = outlines.map((outline) => geometry.path2.fromPoints({ closed: true }, outline))
@@ -125,9 +134,9 @@ const convertGeom2 = (object, offsets, options) => {
   return convertToContinousPath(paths, offsets, options)
 }
 
-const convertToContinousPath = (paths, offset, options) => {
+const convertToContinousPath = (paths, offsets, options) => {
   let instructions = ''
-  paths.forEach((path) => (instructions += convertPath(path, offset, options)))
+  paths.forEach((path) => (instructions += convertPath(path, offsets, options)))
   let continouspath = ['path', { d: instructions }]
   if (paths.length > 0) {
     const path0 = paths[0]
@@ -152,8 +161,10 @@ const convertPath = (path, offsets, options) => {
     let pointindexwrapped = pointindex
     if (pointindexwrapped >= path.points.length) pointindexwrapped -= path.points.length
     const point = path.points[pointindexwrapped]
-    const x = Math.round((point[0] + offsets[0]) * options.decimals) / options.decimals
-    const y = Math.round((point[1] + offsets[1]) * options.decimals) / options.decimals
+    const offpoint = [point[0] + offsets[0], point[1] + offsets[1]]
+    const svgpoint = reflect(offpoint[0], offpoint[1], 0, 0)
+    const x = Math.round(svgpoint[0] * options.decimals) / options.decimals
+    const y = Math.round(svgpoint[1] * options.decimals) / options.decimals
     if (pointindex > 0) {
       str += `L${x} ${y}`
     } else {

--- a/packages/io/svg-serializer/tests/geom2.test.js
+++ b/packages/io/svg-serializer/tests/geom2.test.js
@@ -74,7 +74,7 @@ const expected2 = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1 Tiny//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11-tiny.dtd">
 <svg width="10mm" height="20mm" viewBox="0 0 10 20" version="1.1" baseProfile="tiny" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <g>
-    <path d="M0 0L10 0L10 20L0 20L0 0"/>
+    <path d="M0 20L10 20L10 0L0 0L0 20"/>
   </g>
 </svg>
 `
@@ -84,10 +84,10 @@ const expected3 = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1 Tiny//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11-tiny.dtd">
 <svg width="70mm" height="80mm" viewBox="0 0 70 80" version="1.1" baseProfile="tiny" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <g>
-    <path d="M0 0L10 0L10 20L0 20L0 0"/>
+    <path d="M0 80L10 80L10 60L0 60L0 80"/>
   </g>
   <g>
-    <path d="M60 60L70 60L70 80L60 80L60 60"/>
+    <path d="M60 20L70 20L70 0L60 0L60 20"/>
   </g>
 </svg>
 `
@@ -97,7 +97,7 @@ const expected4 = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1 Tiny//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11-tiny.dtd">
 <svg width="10mm" height="20mm" viewBox="0 0 10 20" version="1.1" baseProfile="tiny" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <g>
-    <path fill-rule="evenodd" fill="rgb(127.5,127.5,127.5,127.5)" d="M0 0L10 0L10 20L0 20L0 0"/>
+    <path fill-rule="evenodd" fill="rgb(127.5,127.5,127.5,127.5)" d="M0 20L10 20L10 0L0 0L0 20"/>
   </g>
 </svg>
 `
@@ -107,7 +107,7 @@ const expected5 = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1 Tiny//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11-tiny.dtd">
 <svg width="150mm" height="150mm" viewBox="0 0 150 150" version="1.1" baseProfile="tiny" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <g>
-    <path fill-rule="evenodd" fill="rgb(127.5,127.5,127.5,127.5)" d="M0 0L150 0L150 150L115 150L115 75L35 75L35 150L0 150L0 0M90 35L83 35L83 50L67 50L67 35L60 35L60 65L90 65L90 35M73 56L77 56L77 60L73 60L73 56"/>
+    <path fill-rule="evenodd" fill="rgb(127.5,127.5,127.5,127.5)" d="M0 150L150 150L150 0L115 0L115 75L35 75L35 0L0 0L0 150M90 115L83 115L83 100L67 100L67 115L60 115L60 85L90 85L90 115M73 94L77 94L77 90L73 90L73 94"/>
   </g>
 </svg>
 `

--- a/packages/io/svg-serializer/tests/path2.test.js
+++ b/packages/io/svg-serializer/tests/path2.test.js
@@ -39,7 +39,7 @@ const expected1 = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1 Tiny//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11-tiny.dtd">
 <svg width="4mm" height="3mm" viewBox="0 0 4 3" version="1.1" baseProfile="tiny" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <g>
-    <path d="M3 0L4 1L0 3"/>
+    <path d="M3 3L4 2L0 0"/>
   </g>
 </svg>
 `
@@ -49,7 +49,7 @@ const expected3 = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1 Tiny//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11-tiny.dtd">
 <svg width="42.3333mm" height="56.4444mm" viewBox="0 0 42.3333 56.4444" version="1.1" baseProfile="tiny" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <g>
-    <path d="M21.1667 56.4444L0 0L42.3333 0L21.1667 56.4444"/>
+    <path d="M21.1667 0L0 56.4444L42.3333 56.4444L21.1667 0"/>
   </g>
 </svg>
 `
@@ -59,7 +59,7 @@ const expected4 = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1 Tiny//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11-tiny.dtd">
 <svg width="4mm" height="3mm" viewBox="0 0 4 3" version="1.1" baseProfile="tiny" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <g>
-    <path stroke="rgb(127.5,127.5,127.5,127.5)" stroke-width="1" d="M3 0L4 1L0 3"/>
+    <path stroke="rgb(127.5,127.5,127.5,127.5)" stroke-width="1" d="M3 3L4 2L0 0"/>
   </g>
 </svg>
 `


### PR DESCRIPTION
These changes correct the orientation of SVG shapes. The orientation is now the same as designs / rendering. Test suites have been updated as well.

I noticed this a while back and finally got around to fixing this.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Does your submission pass tests?