### PR TITLE
Add support for segments in SVG Deserializer

### DIFF
--- a/packages/io/svg-deserializer/index.js
+++ b/packages/io/svg-deserializer/index.js
@@ -38,7 +38,8 @@ const deserialize = (options, input) => {
     output: 'script',
     pxPmm: require('./constants').pxPmm,
     target: 'path', // target - 'geom2' or 'path'
-    version: '0.0.0'
+    version: '0.0.0',
+    segments: 16
   }
   options = Object.assign({}, defaults, options)
   return options.output === 'script' ? translate(input, options) : instantiate(input, options)
@@ -55,7 +56,7 @@ const deserialize = (options, input) => {
  * @return {[geometry]} a set of geometries
  */
 const instantiate = (src, options) => {
-  const { pxPmm, target } = options
+  const { pxPmm, target, segments } = options
 
   options && options.statusCallback && options.statusCallback({ progress: 0 })
 
@@ -67,7 +68,7 @@ const instantiate = (src, options) => {
 
   options && options.statusCallback && options.statusCallback({ progress: 50 })
 
-  const result = objectify({ target }, svgObj)
+  const result = objectify({ target, segments }, svgObj)
 
   options && options.statusCallback && options.statusCallback({ progress: 100 })
   return result
@@ -84,7 +85,7 @@ const instantiate = (src, options) => {
  * @return {string} a string (JSCAD script)
  */
 const translate = (src, options) => {
-  const { filename, version, pxPmm, addMetaData, target } = options
+  const { filename, version, pxPmm, addMetaData, target, segments } = options
 
   options && options.statusCallback && options.statusCallback({ progress: 0 })
 
@@ -105,7 +106,7 @@ const translate = (src, options) => {
 
   options && options.statusCallback && options.statusCallback({ progress: 50 })
 
-  const scadCode = codify({ target }, svgObj)
+  const scadCode = codify({ target, segments }, svgObj)
   code += scadCode
   code += '\nmodule.exports = { main }'
 
@@ -129,7 +130,7 @@ let svgUnitsPmm = [1, 1]
  * Convert the given group (of objects) into geometries
  */
 const objectify = (options, group) => {
-  const { target } = options
+  const { target, segments } = options
   const level = svgGroups.length
   // add this group to the heiarchy
   svgGroups.push(group)
@@ -148,7 +149,8 @@ const objectify = (options, group) => {
     svgUnitsV,
     level,
     target,
-    svgGroups
+    svgGroups,
+    segments
   }
   // apply base level attributes to all shapes
   for (i = 0; i < group.objects.length; i++) {
@@ -196,7 +198,7 @@ const objectify = (options, group) => {
  * Convert the given group into JSCAD script
  */
 const codify = (options, group) => {
-  const { target } = options
+  const { target, segments } = options
   const level = svgGroups.length
   // add this group to the heiarchy
   svgGroups.push(group)
@@ -230,7 +232,8 @@ const codify = (options, group) => {
       svgUnitsY,
       svgUnitsV,
       svgGroups,
-      target
+      target,
+      segments
     }
 
     const tmpCode = shapesMapJscad(obj, codify, params)

--- a/packages/io/svg-deserializer/index.js
+++ b/packages/io/svg-deserializer/index.js
@@ -39,7 +39,7 @@ const deserialize = (options, input) => {
     pxPmm: require('./constants').pxPmm,
     target: 'path', // target - 'geom2' or 'path'
     version: '0.0.0',
-    segments: 16
+    segments: 32
   }
   options = Object.assign({}, defaults, options)
   return options.output === 'script' ? translate(input, options) : instantiate(input, options)
@@ -56,7 +56,7 @@ const deserialize = (options, input) => {
  * @return {[geometry]} a set of geometries
  */
 const instantiate = (src, options) => {
-  const { pxPmm, target, segments } = options
+  const { pxPmm } = options
 
   options && options.statusCallback && options.statusCallback({ progress: 0 })
 
@@ -68,7 +68,7 @@ const instantiate = (src, options) => {
 
   options && options.statusCallback && options.statusCallback({ progress: 50 })
 
-  const result = objectify({ target, segments }, svgObj)
+  const result = objectify(options, svgObj)
 
   options && options.statusCallback && options.statusCallback({ progress: 100 })
   return result
@@ -85,7 +85,7 @@ const instantiate = (src, options) => {
  * @return {string} a string (JSCAD script)
  */
 const translate = (src, options) => {
-  const { filename, version, pxPmm, addMetaData, target, segments } = options
+  const { filename, version, pxPmm, addMetaData } = options
 
   options && options.statusCallback && options.statusCallback({ progress: 0 })
 
@@ -106,7 +106,7 @@ const translate = (src, options) => {
 
   options && options.statusCallback && options.statusCallback({ progress: 50 })
 
-  const scadCode = codify({ target, segments }, svgObj)
+  const scadCode = codify(options, svgObj)
   code += scadCode
   code += '\nmodule.exports = { main }'
 

--- a/packages/io/svg-deserializer/shapesMapGeometry.js
+++ b/packages/io/svg-deserializer/shapesMapGeometry.js
@@ -4,10 +4,10 @@ const { svg2cagX, svg2cagY, cagLengthX, cagLengthY, cagLengthP, reflect } = requ
 // const { cssPxUnit } = require('./constants')
 
 const shapesMapGeometry = (obj, objectify, params) => {
-  const { svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups, target } = params
+  const { svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups, target, segments } = params
 
   const types = {
-    group: (obj) => objectify({ target }, obj),
+    group: (obj) => objectify({ target, segments }, obj),
 
     rect: (obj, svgUnitsPmm, svgUnitsX, svgUnitsY) => {
       let x = cagLengthX(obj.x, svgUnitsPmm, svgUnitsX)
@@ -130,8 +130,8 @@ const shapesMapGeometry = (obj, objectify, params) => {
       return shape
     },
 
-    path: (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups) => {
-      const listofpaths = expandPath(obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups)
+    path: (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups, segments) => {
+      const listofpaths = expandPath(obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups, segments)
       // order is important
       const listofentries = Object.entries(listofpaths).sort((a, b) => a[0].localeCompare(b[0]))
       const shapes = listofentries.map((entry) => {
@@ -146,12 +146,13 @@ const shapesMapGeometry = (obj, objectify, params) => {
       return shapes
     }
   }
-  return types[obj.type](obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups)
+
+  return types[obj.type](obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups, segments)
 }
 
 module.exports = shapesMapGeometry
 
-const expandPath = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups) => {
+const expandPath = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups, segments) => {
   const paths = {}
   const on = 'path'
 
@@ -239,7 +240,7 @@ const expandPath = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups
           const sf = (pts.shift() === '1')
           cx = cx + parseFloat(pts.shift())
           cy = cy + parseFloat(pts.shift())
-          paths[pathName] = geometries.path2.appendArc({ endpoint: [svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)], radius: [svg2cagX(rx, svgUnitsPmm), svg2cagY(ry, svgUnitsPmm)], xaxisrotation: ro, clockwise: sf, large: lf }, paths[pathName])
+          paths[pathName] = geometries.path2.appendArc({ segments, endpoint: [svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)], radius: [svg2cagX(rx, svgUnitsPmm), svg2cagY(ry, svgUnitsPmm)], xaxisrotation: ro, clockwise: sf, large: lf }, paths[pathName])
         }
         break
       case 'A': // absolute elliptical arc
@@ -251,7 +252,7 @@ const expandPath = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups
           const sf = (pts.shift() === '1')
           cx = parseFloat(pts.shift())
           cy = parseFloat(pts.shift())
-          paths[pathName] = geometries.path2.appendArc({ endpoint: [svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)], radius: [svg2cagX(rx, svgUnitsPmm), svg2cagY(ry, svgUnitsPmm)], xaxisrotation: ro, clockwise: sf, large: lf }, paths[pathName])
+          paths[pathName] = geometries.path2.appendArc({ segments, endpoint: [svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)], radius: [svg2cagX(rx, svgUnitsPmm), svg2cagY(ry, svgUnitsPmm)], xaxisrotation: ro, clockwise: sf, large: lf }, paths[pathName])
         }
         break
       case 'c': // relative cubic Bézier
@@ -262,7 +263,7 @@ const expandPath = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups
           by = cy + parseFloat(pts.shift())
           cx = cx + parseFloat(pts.shift())
           cy = cy + parseFloat(pts.shift())
-          paths[pathName] = geometries.path2.appendBezier({ controlPoints: [[svg2cagX(x1, svgUnitsPmm), svg2cagY(y1, svgUnitsPmm)], [svg2cagX(bx, svgUnitsPmm), svg2cagY(by, svgUnitsPmm)], [svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]] }, paths[pathName])
+          paths[pathName] = geometries.path2.appendBezier({ segments, controlPoints: [[svg2cagX(x1, svgUnitsPmm), svg2cagY(y1, svgUnitsPmm)], [svg2cagX(bx, svgUnitsPmm), svg2cagY(by, svgUnitsPmm)], [svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]] }, paths[pathName])
           const rf = reflect(bx, by, cx, cy)
           bx = rf[0]
           by = rf[1]
@@ -276,7 +277,7 @@ const expandPath = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups
           by = parseFloat(pts.shift())
           cx = parseFloat(pts.shift())
           cy = parseFloat(pts.shift())
-          paths[pathName] = geometries.path2.appendBezier({ controlPoints: [[svg2cagX(x1, svgUnitsPmm), svg2cagY(y1, svgUnitsPmm)], [svg2cagX(bx, svgUnitsPmm), svg2cagY(by, svgUnitsPmm)], [svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]] }, paths[pathName])
+          paths[pathName] = geometries.path2.appendBezier({ segments, controlPoints: [[svg2cagX(x1, svgUnitsPmm), svg2cagY(y1, svgUnitsPmm)], [svg2cagX(bx, svgUnitsPmm), svg2cagY(by, svgUnitsPmm)], [svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]] }, paths[pathName])
           const rf = reflect(bx, by, cx, cy)
           bx = rf[0]
           by = rf[1]
@@ -288,7 +289,7 @@ const expandPath = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups
           qy = cy + parseFloat(pts.shift())
           cx = cx + parseFloat(pts.shift())
           cy = cy + parseFloat(pts.shift())
-          paths[pathName] = geometries.path2.appendBezier({ controlPoints: [[svg2cagX(qx, svgUnitsPmm), svg2cagY(qy, svgUnitsPmm)], [svg2cagX(qx, svgUnitsPmm), svg2cagY(qy, svgUnitsPmm)], [svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]] }, paths[pathName])
+          paths[pathName] = geometries.path2.appendBezier({ segments, controlPoints: [[svg2cagX(qx, svgUnitsPmm), svg2cagY(qy, svgUnitsPmm)], [svg2cagX(qx, svgUnitsPmm), svg2cagY(qy, svgUnitsPmm)], [svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]] }, paths[pathName])
           const rf = reflect(qx, qy, cx, cy)
           qx = rf[0]
           qy = rf[1]
@@ -300,7 +301,7 @@ const expandPath = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups
           qy = parseFloat(pts.shift())
           cx = parseFloat(pts.shift())
           cy = parseFloat(pts.shift())
-          paths[pathName] = geometries.path2.appendBezier({ controlPoints: [[svg2cagX(qx, svgUnitsPmm), svg2cagY(qy, svgUnitsPmm)], [svg2cagX(qx, svgUnitsPmm), svg2cagY(qy, svgUnitsPmm)], [svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]] }, paths[pathName])
+          paths[pathName] = geometries.path2.appendBezier({ segments, controlPoints: [[svg2cagX(qx, svgUnitsPmm), svg2cagY(qy, svgUnitsPmm)], [svg2cagX(qx, svgUnitsPmm), svg2cagY(qy, svgUnitsPmm)], [svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]] }, paths[pathName])
           const rf = reflect(qx, qy, cx, cy)
           qx = rf[0]
           qy = rf[1]
@@ -310,7 +311,7 @@ const expandPath = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups
         while (pts.length >= 2) {
           cx = cx + parseFloat(pts.shift())
           cy = cy + parseFloat(pts.shift())
-          paths[pathName] = geometries.path2.appendBezier({ controlPoints: [[svg2cagX(qx, svgUnitsPmm), svg2cagY(qy, svgUnitsPmm)], [svg2cagX(qx, svgUnitsPmm), svg2cagY(qy, svgUnitsPmm)], [cx, cy]] }, paths[pathName])
+          paths[pathName] = geometries.path2.appendBezier({ segments, controlPoints: [[svg2cagX(qx, svgUnitsPmm), svg2cagY(qy, svgUnitsPmm)], [svg2cagX(qx, svgUnitsPmm), svg2cagY(qy, svgUnitsPmm)], [cx, cy]] }, paths[pathName])
           const rf = reflect(qx, qy, cx, cy)
           qx = rf[0]
           qy = rf[1]
@@ -320,7 +321,7 @@ const expandPath = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups
         while (pts.length >= 2) {
           cx = parseFloat(pts.shift())
           cy = parseFloat(pts.shift())
-          paths[pathName] = geometries.path2.appendBezier({ controlPoints: [[svg2cagX(qx, svgUnitsPmm), svg2cagY(qy, svgUnitsPmm)], [svg2cagX(qx, svgUnitsPmm), svg2cagY(qy, svgUnitsPmm)], [svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]] }, paths[pathName])
+          paths[pathName] = geometries.path2.appendBezier({ segments, controlPoints: [[svg2cagX(qx, svgUnitsPmm), svg2cagY(qy, svgUnitsPmm)], [svg2cagX(qx, svgUnitsPmm), svg2cagY(qy, svgUnitsPmm)], [svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]] }, paths[pathName])
           const rf = reflect(qx, qy, cx, cy)
           qx = rf[0]
           qy = rf[1]
@@ -334,7 +335,7 @@ const expandPath = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups
           by = cy + parseFloat(pts.shift())
           cx = cx + parseFloat(pts.shift())
           cy = cy + parseFloat(pts.shift())
-          paths[pathName] = geometries.path2.appendBezier({ controlPoints: [[svg2cagX(x1, svgUnitsPmm), svg2cagY(y1, svgUnitsPmm)], [svg2cagX(bx, svgUnitsPmm), svg2cagY(by, svgUnitsPmm)], [svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]] }, paths[pathName])
+          paths[pathName] = geometries.path2.appendBezier({ segments, controlPoints: [[svg2cagX(x1, svgUnitsPmm), svg2cagY(y1, svgUnitsPmm)], [svg2cagX(bx, svgUnitsPmm), svg2cagY(by, svgUnitsPmm)], [svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]] }, paths[pathName])
           const rf = reflect(bx, by, cx, cy)
           bx = rf[0]
           by = rf[1]
@@ -348,7 +349,7 @@ const expandPath = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups
           by = parseFloat(pts.shift())
           cx = parseFloat(pts.shift())
           cy = parseFloat(pts.shift())
-          paths[pathName] = geometries.path2.appendBezier({ controlPoints: [[svg2cagX(x1, svgUnitsPmm), svg2cagY(y1, svgUnitsPmm)], [svg2cagX(bx, svgUnitsPmm), svg2cagY(by, svgUnitsPmm)], [svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]] }, paths[pathName])
+          paths[pathName] = geometries.path2.appendBezier({ segments, controlPoints: [[svg2cagX(x1, svgUnitsPmm), svg2cagY(y1, svgUnitsPmm)], [svg2cagX(bx, svgUnitsPmm), svg2cagY(by, svgUnitsPmm)], [svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]] }, paths[pathName])
           const rf = reflect(bx, by, cx, cy)
           bx = rf[0]
           by = rf[1]

--- a/packages/io/svg-deserializer/shapesMapGeometry.js
+++ b/packages/io/svg-deserializer/shapesMapGeometry.js
@@ -9,7 +9,7 @@ const shapesMapGeometry = (obj, objectify, params) => {
   const types = {
     group: (obj) => objectify({ target, segments }, obj),
 
-    rect: (obj, svgUnitsPmm, svgUnitsX, svgUnitsY) => {
+    rect: (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups, segments) => {
       let x = cagLengthX(obj.x, svgUnitsPmm, svgUnitsX)
       let y = (0 - cagLengthY(obj.y, svgUnitsPmm, svgUnitsY))
       const w = cagLengthX(obj.width, svgUnitsPmm, svgUnitsX)
@@ -24,7 +24,7 @@ const shapesMapGeometry = (obj, objectify, params) => {
         if (rx === 0) {
           shape = transforms.center({ center: [x, y, 0] }, primitives.rectangle({ size: [w / 2, h / 2] }))
         } else {
-          shape = transforms.center({ center: [x, y, 0] }, primitives.roundedRectangle({ size: [w / 2, h / 2], roundRadius: rx }))
+          shape = transforms.center({ center: [x, y, 0] }, primitives.roundedRectangle({ segments, size: [w / 2, h / 2], roundRadius: rx }))
         }
         if (target === 'path') {
           shape = geometries.path2.fromPoints({ }, geometries.geom2.toPoints(shape))
@@ -33,14 +33,14 @@ const shapesMapGeometry = (obj, objectify, params) => {
       return shape
     },
 
-    circle: (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV) => {
+    circle: (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups, segments) => {
       const x = cagLengthX(obj.x, svgUnitsPmm, svgUnitsX)
       const y = (0 - cagLengthY(obj.y, svgUnitsPmm, svgUnitsY))
       const r = cagLengthP(obj.radius, svgUnitsPmm, svgUnitsV)
 
       let shape
       if (r > 0) {
-        shape = transforms.center({ center: [x, y, 0] }, primitives.circle({ radius: r }))
+        shape = transforms.center({ center: [x, y, 0] }, primitives.circle({ segments, radius: r }))
         if (target === 'path') {
           shape = geometries.path2.fromPoints({}, geometries.geom2.toPoints(shape))
         }
@@ -48,7 +48,7 @@ const shapesMapGeometry = (obj, objectify, params) => {
       return shape
     },
 
-    ellipse: (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV) => {
+    ellipse: (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups, segments) => {
       const rx = cagLengthX(obj.rx, svgUnitsPmm, svgUnitsX)
       const ry = cagLengthY(obj.ry, svgUnitsPmm, svgUnitsY)
       const cx = cagLengthX(obj.cx, svgUnitsPmm, svgUnitsX)
@@ -56,7 +56,7 @@ const shapesMapGeometry = (obj, objectify, params) => {
 
       let shape
       if (rx > 0 && ry > 0) {
-        shape = transforms.center({ center: [cx, cy, 0] }, primitives.ellipse({ radius: [rx, ry] }))
+        shape = transforms.center({ center: [cx, cy, 0] }, primitives.ellipse({ segments, radius: [rx, ry] }))
         if (target === 'path') {
           shape = geometries.path2.fromPoints({}, geometries.geom2.toPoints(shape))
         }

--- a/packages/io/svg-deserializer/shapesMapJscad.js
+++ b/packages/io/svg-deserializer/shapesMapJscad.js
@@ -11,7 +11,7 @@ const shapesMap = function (obj, codify, params) {
       return code
     },
 
-    rect: (obj, svgUnitsPmm, svgUnitsX, svgUnitsY) => {
+    rect: (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGroups, segments) => {
       let x = cagLengthX(obj.x, svgUnitsPmm, svgUnitsX)
       let y = (0 - cagLengthY(obj.y, svgUnitsPmm, svgUnitsY))
       const w = cagLengthX(obj.width, svgUnitsPmm, svgUnitsX)
@@ -25,7 +25,7 @@ const shapesMap = function (obj, codify, params) {
         if (rx === 0) {
           code = `${indent}${on} = transforms.center({ center: [${x}, ${y}, 0] }, primitives.rectangle({size: [${w}, ${h}]})) // line ${obj.position}\n`
         } else {
-          code = `${indent}${on} = transforms.center({ center: [${x}, ${y}, 0] }, primitives.roundedRectangle({size: [${w}, ${h}], roundRadius: ${rx}})) // line ${obj.position}\n`
+          code = `${indent}${on} = transforms.center({ center: [${x}, ${y}, 0] }, primitives.roundedRectangle({segments: ${segments}, size: [${w}, ${h}], roundRadius: ${rx}})) // line ${obj.position}\n`
         }
         if (target === 'path') {
           code += `${indent}${on} = geometries.path2.fromPoints({closed: true}, geometries.geom2.toPoints(${on}))\n`
@@ -34,13 +34,13 @@ const shapesMap = function (obj, codify, params) {
       return code
     },
 
-    circle: (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV) => {
+    circle: (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGroups, segments) => {
       const x = cagLengthX(obj.x, svgUnitsPmm, svgUnitsX)
       const y = (0 - cagLengthY(obj.y, svgUnitsPmm, svgUnitsY))
       const r = cagLengthP(obj.radius, svgUnitsPmm, svgUnitsV)
       let code
       if (r > 0) {
-        code = `${indent}${on} = transforms.center({ center: [${x}, ${y}, 0] }, primitives.circle({radius: ${r}})) // line ${obj.position}\n`
+        code = `${indent}${on} = transforms.center({ center: [${x}, ${y}, 0] }, primitives.circle({segments: ${segments}, radius: ${r}})) // line ${obj.position}\n`
         if (target === 'path') {
           code += `${indent}${on} = geometries.path2.fromPoints({closed: true}, geometries.geom2.toPoints(${on}))\n`
         }
@@ -48,14 +48,14 @@ const shapesMap = function (obj, codify, params) {
       return code
     },
 
-    ellipse: (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV) => {
+    ellipse: (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGroups, segments) => {
       const rx = cagLengthX(obj.rx, svgUnitsPmm, svgUnitsX)
       const ry = cagLengthY(obj.ry, svgUnitsPmm, svgUnitsY)
       const cx = cagLengthX(obj.cx, svgUnitsPmm, svgUnitsX)
       const cy = (0 - cagLengthY(obj.cy, svgUnitsPmm, svgUnitsY))
       let code
       if (rx > 0 && ry > 0) {
-        code = `${indent}${on} = transforms.center({ center: [${cx}, ${cy}, 0] }, primitives.ellipse({radius: [${rx}, ${ry}]})) // line ${obj.position}\n`
+        code = `${indent}${on} = transforms.center({ center: [${cx}, ${cy}, 0] }, primitives.ellipse({segments: ${segments}, radius: [${rx}, ${ry}]})) // line ${obj.position}\n`
         if (target === 'path') {
           code += `${indent}${on} = geometries.path2.fromPoints({closed: true}, geometries.geom2.toPoints(${on}))\n`
         }

--- a/packages/io/svg-deserializer/shapesMapJscad.js
+++ b/packages/io/svg-deserializer/shapesMapJscad.js
@@ -2,11 +2,11 @@ const { svg2cagX, svg2cagY, cagLengthX, cagLengthY, cagLengthP, reflect } = requ
 // const { cssPxUnit } = require('./constants')
 
 const shapesMap = function (obj, codify, params) {
-  const { level, indent, on, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups, target } = params
+  const { level, indent, on, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups, target, segments } = params
 
   const types = {
     group: (obj) => {
-      let code = codify({ target }, obj)
+      let code = codify({ target, segments }, obj)
       code += `${indent}${on} = levels.l${level + 1}\n`
       return code
     },
@@ -113,7 +113,8 @@ const shapesMap = function (obj, codify, params) {
 
     path
   }
-  return types[obj.type](obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGroups)
+
+  return types[obj.type](obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGroups, segments)
 }
 
 module.exports = shapesMap
@@ -131,7 +132,7 @@ module.exports = shapesMap
 //   return r
 // }
 
-const path = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGroups) => {
+const path = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGroups, segments) => {
   const { indent, on, target } = params
   let tmpCode = `${indent}parts = [] // line ${obj.position}\n`
 
@@ -210,7 +211,7 @@ const path = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGrou
           const sf = (pts.shift() === '1')
           cx = cx + parseFloat(pts.shift())
           cy = cy + parseFloat(pts.shift())
-          tmpCode += `${indent}${pathName} = geometries.path2.appendArc({endpoint: [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}], radius: [${svg2cagX(rx, svgUnitsPmm)}, ${svg2cagY(ry, svgUnitsPmm)}], xaxisrotation: ${ro}, clockwise: ${sf}, large: ${lf}}, ${pathName})\n`
+          tmpCode += `${indent}${pathName} = geometries.path2.appendArc({segments: ${segments}, endpoint: [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}], radius: [${svg2cagX(rx, svgUnitsPmm)}, ${svg2cagY(ry, svgUnitsPmm)}], xaxisrotation: ${ro}, clockwise: ${sf}, large: ${lf}}, ${pathName})\n`
         }
         break
       case 'A': // absolute elliptical arc
@@ -222,7 +223,7 @@ const path = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGrou
           const sf = (pts.shift() === '1')
           cx = parseFloat(pts.shift())
           cy = parseFloat(pts.shift())
-          tmpCode += `${indent}${pathName} = geometries.path2.appendArc({endpoint: [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}], radius: [${svg2cagX(rx, svgUnitsPmm)}, ${svg2cagY(ry, svgUnitsPmm)}], xaxisrotation: ${ro}, clockwise: ${sf}, large: ${lf}}, ${pathName})\n`
+          tmpCode += `${indent}${pathName} = geometries.path2.appendArc({segments: ${segments}, endpoint: [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}], radius: [${svg2cagX(rx, svgUnitsPmm)}, ${svg2cagY(ry, svgUnitsPmm)}], xaxisrotation: ${ro}, clockwise: ${sf}, large: ${lf}}, ${pathName})\n`
         }
         break
       case 'c': // relative cubic Bézier
@@ -233,7 +234,7 @@ const path = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGrou
           by = cy + parseFloat(pts.shift())
           cx = cx + parseFloat(pts.shift())
           cy = cy + parseFloat(pts.shift())
-          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({controlPoints: [[${svg2cagX(x1, svgUnitsPmm)}, ${svg2cagY(y1, svgUnitsPmm)}], [${svg2cagX(bx, svgUnitsPmm)}, ${svg2cagY(by, svgUnitsPmm)}], [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]]}, ${pathName})\n`
+          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({segments: ${segments}, controlPoints: [[${svg2cagX(x1, svgUnitsPmm)}, ${svg2cagY(y1, svgUnitsPmm)}], [${svg2cagX(bx, svgUnitsPmm)}, ${svg2cagY(by, svgUnitsPmm)}], [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]]}, ${pathName})\n`
           const rf = reflect(bx, by, cx, cy)
           bx = rf[0]
           by = rf[1]
@@ -247,7 +248,7 @@ const path = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGrou
           by = parseFloat(pts.shift())
           cx = parseFloat(pts.shift())
           cy = parseFloat(pts.shift())
-          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({controlPoints: [[${svg2cagX(x1, svgUnitsPmm)}, ${svg2cagY(y1, svgUnitsPmm)}], [${svg2cagX(bx, svgUnitsPmm)}, ${svg2cagY(by, svgUnitsPmm)}], [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]]}, ${pathName})\n`
+          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({segments: ${segments}, controlPoints: [[${svg2cagX(x1, svgUnitsPmm)}, ${svg2cagY(y1, svgUnitsPmm)}], [${svg2cagX(bx, svgUnitsPmm)}, ${svg2cagY(by, svgUnitsPmm)}], [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]]}, ${pathName})\n`
           const rf = reflect(bx, by, cx, cy)
           bx = rf[0]
           by = rf[1]
@@ -259,7 +260,7 @@ const path = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGrou
           qy = cy + parseFloat(pts.shift())
           cx = cx + parseFloat(pts.shift()) // end point
           cy = cy + parseFloat(pts.shift())
-          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({controlPoints: [[${svg2cagX(qx, svgUnitsPmm)}, ${svg2cagY(qy, svgUnitsPmm)}], [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]]}, ${pathName})\n`
+          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({segments: ${segments}, controlPoints: [[${svg2cagX(qx, svgUnitsPmm)}, ${svg2cagY(qy, svgUnitsPmm)}], [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]]}, ${pathName})\n`
           const rf = reflect(qx, qy, cx, cy)
           qx = rf[0]
           qy = rf[1]
@@ -271,7 +272,7 @@ const path = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGrou
           qy = parseFloat(pts.shift())
           cx = parseFloat(pts.shift()) // end point
           cy = parseFloat(pts.shift())
-          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({controlPoints: [[${svg2cagX(qx, svgUnitsPmm)}, ${svg2cagY(qy, svgUnitsPmm)}], [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]]}, ${pathName})\n`
+          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({segments: ${segments}, controlPoints: [[${svg2cagX(qx, svgUnitsPmm)}, ${svg2cagY(qy, svgUnitsPmm)}], [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]]}, ${pathName})\n`
           const rf = reflect(qx, qy, cx, cy)
           qx = rf[0]
           qy = rf[1]
@@ -281,7 +282,7 @@ const path = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGrou
         while (pts.length >= 2) {
           cx = cx + parseFloat(pts.shift()) // end point
           cy = cy + parseFloat(pts.shift())
-          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({controlPoints: [[${svg2cagX(qx, svgUnitsPmm)}, ${svg2cagY(qy, svgUnitsPmm)}], [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]]}, ${pathName})\n`
+          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({segments: ${segments}, controlPoints: [[${svg2cagX(qx, svgUnitsPmm)}, ${svg2cagY(qy, svgUnitsPmm)}], [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]]}, ${pathName})\n`
           const rf = reflect(qx, qy, cx, cy)
           qx = rf[0]
           qy = rf[1]
@@ -291,7 +292,7 @@ const path = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGrou
         while (pts.length >= 2) {
           cx = parseFloat(pts.shift()) // end point
           cy = parseFloat(pts.shift())
-          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({controlPoints: [[${svg2cagX(qx, svgUnitsPmm)}, ${svg2cagY(qy, svgUnitsPmm)}], [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]]}, ${pathName})\n`
+          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({segments: ${segments}, controlPoints: [[${svg2cagX(qx, svgUnitsPmm)}, ${svg2cagY(qy, svgUnitsPmm)}], [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]]}, ${pathName})\n`
           const rf = reflect(qx, qy, cx, cy)
           qx = rf[0]
           qy = rf[1]
@@ -305,7 +306,7 @@ const path = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGrou
           by = cy + parseFloat(pts.shift())
           cx = cx + parseFloat(pts.shift())
           cy = cy + parseFloat(pts.shift())
-          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({controlPoints: [[${svg2cagX(x1, svgUnitsPmm)}, ${svg2cagY(y1, svgUnitsPmm)}], [${svg2cagX(bx, svgUnitsPmm)}, ${svg2cagY(by, svgUnitsPmm)}], [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]]}, ${pathName})\n`
+          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({segments: ${segments}, controlPoints: [[${svg2cagX(x1, svgUnitsPmm)}, ${svg2cagY(y1, svgUnitsPmm)}], [${svg2cagX(bx, svgUnitsPmm)}, ${svg2cagY(by, svgUnitsPmm)}], [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]]}, ${pathName})\n`
           const rf = reflect(bx, by, cx, cy)
           bx = rf[0]
           by = rf[1]
@@ -319,7 +320,7 @@ const path = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGrou
           by = parseFloat(pts.shift())
           cx = parseFloat(pts.shift())
           cy = parseFloat(pts.shift())
-          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({controlPoints: [[${svg2cagX(x1, svgUnitsPmm)}, ${svg2cagY(y1, svgUnitsPmm)}], [${svg2cagX(bx, svgUnitsPmm)}, ${svg2cagY(by, svgUnitsPmm)}], [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]]}, ${pathName})\n`
+          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({segments: ${segments}, controlPoints: [[${svg2cagX(x1, svgUnitsPmm)}, ${svg2cagY(y1, svgUnitsPmm)}], [${svg2cagX(bx, svgUnitsPmm)}, ${svg2cagY(by, svgUnitsPmm)}], [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]]}, ${pathName})\n`
           const rf = reflect(bx, by, cx, cy)
           bx = rf[0]
           by = rf[1]

--- a/packages/io/svg-deserializer/tests/instantiate.test.js
+++ b/packages/io/svg-deserializer/tests/instantiate.test.js
@@ -17,14 +17,14 @@ test('deserialize : instantiate svg (rect) to objects', (t) => {
   let shape = observed[0]
   t.is(shape.sides.length, 4)
   shape = observed[1]
-  t.is(shape.sides.length, 20)
+  t.is(shape.sides.length, 36)
 
   observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 4)
   shape = observed[0]
   t.is(shape.points.length, 4)
   shape = observed[1]
-  t.is(shape.points.length, 20) // rounded rectangle
+  t.is(shape.points.length, 36) // rounded rectangle
 })
 
 // ################################
@@ -38,19 +38,19 @@ test('deserialize : instantiate svg (circle) to objects', (t) => {
   let observed = deserializer.deserialize({ output: 'geometry', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   let shape = observed[0]
-  t.is(shape.sides.length, 16)
+  t.is(shape.sides.length, 32)
   t.deepEqual(shape.color, [1, 0, 0, 1])
 
   observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
-  t.is(shape.points.length, 16)
+  t.is(shape.points.length, 32)
   t.deepEqual(shape.color, [0, 0, 0, 1])
 
-  observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false, segments: 32 }, sourceSvg)
+  observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false, segments: 16 }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
-  t.is(shape.points.length, 32)
+  t.is(shape.points.length, 16)
   t.deepEqual(shape.color, [0, 0, 0, 1])
 })
 
@@ -65,17 +65,17 @@ test('deserialize : instantiate svg (ellipse) to objects', (t) => {
   let observed = deserializer.deserialize({ output: 'geometry', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   let shape = observed[0]
-  t.is(shape.sides.length, 16)
+  t.is(shape.sides.length, 32)
 
   observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
-  t.is(shape.points.length, 16)
+  t.is(shape.points.length, 32)
 
-  observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false, segments: 32 }, sourceSvg)
+  observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false, segments: 16 }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
-  t.is(shape.points.length, 32)
+  t.is(shape.points.length, 16)
 })
 
 // ################################
@@ -218,17 +218,17 @@ test('deserialize : instantiate svg (path: arc) to objects', (t) => {
   let observed = deserializer.deserialize({ output: 'geometry', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   let shape = observed[0]
-  t.is(shape.sides.length, 16)
+  t.is(shape.sides.length, 28)
 
   observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
-  t.is(shape.points.length, 15)
+  t.is(shape.points.length, 27)
 
-  observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false, segments: 32 }, sourceSvg)
+  observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false, segments: 16 }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
-  t.is(shape.points.length, 27) // segments double on a 3/4 circle
+  t.is(shape.points.length, 15) // segments double on a 3/4 circle
 })
 
 // ################################
@@ -241,17 +241,17 @@ test('deserialize : instantiate svg (path: with bezier) to objects', (t) => {
   let observed = deserializer.deserialize({ output: 'geometry', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   let shape = observed[0]
-  t.is(shape.sides.length, 12)
+  t.is(shape.sides.length, 17)
 
   observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
-  t.is(shape.points.length, 11)
+  t.is(shape.points.length, 16)
 
-  observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false, segments: 32 }, sourceSvg)
+  observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false, segments: 16 }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
-  t.is(shape.points.length, 16)
+  t.is(shape.points.length, 11)
 
   // absolute CUBIC bezier
   // relative CUBIC bezier
@@ -262,12 +262,12 @@ test('deserialize : instantiate svg (path: with bezier) to objects', (t) => {
   observed = deserializer.deserialize({ output: 'geometry', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
-  t.is(shape.sides.length, 39)
+  t.is(shape.sides.length, 63)
 
   observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
-  t.is(shape.points.length, 38)
+  t.is(shape.points.length, 62)
 
   // absolute QUADRATIC bezier
   sourceSvg = `<svg height="500" width="500">
@@ -277,12 +277,12 @@ test('deserialize : instantiate svg (path: with bezier) to objects', (t) => {
   observed = deserializer.deserialize({ output: 'geometry', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
-  t.is(shape.sides.length, 21)
+  t.is(shape.sides.length, 41)
 
   observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
-  t.is(shape.points.length, 20)
+  t.is(shape.points.length, 40)
 
   // absolute CUBIC bezier shorthand
   // relative CUBIC bezier shorthand
@@ -293,14 +293,14 @@ test('deserialize : instantiate svg (path: with bezier) to objects', (t) => {
   observed = deserializer.deserialize({ output: 'geometry', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(observed.length, 2)
   shape = observed[0]
-  t.is(shape.points.length, 8) // open path
+  t.is(shape.points.length, 14) // open path
 
   observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 2)
   shape = observed[0]
-  t.is(shape.points.length, 8)
+  t.is(shape.points.length, 14)
   shape = observed[1]
-  t.is(shape.points.length, 8)
+  t.is(shape.points.length, 14)
 
   // absolute QUADRATIC bezier shorthand
   // relative QUADRATIC bezier shorthand
@@ -311,12 +311,12 @@ test('deserialize : instantiate svg (path: with bezier) to objects', (t) => {
   observed = deserializer.deserialize({ output: 'geometry', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
-  t.is(shape.points.length, 19) // open path
+  t.is(shape.points.length, 37) // open path
 
   observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
-  t.is(shape.points.length, 19)
+  t.is(shape.points.length, 37)
 
   // test fill color
   sourceSvg = `<svg height="500" width="500">
@@ -326,13 +326,13 @@ test('deserialize : instantiate svg (path: with bezier) to objects', (t) => {
   observed = deserializer.deserialize({ output: 'geometry', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
-  t.is(shape.sides.length, 39)
+  t.is(shape.sides.length, 127)
   t.deepEqual(shape.color, [1, 0, 0, 1])
 
   observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
-  t.is(shape.points.length, 38)
+  t.is(shape.points.length, 126)
 })
 
 // ################################
@@ -412,16 +412,16 @@ test('deserialize : instantiate shape with a hole to objects', (t) => {
   let observed = deserializer.deserialize({ output: 'geometry', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(observed.length, 2)
   let shape = observed[0]
-  t.is(shape.sides.length, 24)
+  t.is(shape.sides.length, 40)
   shape = observed[1]
-  t.is(shape.sides.length, 24)
+  t.is(shape.sides.length, 40)
 
   observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 2)
   shape = observed[0]
-  t.is(shape.points.length, 23)
+  t.is(shape.points.length, 39)
   shape = observed[1]
-  t.is(shape.points.length, 23)
+  t.is(shape.points.length, 39)
 })
 
 // ################################
@@ -436,12 +436,12 @@ test('deserialize : instantiate shape with a nested hole to objects', (t) => {
   let observed = deserializer.deserialize({ output: 'geometry', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(observed.length, 4)
   let shape = observed[0]
-  t.is(shape.sides.length, 24)
+  t.is(shape.sides.length, 40)
 
   observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 4)
   shape = observed[0]
-  t.is(shape.points.length, 23)
+  t.is(shape.points.length, 39)
 })
 
 // ################################
@@ -461,7 +461,7 @@ test('deserialize : translate svg with simple defs to script', (t) => {
   const observed = deserializer.deserialize({ output: 'geometry', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   const shape = observed[0]
-  t.is(shape.sides.length, 16)
+  t.is(shape.sides.length, 32)
 })
 
 // ################################
@@ -486,5 +486,5 @@ test('deserialize : translate svg with defs using defs to script', (t) => {
   const observed = deserializer.deserialize({ output: 'geometry', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   const shape = observed[0]
-  t.is(shape.sides.length, 16)
+  t.is(shape.sides.length, 32)
 })

--- a/packages/io/svg-deserializer/tests/instantiate.test.js
+++ b/packages/io/svg-deserializer/tests/instantiate.test.js
@@ -17,14 +17,14 @@ test('deserialize : instantiate svg (rect) to objects', (t) => {
   let shape = observed[0]
   t.is(shape.sides.length, 4)
   shape = observed[1]
-  t.is(shape.sides.length, 36)
+  t.is(shape.sides.length, 20)
 
   observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 4)
   shape = observed[0]
   t.is(shape.points.length, 4)
   shape = observed[1]
-  t.is(shape.points.length, 36) // rounded rectangle
+  t.is(shape.points.length, 20) // rounded rectangle
 })
 
 // ################################
@@ -38,10 +38,16 @@ test('deserialize : instantiate svg (circle) to objects', (t) => {
   let observed = deserializer.deserialize({ output: 'geometry', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   let shape = observed[0]
-  t.is(shape.sides.length, 32)
+  t.is(shape.sides.length, 16)
   t.deepEqual(shape.color, [1, 0, 0, 1])
 
   observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
+  t.is(observed.length, 1)
+  shape = observed[0]
+  t.is(shape.points.length, 16)
+  t.deepEqual(shape.color, [0, 0, 0, 1])
+
+  observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false, segments: 32 }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
   t.is(shape.points.length, 32)
@@ -59,9 +65,14 @@ test('deserialize : instantiate svg (ellipse) to objects', (t) => {
   let observed = deserializer.deserialize({ output: 'geometry', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   let shape = observed[0]
-  t.is(shape.sides.length, 32)
+  t.is(shape.sides.length, 16)
 
   observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
+  t.is(observed.length, 1)
+  shape = observed[0]
+  t.is(shape.points.length, 16)
+
+  observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false, segments: 32 }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
   t.is(shape.points.length, 32)
@@ -213,6 +224,11 @@ test('deserialize : instantiate svg (path: arc) to objects', (t) => {
   t.is(observed.length, 1)
   shape = observed[0]
   t.is(shape.points.length, 15)
+
+  observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false, segments: 32 }, sourceSvg)
+  t.is(observed.length, 1)
+  shape = observed[0]
+  t.is(shape.points.length, 27) // segments double on a 3/4 circle
 })
 
 // ################################
@@ -231,6 +247,11 @@ test('deserialize : instantiate svg (path: with bezier) to objects', (t) => {
   t.is(observed.length, 1)
   shape = observed[0]
   t.is(shape.points.length, 11)
+
+  observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false, segments: 32 }, sourceSvg)
+  t.is(observed.length, 1)
+  shape = observed[0]
+  t.is(shape.points.length, 16)
 
   // absolute CUBIC bezier
   // relative CUBIC bezier
@@ -440,7 +461,7 @@ test('deserialize : translate svg with simple defs to script', (t) => {
   const observed = deserializer.deserialize({ output: 'geometry', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   const shape = observed[0]
-  t.is(shape.sides.length, 32)
+  t.is(shape.sides.length, 16)
 })
 
 // ################################
@@ -465,5 +486,5 @@ test('deserialize : translate svg with defs using defs to script', (t) => {
   const observed = deserializer.deserialize({ output: 'geometry', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   const shape = observed[0]
-  t.is(shape.sides.length, 32)
+  t.is(shape.sides.length, 16)
 })


### PR DESCRIPTION
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?

This adds a `segments` argument to the SVG Deserializer. It gets passed down to any curves, specifically: ellipses, circle, rounded rectangles and bezier curves using the existing `segments` argument in each of the primitives. This works both for the script and path output.

The tests add a case for each of these testing the increase of segments. In the case of ellipses and circles, the default used (32) to be different from the default for bezier curves (16). Now, since there's only one argument to control both and the new default is 16, the ellipses, circles and rounded rectangles created through the SVG deserializer will have `segments=16`. 

This PR comes after the discussion in issue #681 