### PR TITLE
V2 fix vecs

### DIFF
--- a/packages/modeling/src/maths/OrthoNormalBasis.js
+++ b/packages/modeling/src/maths/OrthoNormalBasis.js
@@ -18,7 +18,7 @@ const vec3 = require('./vec3')
 const OrthoNormalBasis = function (plane, rightvector) {
   if (arguments.length < 2) {
     // choose an arbitrary right hand vector, making sure it is somewhat orthogonal to the plane normal:
-    rightvector = vec3.random(plane)
+    rightvector = vec3.orthogonal(plane)
   } else {
     rightvector = rightvector
   }

--- a/packages/modeling/src/maths/plane/fromPointsRandom.js
+++ b/packages/modeling/src/maths/plane/fromPointsRandom.js
@@ -18,15 +18,15 @@ const fromPointsRandom = (a, b, c) => {
   let ba = vec3.subtract(b, a)
   let ca = vec3.subtract(c, a)
   if (vec3.length(ba) < EPS) {
-    ba = vec3.random(ca)
+    ba = vec3.orthogonal(ca)
   }
   if (vec3.length(ca) < EPS) {
-    ca = vec3.random(ba)
+    ca = vec3.orthogonal(ba)
   }
   let normal = vec3.cross(ba, ca)
   if (vec3.length(normal) < EPS) {
     // this would mean that ba == ca.negated()
-    ca = vec3.random(ba)
+    ca = vec3.orthogonal(ba)
     normal = vec3.cross(ba, ca)
   }
   normal = vec3.unit(normal)

--- a/packages/modeling/src/maths/plane/transform.js
+++ b/packages/modeling/src/maths/plane/transform.js
@@ -14,7 +14,7 @@ const flip = require('./flip')
 const transform = (matrix, plane) => {
   const ismirror = mat4.isMirroring(matrix)
   // get two vectors in the plane:
-  const r = vec3.random(plane)
+  const r = vec3.orthogonal(plane)
   const u = vec3.cross(plane, r)
   const v = vec3.cross(plane, u)
   // get 3 points in the plane:

--- a/packages/modeling/src/maths/vec2/distance.js
+++ b/packages/modeling/src/maths/vec2/distance.js
@@ -9,7 +9,7 @@
 const distance = (a, b) => {
   const x = b[0] - a[0]
   const y = b[1] - a[1]
-  return Math.sqrt(x * x + y * y)
+  return Math.hypot(x, y)
 }
 
 module.exports = distance

--- a/packages/modeling/src/maths/vec2/length.js
+++ b/packages/modeling/src/maths/vec2/length.js
@@ -8,7 +8,7 @@
 const length = (a) => {
   const x = a[0]
   const y = a[1]
-  return Math.sqrt(x * x + y * y)
+  return Math.hypot(x, y)
 }
 
 module.exports = length

--- a/packages/modeling/src/maths/vec2/normalize.js
+++ b/packages/modeling/src/maths/vec2/normalize.js
@@ -23,9 +23,9 @@ const normalize = (...params) => {
   let len = x * x + y * y
   if (len > 0) {
     len = 1 / Math.sqrt(len)
-    out[0] = a[0] * len
-    out[1] = a[1] * len
   }
+  out[0] = x * len
+  out[1] = y * len
   return out
 }
 

--- a/packages/modeling/src/maths/vec2/normalize.test.js
+++ b/packages/modeling/src/maths/vec2/normalize.test.js
@@ -23,18 +23,28 @@ test('vec2: normalize() called with two paramerters should update a vec2 with co
   t.true(compareVectors(obs1, [0, 0]))
   t.true(compareVectors(ret1, [0, 0]))
 
-  const obs2 = fromValues(0, 0, 0)
+  const obs2 = fromValues(0, 0)
   const ret2 = normalize(obs2, [1, 2])
   t.true(compareVectors(obs2, [0.4472135901451111, 0.8944271802902222]))
   t.true(compareVectors(ret2, [0.4472135901451111, 0.8944271802902222]))
 
-  const obs3 = fromValues(0, 0, 0)
+  const obs3 = fromValues(0, 0)
   const ret3 = normalize(obs3, [-1, -2])
   t.true(compareVectors(obs3, [-0.4472135901451111, -0.8944271802902222]))
   t.true(compareVectors(ret3, [-0.4472135901451111, -0.8944271802902222]))
 
-  const obs4 = fromValues(0, 0, 0)
+  const obs4 = fromValues(0, 0)
   const ret4 = normalize(obs4, [-1, 2])
   t.true(compareVectors(obs4, [-0.4472135901451111, 0.8944271802902222]))
   t.true(compareVectors(ret4, [-0.4472135901451111, 0.8944271802902222]))
+
+  const obs5 = fromValues(0, 0)
+  const ret5 = normalize(obs5, [0.5, 1.5])
+  t.true(compareVectors(obs5, [0.3162277638912201, 0.9486833214759827]))
+  t.true(compareVectors(ret5, [0.3162277638912201, 0.9486833214759827]))
+
+  const obs6 = fromValues(0, 0)
+  const ret6 = normalize(obs6, [0.5, 0.5])
+  t.true(compareVectors(obs6, [0.7071067690849304, 0.7071067690849304]))
+  t.true(compareVectors(ret6, [0.7071067690849304, 0.7071067690849304]))
 })

--- a/packages/modeling/src/maths/vec3/angle.js
+++ b/packages/modeling/src/maths/vec3/angle.js
@@ -9,11 +9,17 @@ const dot = require('./dot')
  * @alias module:modeling/maths/vec3.angle
  */
 const angle = (a, b) => {
-  const tempA = normalize(a)
-  const tempB = normalize(b)
-
-  const cosine = dot(tempA, tempB)
-  return cosine > 1.0 ? 0 : Math.acos(cosine)
+  const ax = a[0]
+  const ay = a[1]
+  const az = a[2]
+  const bx = b[0]
+  const by = b[1]
+  const bz = b[2]
+  const mag1 = Math.sqrt(ax * ax + ay * ay + az * az)
+  const mag2 = Math.sqrt(bx * bx + by * by + bz * bz)
+  const mag = mag1 * mag2
+  const cosine = mag && dot(a, b) / mag
+  return Math.acos(Math.min(Math.max(cosine, -1), 1))
 }
 
 module.exports = angle

--- a/packages/modeling/src/maths/vec3/angle.test.js
+++ b/packages/modeling/src/maths/vec3/angle.test.js
@@ -23,7 +23,7 @@ test('vec3: angle() should return correct values', (t) => {
   const veca4 = fromValues(1, 1, 1)
   const vec4 = fromValues(-1, -1, -1)
   const angle4 = angle(veca4, vec4)
-  nearlyEqual(t, angle4, 3.14132, EPS)
+  nearlyEqual(t, angle4, 3.14159, EPS)
 
   t.true(true)
 })

--- a/packages/modeling/src/maths/vec3/distance.js
+++ b/packages/modeling/src/maths/vec3/distance.js
@@ -10,7 +10,7 @@ const distance = (a, b) => {
   const x = b[0] - a[0]
   const y = b[1] - a[1]
   const z = b[2] - a[2]
-  return Math.sqrt(x * x + y * y + z * z)
+  return Math.hypot(x, y, z)
 }
 
 module.exports = distance

--- a/packages/modeling/src/maths/vec3/index.js
+++ b/packages/modeling/src/maths/vec3/index.js
@@ -24,7 +24,7 @@ module.exports = {
   multiply: require('./multiply'),
   negate: require('./negate'),
   normalize: require('./normalize'),
-  random: require('./random'),
+  orthogonal: require('./orthogonal'),
   rotateX: require('./rotateX'),
   rotateY: require('./rotateY'),
   rotateZ: require('./rotateZ'),

--- a/packages/modeling/src/maths/vec3/length.js
+++ b/packages/modeling/src/maths/vec3/length.js
@@ -9,7 +9,7 @@ const length = (a) => {
   const x = a[0]
   const y = a[1]
   const z = a[2]
-  return Math.sqrt(x * x + y * y + z * z)
+  return Math.hypot(x, y, z)
 }
 
 module.exports = length

--- a/packages/modeling/src/maths/vec3/normalize.js
+++ b/packages/modeling/src/maths/vec3/normalize.js
@@ -23,12 +23,11 @@ const normalize = (...params) => {
   const z = a[2]
   let len = x * x + y * y + z * z
   if (len > 0) {
-    // TODO: evaluate use of glm_invsqrt here?
     len = 1 / Math.sqrt(len)
-    out[0] = a[0] * len
-    out[1] = a[1] * len
-    out[2] = a[2] * len
   }
+  out[0] = x * len
+  out[1] = y * len
+  out[2] = z * len
   return out
 }
 

--- a/packages/modeling/src/maths/vec3/normalize.test.js
+++ b/packages/modeling/src/maths/vec3/normalize.test.js
@@ -37,4 +37,14 @@ test('vec3: normalize() called with two paramerters should update a vec3 with co
   const ret4 = normalize(obs4, [-1, 2, -3])
   t.true(compareVectors(obs4, [-0.26726123690605164, 0.5345224738121033, -0.8017837405204773]))
   t.true(compareVectors(ret4, [-0.26726123690605164, 0.5345224738121033, -0.8017837405204773]))
+
+  const obs5 = fromValues(0, 0, 0)
+  const ret5 = normalize(obs5, [0.5, 1.5, 0.5])
+  t.true(compareVectors(obs5, [0.30151134729385376, 0.9045340418815613, 0.30151134729385376]))
+  t.true(compareVectors(ret5, [0.30151134729385376, 0.9045340418815613, 0.30151134729385376]))
+
+  const obs6 = fromValues(0, 0, 0)
+  const ret6 = normalize(obs6, [0.5, 0.5, 0.5])
+  t.true(compareVectors(obs6, [0.5773502588272095, 0.5773502588272095, 0.5773502588272095]))
+  t.true(compareVectors(ret6, [0.5773502588272095, 0.5773502588272095, 0.5773502588272095]))
 })

--- a/packages/modeling/src/maths/vec3/orthogonal.js
+++ b/packages/modeling/src/maths/vec3/orthogonal.js
@@ -2,13 +2,13 @@ const abs = require('./abs')
 const create = require('./create')
 
 /**
- * Create a vector that is somewhat perpendicular to the given vector.
+ * Create a vector that is somewhat orthogonal to the given vector.
  * @param {vec3} [out] - the receiving vector
  * @param {vec3} vector - vector of reference
  * @returns {vec3} a new vector
- * @alias module:modeling/maths/vec3.random
+ * @alias module:modeling/maths/vec3.orthogonal
  */
-const random = (...params) => {
+const orthogonal = (...params) => {
   let out
   let vec
   if (params.length === 1) {
@@ -35,4 +35,4 @@ const random = (...params) => {
   return out
 }
 
-module.exports = random
+module.exports = orthogonal

--- a/packages/modeling/src/maths/vec3/orthogonal.test.js
+++ b/packages/modeling/src/maths/vec3/orthogonal.test.js
@@ -1,34 +1,34 @@
 const test = require('ava')
-const { create, random } = require('./index')
+const { create, orthogonal } = require('./index')
 
 const { compareVectors } = require('../../../test/helpers/index')
 
-test('vec3: random() should return a vec3 with correct values', (t) => {
-  const obs1 = random([0, 0, 0])
+test('vec3: orthogonal() should return a vec3 with correct values', (t) => {
+  const obs1 = orthogonal([0, 0, 0])
   t.true(compareVectors(obs1, [1, 0, 0]))
 
-  const obs2 = random([3, 1, 3])
+  const obs2 = orthogonal([3, 1, 3])
   t.true(compareVectors(obs2, [0, 1, 0]))
 
-  const obs3 = random([3, 2, 1])
+  const obs3 = orthogonal([3, 2, 1])
   t.true(compareVectors(obs3, [0, 0, 1]))
 })
 
-test('vec3: random() with two params should update a vec3 with correct values', (t) => {
+test('vec3: orthogonal() with two params should update a vec3 with correct values', (t) => {
   const org1 = create()
-  const ret1 = random(org1, [0, 0, 0])
+  const ret1 = orthogonal(org1, [0, 0, 0])
   t.true(compareVectors(org1, [1, 0, 0]))
   t.true(compareVectors(ret1, [1, 0, 0]))
   t.is(org1, ret1)
 
   const org2 = create()
-  const ret2 = random(org2, [3, 1, 3])
+  const ret2 = orthogonal(org2, [3, 1, 3])
   t.true(compareVectors(org2, [0, 1, 0]))
   t.true(compareVectors(ret2, [0, 1, 0]))
   t.is(org2, ret2)
 
   const org3 = create()
-  const ret3 = random(org3, [3, 2, 1])
+  const ret3 = orthogonal(org3, [3, 2, 1])
   t.true(compareVectors(org3, [0, 0, 1]))
   t.true(compareVectors(ret3, [0, 0, 1]))
   t.is(org3, ret3)

--- a/packages/modeling/src/operations/hulls/hullChain.test.js
+++ b/packages/modeling/src/operations/hulls/hullChain.test.js
@@ -40,7 +40,7 @@ test('hullChain (three, geom2)', (t) => {
 
   // the sides change based on the bestplane chosen in trees/Node.js
   // t.is(pts.length, 10)
-  t.is(pts.length, 12)
+  t.is(pts.length, 13)
 })
 
 test('hullChain (three, geom3)', (t) => {
@@ -79,5 +79,6 @@ test('hullChain (three, geom3)', (t) => {
   obs = hullChain(geometry1, geometry2, geometry3, geometry1)
   pts = geom3.toPoints(obs)
 
-  t.is(pts.length, 52)
+  // t.is(pts.length, 52)
+  t.is(pts.length, 45)
 })

--- a/packages/modeling/src/primitives/cylinderElliptic.js
+++ b/packages/modeling/src/primitives/cylinderElliptic.js
@@ -69,7 +69,7 @@ const cylinderElliptic = (options) => {
   const ray = vec3.subtract(endv, startv)
 
   const axisZ = vec3.unit(ray)
-  const axisX = vec3.unit(vec3.random(axisZ))
+  const axisX = vec3.unit(vec3.orthogonal(axisZ))
   const axisY = vec3.unit(vec3.cross(axisZ, axisX))
 
   const point = (stack, slice, radius) => {


### PR DESCRIPTION
These changes bring the logic of vec2 and vec3 upto the same logic as glmatrix. Most are small changes, but improve precision as well as speed.

vec3.random() was renamed to vec3.orthogonal() to better reflect the functionality. (There's nothing random about this function!)

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Does your submission pass tests?