### PR TITLE
Fixes #520. Warning: this is a substantial breaking change!

### DIFF
--- a/packages/modeling/src/geometries/geom2/transform.js
+++ b/packages/modeling/src/geometries/geom2/transform.js
@@ -17,7 +17,7 @@ const create = require('./create')
 const transform = (matrix, geometry) => {
   const newgeometry = create(geometry.sides) // reuse the sides
 
-  newgeometry.transforms = mat4.multiply(geometry.transforms, matrix)
+  newgeometry.transforms = mat4.multiply(matrix, geometry.transforms)
   return newgeometry
 }
 

--- a/packages/modeling/src/geometries/geom2/transform.test.js
+++ b/packages/modeling/src/geometries/geom2/transform.test.js
@@ -27,15 +27,15 @@ test('transform: adjusts the transforms of geom2', (t) => {
   t.true(compareVectors(another.transforms, expected.transforms))
 
   // expect lazy transform, i.e. only the transforms change
-  expected.transforms = [0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, -5, 5, 5, 1]
-  another = transform(mat4.fromTranslation([5, 5, 5]), another)
+  expected.transforms = [0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, 5, 10, 15, 1]
+  another = transform(mat4.fromTranslation([5, 10, 15]), another)
   t.true(comparePoints(another.sides[0], expected.sides[0]))
   t.true(comparePoints(another.sides[1], expected.sides[1]))
   t.true(comparePoints(another.sides[2], expected.sides[2]))
   t.true(compareVectors(another.transforms, expected.transforms))
 
   // expect application of the transforms to the sides
-  expected.sides = [[[-6, 5], [-5, 5]], [[-5, 5], [-5, 6]], [[-5, 6], [-6, 5]]]
+  expected.sides = [[[4, 10], [5, 10]], [[5, 10], [5, 11]], [[5, 11], [4, 10]]]
   expected.transforms = mat4.identity()
   toSides(another)
   t.true(comparePoints(another.sides[0], expected.sides[0]))
@@ -44,8 +44,8 @@ test('transform: adjusts the transforms of geom2', (t) => {
   t.true(compareVectors(another.transforms, expected.transforms))
 
   // expect lazy transform, i.e. only the transforms change
-  expected.transforms = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 5, 5, 5, 1]
-  another = transform(mat4.fromTranslation([5, 5, 5]), another)
+  expected.transforms = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 5, 10, 15, 1]
+  another = transform(mat4.fromTranslation([5, 10, 15]), another)
   t.true(comparePoints(another.sides[0], expected.sides[0]))
   t.true(comparePoints(another.sides[1], expected.sides[1]))
   t.true(comparePoints(another.sides[2], expected.sides[2]))

--- a/packages/modeling/src/geometries/geom3/transform.js
+++ b/packages/modeling/src/geometries/geom3/transform.js
@@ -18,7 +18,7 @@ const transform = (matrix, geometry) => {
   const newgeometry = create(geometry.polygons) // reuse the polygons
   newgeometry.isRetesselated = geometry.isRetesselated
 
-  newgeometry.transforms = mat4.multiply(geometry.transforms, matrix)
+  newgeometry.transforms = mat4.multiply(matrix, geometry.transforms)
   return newgeometry
 }
 

--- a/packages/modeling/src/geometries/geom3/transform.test.js
+++ b/packages/modeling/src/geometries/geom3/transform.test.js
@@ -28,14 +28,14 @@ test('transform: Adjusts the transforms of a populated geom3', (t) => {
   t.true(compareVectors(another.transforms, expected.transforms))
 
   // expect lazy transform, i.e. only the transforms change
-  expected.transforms = [6.123234262925839e-17, 1, 0, 0, -1, 6.123234262925839e-17, 0, 0, 0, 0, 1, 0, -5, 5, 5, 1]
-  another = transform(mat4.fromTranslation([5, 5, 5]), another)
+  expected.transforms = [6.123234262925839e-17, 1, 0, 0, -1, 6.123234262925839e-17, 0, 0, 0, 0, 1, 0, 5, 10, 15, 1]
+  another = transform(mat4.fromTranslation([5, 10, 15]), another)
   t.true(comparePolygons(another.polygons[0], expected.polygons[0]))
   t.true(compareVectors(another.transforms, expected.transforms))
 
   // expect application of the transforms to the polygons
   expected.polygons = [
-    { vertices: [[-5, 5, 5], [-5, 6, 5], [-5, 6, 6]] }
+    { vertices: [[5, 10, 15], [5, 11, 15], [5, 11, 16]] }
   ]
   expected.transforms = mat4.identity()
   toPolygons(another)
@@ -43,8 +43,8 @@ test('transform: Adjusts the transforms of a populated geom3', (t) => {
   t.true(compareVectors(another.transforms, expected.transforms))
 
   // expect lazy transform, i.e. only the transforms change
-  expected.transforms = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 5, 5, 5, 1]
-  another = transform(mat4.fromTranslation([5, 5, 5]), another)
+  expected.transforms = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 5, 10, 15, 1]
+  another = transform(mat4.fromTranslation([5, 10, 15]), another)
   t.true(comparePolygons(another.polygons[0], expected.polygons[0]))
   t.true(compareVectors(another.transforms, expected.transforms))
 })

--- a/packages/modeling/src/geometries/path2/transform.js
+++ b/packages/modeling/src/geometries/path2/transform.js
@@ -18,7 +18,7 @@ const transform = (matrix, geometry) => {
   const newgeometry = create(geometry.points) // reuse the points
   newgeometry.isClosed = geometry.isClosed
 
-  newgeometry.transforms = mat4.multiply(geometry.transforms, matrix)
+  newgeometry.transforms = mat4.multiply(matrix, geometry.transforms)
   return newgeometry
 }
 

--- a/packages/modeling/src/geometries/path2/transform.test.js
+++ b/packages/modeling/src/geometries/path2/transform.test.js
@@ -27,14 +27,14 @@ test('transform: adjusts the transforms of path', (t) => {
   t.true(compareVectors(another.transforms, expected.transforms))
 
   // expect lazy transform, i.e. only the transforms change
-  expected.transforms = [0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, -5, 5, 5, 1]
-  another = transform(mat4.fromTranslation([5, 5, 5]), another)
+  expected.transforms = [0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, 5, 10, 15, 1]
+  another = transform(mat4.fromTranslation([5, 10, 15]), another)
   t.true(comparePoints(another.points, expected.points))
   t.false(another.isClosed)
   t.true(compareVectors(another.transforms, expected.transforms))
 
   // expect application of the transforms to the sides
-  expected.points = [[-5, 5], [-5, 6], [-6, 5]]
+  expected.points = [[5, 10], [5, 11], [4, 10]]
   expected.transforms = mat4.identity()
   toPoints(another)
   t.true(comparePoints(another.points, expected.points))
@@ -42,8 +42,8 @@ test('transform: adjusts the transforms of path', (t) => {
   t.true(compareVectors(another.transforms, expected.transforms))
 
   // expect lazy transform, i.e. only the transforms change
-  expected.transforms = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 5, 5, 5, 1]
-  another = transform(mat4.fromTranslation([5, 5, 5]), another)
+  expected.transforms = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 5, 10, 15, 1]
+  another = transform(mat4.fromTranslation([5, 10, 15]), another)
   t.true(comparePoints(another.points, expected.points))
   t.false(another.isClosed)
   t.true(compareVectors(another.transforms, expected.transforms))


### PR DESCRIPTION
Fixes #520. Warning: this is a substantial breaking change!

New matrices applied via the transform() functions of geom2, geom3, and
path2 should multiply with the new matrix on the left. That is, instead
of geom.transform = geom.transform * new_transform, it should be
geom.transform = new_transform * geom.transform.

Before this change, calls to transform() are effectively applied
Last-In-First-Out (stack order). This can lead to strange circumstances
like where a caller tries to move a shape long the X axis, but since
previous code already pushed a "rotate around the Z axis" matrix onto the
"stack", the call to translateX() actually translates along the Y axis,
which is clearly not the user's intent.

Fixed tests, and also changed them a bit to translate differenly along
different axes. This makes the strangness of the behavior more obvious.

This is a breaking change for any code that applies multiple transforms
to a single geometry (except for the special case where they commute).

### All Submissions:

* [Y] Have you followed the guidelines in our Contributing document?
* [Y] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [Y] Does your submission pass tests?