### PR TITLE
V2 Add VagrantFile to develop on a local vm.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ packages/web/examples
 package-lock.json
 *.log
 *.swp
+out
+vagrant/.vagrant/
+

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,79 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "ubuntu/bionic64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  config.vm.network "forwarded_port", guest: 8081, host: 8081, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder "../", "/openjscad"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+    vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", inline: <<-SHELL
+    apt-get update
+    cp /openjscad/vagrant/resources/.bash_aliases ~/
+    curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
+    sudo apt-get install -y nodejs
+    cd /openjscad
+    npm install
+    npm run bootstrap
+    npm test
+    npm run docs
+
+  SHELL
+
+end

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -43,7 +43,7 @@ Vagrant.configure("2") do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  config.vm.synced_folder "../", "/openjscad"
+  config.vm.synced_folder "../", "/jscad"
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.
@@ -65,10 +65,11 @@ Vagrant.configure("2") do |config|
   # documentation for more information about their specific syntax and use.
   config.vm.provision "shell", inline: <<-SHELL
     apt-get update
-    cp /openjscad/vagrant/resources/.bash_aliases ~/
+    cp /jscad/vagrant/resources/.bash_aliases ~/
     curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
     sudo apt-get install -y nodejs
-    cd /openjscad
+    sudo npm install standard --global
+    cd /jscad
     npm install
     npm run bootstrap
     npm test

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -65,15 +65,20 @@ Vagrant.configure("2") do |config|
   # documentation for more information about their specific syntax and use.
   config.vm.provision "shell", inline: <<-SHELL
     apt-get update
-    cp /jscad/vagrant/resources/.bash_aliases ~/
     curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
-    sudo apt-get install -y nodejs
-    sudo npm install standard --global
+    apt-get install -y nodejs
+    npm install standard --global
+
+    cp /jscad/vagrant/resources/.bash_aliases /home/vagrant/
+    chowm vagrant:vagrant /home/vagrant/.bash_aliases
+
     cd /jscad
     npm install
     npm run bootstrap
     npm run docs
     npm test
+
+    echo "Log in to the vm using 'vagrant ssh', and launch jscad on the vm with 'jscad'"
   SHELL
 
 end

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -37,7 +37,7 @@ Vagrant.configure("2") do |config|
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on
   # your network.
-  config.vm.network "public_network"
+  # config.vm.network "public_network"
 
   # Share an additional folder to the guest VM. The first argument is
   # the path on the host to the actual folder. The second argument is
@@ -54,7 +54,7 @@ Vagrant.configure("2") do |config|
     vb.gui = true
   #
   #   # Customize the amount of memory on the VM:
-  #   vb.memory = "1024"
+    vb.memory = "4096"
   end
   #
   # View the documentation for the provider you are using for more
@@ -72,9 +72,8 @@ Vagrant.configure("2") do |config|
     cd /jscad
     npm install
     npm run bootstrap
-    npm test
     npm run docs
-
+    npm test
   SHELL
 
 end

--- a/vagrant/resources/.bash_aliases
+++ b/vagrant/resources/.bash_aliases
@@ -1,2 +1,2 @@
-alias jscad="echo \"Check http://127.0.0.1:8081 from host computer\"; cd /openjscad/packages/web; npm run dev;"
+alias jscad="echo \"Check http://127.0.0.1:8081 from host computer\"; cd /jscad/packages/web; npm run dev;"
 

--- a/vagrant/resources/.bash_aliases
+++ b/vagrant/resources/.bash_aliases
@@ -1,0 +1,2 @@
+alias openjscad="echo \"Check http://127.0.0.1:8081 from host computer\"; cd /openjscad/packages/web; npm run dev;"
+

--- a/vagrant/resources/.bash_aliases
+++ b/vagrant/resources/.bash_aliases
@@ -1,2 +1,2 @@
-alias openjscad="echo \"Check http://127.0.0.1:8081 from host computer\"; cd /openjscad/packages/web; npm run dev;"
+alias jscad="echo \"Check http://127.0.0.1:8081 from host computer\"; cd /openjscad/packages/web; npm run dev;"
 


### PR DESCRIPTION
Easily create a local VM for building and running JSCAD. This means that:
- Dependencies are installed on a known-good system
- If you mess up your development system, destroy it and rebuild :)
- Nothing (other than vagrant / virtualbox) gets installed on your main system.


To Test: 
- Install Vagrant and VirtualBox on your host machine.  
- "cd OpenJSCAD/vagrant"
- "vagrant up"
- "vagrant ssh"
- "jscad"
- point your browser at http://127.0.0.1:8081
