### PR TITLE
V2 : tune retesselate

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,20 +1,31 @@
 {
-  "lerna": "3.19.0",
-  "packages": [
-    "packages/vtree",
-    "packages/core",
-    "packages/modeling",
-    "packages/cli",
-    "packages/desktop",
-    "packages/web",
-    "packages/examples",
-    "packages/io/*",
-    "packages/utils/*"
-  ],
   "version": "independent",
   "command": {
-    "init": {
-      "exact": true
+    "bootstrap": {
+      "ignore": [
+        "@jscad/desktop",
+        "@jscad/gcode-deserializer",
+        "@jscad/scad-deserializer"
+      ]
+    },
+    "version": {
+      "conventionalCommits": true,
+      "exact": true,
+      "message": "chore(release): publish"
     }
-  }
+  },
+  "packages": [
+    "packages/cli",
+    "packages/core",
+    "packages/desktop",
+    "packages/examples",
+    "packages/io/*",
+    "packages/modeling",
+    "packages/utils/*",
+    "packages/vtree",
+    "packages/web"
+  ],
+  "ignoreChanges": [
+    "**/*.md"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -8,14 +8,15 @@
     "coverage": "npm run bootstrap && lerna run --concurrency 1 --stream coverage",
     "test": "npm run bootstrap && lerna run --stream test",
     "lint": "standardx 'packages/**/*.js'",
-    "bootstrap": "lerna bootstrap --hoist nyc --ignore-prepublish --no-ci --ignore @jscad/scad-deserializer --ignore @jscad/desktop",
-    "list": "lerna ls",
+    "bootstrap": "lerna bootstrap --hoist nyc --ignore-prepublish --no-ci",
+    "changed": "lerna changed",
     "clean": "lerna clean",
+    "graph": "lerna list --graph",
+    "list": "lerna ls",
     "cli": "npm run bootstrap && cd ./packages/cli",
     "web": "npm run bootstrap && cd ./packages/web && npm run dev",
     "desktop": "npm run bootstrap && cd ./packages/desktop && npm run dev",
-    "publish": "git checkout master && git pull origin master && npm t && lerna publish --conventional-commits",
-    "publish-dryrun": "git checkout master && git pull origin master && npm t && lerna publish --conventional-commits --skip-git --skip-npm"
+    "publish-dryrun": "git checkout V2 && git pull origin V2 && git add --all && npm test && lerna version 2.0.0 --no-push"
   },
   "contributors": [
     {

--- a/packages/modeling/src/measurements/measureArea.js
+++ b/packages/modeling/src/measurements/measureArea.js
@@ -23,10 +23,12 @@ const measureAreaOfPath2 = () => 0
  * @returns {Number} area of the geometry
  */
 const measureAreaOfGeom2 = (geometry) => {
+  if (geometry.area) return geometry.area
+
   const sides = geom2.toSides(geometry)
-  let area = sides.reduce((area, side) => area + (side[0][0] * side[1][1] - side[0][1] * side[1][0]), 0)
-  area *= 0.5
-  return area
+  const area = sides.reduce((area, side) => area + (side[0][0] * side[1][1] - side[0][1] * side[1][0]), 0)
+  geometry.area = area * 0.5
+  return geometry.area
 }
 
 /*
@@ -36,8 +38,11 @@ const measureAreaOfGeom2 = (geometry) => {
  * @returns {Number} area of the geometry
  */
 const measureAreaOfGeom3 = (geometry) => {
+  if (geometry.area) return geometry.area
+
   const polygons = geom3.toPolygons(geometry)
-  return polygons.reduce((area, polygon) => area + poly3.measureArea(polygon), 0)
+  geometry.area = polygons.reduce((area, polygon) => area + poly3.measureArea(polygon), 0)
+  return geometry.area
 }
 
 /**

--- a/packages/modeling/src/measurements/measureBoundingBox.js
+++ b/packages/modeling/src/measurements/measureBoundingBox.js
@@ -99,7 +99,7 @@ const measureBoundingBoxOfGeom3 = (geometry) => {
  * Measure the min and max bounds of the given geometries.
  * @param {...Objects} geometries - the geometries to measure
  * @return {Array} the min and max bounds for each geometry, i.e. [[X,Y,Z],[X,Y,Z]]
- * @alias module:modeling/measurements.measureBounds
+ * @alias module:modeling/measurements.measureBoundingBox
  *
  * @example
  * let bounds = measureBoundingBox(sphere())

--- a/packages/modeling/src/measurements/measureBoundingBox.js
+++ b/packages/modeling/src/measurements/measureBoundingBox.js
@@ -13,6 +13,8 @@ const poly3 = require('../geometries/poly3')
  * @return {Array[]} the min and max bounds for the geometry
  */
 const measureBoundingBoxOfPath2 = (geometry) => {
+  if (geometry.boundingBox) return geometry.boundingBox
+
   const points = path2.toPoints(geometry)
 
   let minpoint
@@ -30,7 +32,8 @@ const measureBoundingBoxOfPath2 = (geometry) => {
   minpoint = [minpoint[0], minpoint[1], 0]
   maxpoint = [maxpoint[0], maxpoint[1], 0]
 
-  return [minpoint, maxpoint]
+  geometry.boundingBox = [minpoint, maxpoint]
+  return geometry.boundingBox
 }
 
 /*
@@ -38,6 +41,8 @@ const measureBoundingBoxOfPath2 = (geometry) => {
  * @return {Array[]} the min and max bounds for the geometry
  */
 const measureBoundingBoxOfGeom2 = (geometry) => {
+  if (geometry.boundingBox) return geometry.boundingBox
+
   const points = geom2.toPoints(geometry)
 
   let minpoint
@@ -56,7 +61,8 @@ const measureBoundingBoxOfGeom2 = (geometry) => {
   minpoint = [minpoint[0], minpoint[1], 0]
   maxpoint = [maxpoint[0], maxpoint[1], 0]
 
-  return [minpoint, maxpoint]
+  geometry.boundingBox = [minpoint, maxpoint]
+  return geometry.boundingBox
 }
 
 /*
@@ -64,6 +70,8 @@ const measureBoundingBoxOfGeom2 = (geometry) => {
  * @return {Array[]} the min and max bounds for the geometry
  */
 const measureBoundingBoxOfGeom3 = (geometry) => {
+  if (geometry.boundingBox) return geometry.boundingBox
+
   const polygons = geom3.toPolygons(geometry)
 
   let minpoint = vec3.create()
@@ -83,7 +91,8 @@ const measureBoundingBoxOfGeom3 = (geometry) => {
   minpoint = [minpoint[0], minpoint[1], minpoint[2]]
   maxpoint = [maxpoint[0], maxpoint[1], maxpoint[2]]
 
-  return [minpoint, maxpoint]
+  geometry.boundingBox = [minpoint, maxpoint]
+  return geometry.boundingBox
 }
 
 /**

--- a/packages/modeling/src/measurements/measureEpsilon.js
+++ b/packages/modeling/src/measurements/measureEpsilon.js
@@ -1,22 +1,24 @@
-const flatten = require('../../utils/flatten')
+const flatten = require('../utils/flatten')
 
-const { EPS } = require('../../maths/constants')
+const { EPS } = require('../maths/constants')
 
-const { geom2, geom3, path2 } = require('../../geometries')
+const { geom2, geom3, path2 } = require('../geometries')
 
-const measureBoundingBox = require('../../measurements/measureBoundingBox')
+const measureBoundingBox = require('./measureBoundingBox')
 
 /*
  * Measure the epsilon of the given (path2) geometry.
  * @return {Float} the epsilon (precision) of the geometry
  */
 const measureEpsilonOfPath2 = (geometry) => {
+  if (geometry.epsilon) return geometry.epsilon
+
   const bounds = measureBoundingBox(geometry)
   const x = bounds[1][0] - bounds[0][0]
   const y = bounds[1][1] - bounds[0][1]
 
-  const epsilon = (x + y) / 2 * EPS
-  return epsilon
+  geometry.epsilon = (x + y) / 2 * EPS
+  return geometry.epsilon
 }
 
 /*
@@ -24,12 +26,14 @@ const measureEpsilonOfPath2 = (geometry) => {
  * @return {Float} the epsilon (precision) of the geometry
  */
 const measureEpsilonOfGeom2 = (geometry) => {
+  if (geometry.epsilon) return geometry.epsilon
+
   const bounds = measureBoundingBox(geometry)
   const x = bounds[1][0] - bounds[0][0]
   const y = bounds[1][1] - bounds[0][1]
 
-  const epsilon = (x + y) / 2 * EPS
-  return epsilon
+  geometry.epsilon = (x + y) / 2 * EPS
+  return geometry.epsilon
 }
 
 /*
@@ -37,20 +41,23 @@ const measureEpsilonOfGeom2 = (geometry) => {
  * @return {Float} the epsilon (precision) of the geometry
  */
 const measureEpsilonOfGeom3 = (geometry) => {
+  if (geometry.epsilon) return geometry.epsilon
+
   const bounds = measureBoundingBox(geometry)
   const x = bounds[1][0] - bounds[0][0]
   const y = bounds[1][1] - bounds[0][1]
   const z = bounds[1][2] - bounds[0][2]
 
-  const epsilon = (x + y + z) / 3 * EPS
-  return epsilon
+  geometry.epsilon = (x + y + z) / 3 * EPS
+  return geometry.epsilon
 }
 
-/*
- * Measure the epsilon of the given geometry(s).
+/**
+ * Measure the epsilon of the given geometries.
  * Epsilon values are used in various functions to determin minimum distances between points, planes, etc.
- * @param {...Objects} geometries - the geometry(s) to measure
+ * @param {...Objects} geometries - the geometries to measure
  * @return {Float|Array} the epsilon of each geometry
+ * @alias module:modeling/measurements.measureEpsilon
  *
  * @example
  * let epsilon = measureEpsilon(sphere())
@@ -63,7 +70,7 @@ const measureEpsilon = (...geometries) => {
     if (path2.isA(geometry)) return measureEpsilonOfPath2(geometry)
     if (geom2.isA(geometry)) return measureEpsilonOfGeom2(geometry)
     if (geom3.isA(geometry)) return measureEpsilonOfGeom3(geometry)
-    return EPS
+    return 0
   })
   return results.length === 1 ? results[0] : results
 }

--- a/packages/modeling/src/measurements/measureVolume.js
+++ b/packages/modeling/src/measurements/measureVolume.js
@@ -30,8 +30,11 @@ const measureVolumeOfGeom2 = () => 0
  * @returns {Number} volume of the geometry
  */
 const measureVolumeOfGeom3 = (geometry) => {
+  if (geometry.volume) return volume
+
   const polygons = geom3.toPolygons(geometry)
-  return polygons.reduce((volume, polygon) => volume + poly3.measureSignedVolume(polygon), 0)
+  geometry.volume = polygons.reduce((volume, polygon) => volume + poly3.measureSignedVolume(polygon), 0)
+  return geometry.volume
 }
 
 /**

--- a/packages/modeling/src/operations/booleans/intersectGeom2.js
+++ b/packages/modeling/src/operations/booleans/intersectGeom2.js
@@ -2,11 +2,11 @@ const flatten = require('../../utils/flatten')
 
 const geom3 = require('../../geometries/geom3')
 
+const measureEpsilon = require('../../measurements/measureEpsilon')
+
 const fromFakePolygons = require('./fromFakePolygons')
 const to3DWalls = require('./to3DWalls')
 const intersectGeom3 = require('./intersectGeom3')
-
-const measureEpsilon = require('./measureEpsilon')
 
 /*
  * Return a new 2D geometry representing space in both the first geometry and

--- a/packages/modeling/src/operations/booleans/retessellate.js
+++ b/packages/modeling/src/operations/booleans/retessellate.js
@@ -5,11 +5,21 @@ const poly3 = require('../../geometries/poly3')
 
 const reTesselateCoplanarPolygons = require('./reTesselateCoplanarPolygons')
 
+// Normals are directional vectors of length 0 to 1.0
+// This EPS is derived from a serieas of tests to determine the optimal precision for comparing coplanar polygons,
+// as provided by the sphere primitive at high segmentation
+// This EPS is for 64 bit Number values
+const NEPS = 1e-13
+
+// Compare two normals (unit vectors) for equality.
+const aboutEqualNormals = (a, b) => {
+  return (Math.abs(a[0] - b[0]) <= NEPS && Math.abs(a[1] - b[1]) <= NEPS && Math.abs(a[2] - b[2]) <= NEPS)
+}
+
 const coplanar = (plane1, plane2) => {
   // expect the same distance from the origin, within tolerance
   if (Math.abs(plane1[3] - plane2[3]) < 0.00000015) {
-    // expect a zero (0) angle between the normals
-    if (vec3.angle(plane1, plane2) === 0) return true
+    return aboutEqualNormals(plane1, plane2)
   }
   return false
 }

--- a/packages/modeling/src/operations/booleans/retessellate.js
+++ b/packages/modeling/src/operations/booleans/retessellate.js
@@ -5,7 +5,7 @@ const poly3 = require('../../geometries/poly3')
 
 const reTesselateCoplanarPolygons = require('./reTesselateCoplanarPolygons')
 
-// Normals are directional vectors of length 0 to 1.0
+// Normals are directional vectors with component values from 0 to 1.0, requiring specialized comparision
 // This EPS is derived from a serieas of tests to determine the optimal precision for comparing coplanar polygons,
 // as provided by the sphere primitive at high segmentation
 // This EPS is for 64 bit Number values

--- a/packages/modeling/src/operations/booleans/subtractGeom2.js
+++ b/packages/modeling/src/operations/booleans/subtractGeom2.js
@@ -2,11 +2,11 @@ const flatten = require('../../utils/flatten')
 
 const geom3 = require('../../geometries/geom3')
 
+const measureEpsilon = require('../../measurements/measureEpsilon')
+
 const fromFakePolygons = require('./fromFakePolygons')
 const to3DWalls = require('./to3DWalls')
 const subtractGeom3 = require('./subtractGeom3')
-
-const measureEpsilon = require('./measureEpsilon')
 
 /*
  * Return a new 2D geometry representing space in the first geometry but

--- a/packages/modeling/src/operations/booleans/unionGeom2.js
+++ b/packages/modeling/src/operations/booleans/unionGeom2.js
@@ -2,11 +2,11 @@ const flatten = require('../../utils/flatten')
 
 const geom3 = require('../../geometries/geom3')
 
+const measureEpsilon = require('../../measurements/measureEpsilon')
+
 const fromFakePolygons = require('./fromFakePolygons')
 const to3DWalls = require('./to3DWalls')
 const unionGeom3 = require('./unionGeom3')
-
-const measureEpsilon = require('./measureEpsilon')
 
 /*
  * Return a new 2D geometry representing the total space in the given 2D geometries.


### PR DESCRIPTION
These changes tune the comparison of plane normals, which assists retesselate.

There are also changes to the measurements, caching calculated values as object attributes. For example, object.volume, etc. These are expected to improve the performace of boolean operations.

Additional testing was completed with both CLI and WEB applications.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Does your submission pass tests?