### PR TITLE
V2 throttle viewer events

### DIFF
--- a/packages/web/src/sideEffects/localFs/walkFileTree.js
+++ b/packages/web/src/sideEffects/localFs/walkFileTree.js
@@ -52,7 +52,7 @@ const pseudoArraytoArray = (pseudoArray) => {
   const array = []
   for (let i = 0; i < pseudoArray.length; i++) {
     const item = pseudoArray[i]
-    array.push(item.webkitGetAsEntry ? item.webkitGetAsEntry() : item)
+    if (item) array.push(item.webkitGetAsEntry ? item.webkitGetAsEntry() : item)
   }
   return array
 }


### PR DESCRIPTION
These changes throttle the events being received by the viewer, which results in smoother transitions across all devices.
- zoom events
- rotate events
- pan events
- render events

Testing was performed across as many devices as possible; PC, mobile phones, and tablets.
Testing was performed across as many browsers as possible; Safari, FireFox, Chrome, Opera.

There's also a late change from V1, which was applied to the latest V2 base.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Does your submission pass tests?