### PR TITLE
V2 : fix loading of designs from remote URLs

### DIFF
--- a/packages/web/remote.php
+++ b/packages/web/remote.php
@@ -12,13 +12,20 @@ retrieveFile($_REQUEST['url']);
 cleanUpExpired();
 
 function retrieveFile($url) {
+   // only process valid requests
+   $valid = strncmp($url, "http://", 7) || strncmp($url, "https://", 8);
+   if (! $valid) return;
+
    $contents = file_get_contents($url);
-   $f = CACHE_PATH . "/tmp-".time()."-".rand(0,1024*1024)."-".basename($url);
-   file_put_contents("./".$f, $contents);
+
+   $fileName = basename($url); // FIXME a default extension needs to be added
+   $filePath = CACHE_PATH . "/".date("ymdHms")."-".$fileName;
+   file_put_contents("./".$filePath, $contents);
+
    $data = array(
-      'filename'  => basename($url),
-      'file'      => CACHE_PATH."/".basename($f),
-      'url'    => $url
+      'filename' => $fileName,
+      'file'     => $filePath,
+      'url'      => $url
    );
 
    echo json_encode ( $data );

--- a/packages/web/src/index.js
+++ b/packages/web/src/index.js
@@ -70,11 +70,12 @@ async function makeJscad (targetElement, options) {
     store: storage.source(),
     fs: fs.source(),
     http: http.source(),
+    https: http.source(),
     drops: dragDrop.source(),
     dom: dom.source(),
     solidWorker: solidWorker.source(),
     i18n: i18n.source(),
-    titleBar: titleBar.source(), // #http://openjscad.org/examples/slices/tor.jscad
+    titleBar: titleBar.source(),
     fileDialog: fileDialog.source(),
     dat: await dat.source()
   }
@@ -84,6 +85,7 @@ async function makeJscad (targetElement, options) {
     store: storage.sink,
     fs: fs.sink,
     http: http.sink,
+    https: http.sink,
     i18n: i18n.sink,
     dom: dom.sink,
     solidWorker: solidWorker.sink,

--- a/packages/web/src/sideEffects/dragDrop/index.js
+++ b/packages/web/src/sideEffects/dragDrop/index.js
@@ -1,3 +1,4 @@
+const url = require('url')
 const { fromEvent } = require('most')
 
 const preventDefault = (event) => {
@@ -24,7 +25,12 @@ const extractData = (event) => {
   }
   if (event.dataTransfer.types.includes('text/plain')) {
     const data = event.dataTransfer.getData('text')
-    return { type: 'text', data }
+    try {
+      const parts = new URL(data)
+      return { type: 'url', data: parts.href }
+    } catch {
+      return { type: 'text', data }
+    }
   }
   if (event.dataTransfer.items && event.dataTransfer.items.length > 0) {
     return { type: 'fileOrFolder', data: itemListToArray(event.dataTransfer.items) }
@@ -33,8 +39,6 @@ const extractData = (event) => {
 }
 
 const makeDragAndDropSideEffect = ({ targetEl }) => {
-  // onst dragOvers$ = DOM.select(':root').events('dragover')
-  // const drops$ = DOM.select(':root').events('drop')
   const dragEvents = (targetEl) => {
     const dragOvers$ = fromEvent('dragover', targetEl)
     const drops$ = fromEvent('drop', targetEl)

--- a/packages/web/src/sideEffects/dragDrop/index.js
+++ b/packages/web/src/sideEffects/dragDrop/index.js
@@ -9,10 +9,10 @@ const isTextNotEmpty = (text) => text !== ''
 
 const exists = (input) => (input !== null && input !== undefined)
 
-const pseudoArraytoArray = (pseudoArray) => {
+const itemListToArray = (list) => {
   const array = []
-  for (let i = 0; i < pseudoArray.length; i++) {
-    const item = pseudoArray[i]
+  for (let i = 0; i < list.length; i++) {
+    const item = list[i]
     array.push(item.webkitGetAsEntry ? item.webkitGetAsEntry() : item)
   }
   return array
@@ -23,10 +23,11 @@ const extractData = (event) => {
     return { type: 'url', data: event.dataTransfer.getData('url') }
   }
   if (event.dataTransfer.types.includes('text/plain')) {
-    return { type: 'text', data: event.dataTransfer.getData('text') }
+    const data = event.dataTransfer.getData('text')
+    return { type: 'text', data }
   }
   if (event.dataTransfer.items && event.dataTransfer.items.length > 0) {
-    return { type: 'fileOrFolder', data: pseudoArraytoArray(event.dataTransfer.items) }
+    return { type: 'fileOrFolder', data: itemListToArray(event.dataTransfer.items) }
   }
   return undefined
 }

--- a/packages/web/src/sideEffects/localFs/walkFileTree.js
+++ b/packages/web/src/sideEffects/localFs/walkFileTree.js
@@ -94,7 +94,7 @@ const processItems = (items) => {
  * @returns {Promise} new promise to read and process the file
  */
 const processFile = (fileItem) => {
-  console.log('processFile',fileItem)
+  // console.log('processFile',fileItem)
   const promiseFile = new Promise((resolve, reject) => {
     fileItem.file(
       (fileData) => {

--- a/packages/web/src/sideEffects/localFs/walkFileTree.js
+++ b/packages/web/src/sideEffects/localFs/walkFileTree.js
@@ -94,11 +94,17 @@ const processItems = (items) => {
  * @returns {Promise} new promise to read and process the file
  */
 const processFile = (fileItem) => {
-  // console.log('processFile',fileItem)
+  console.log('processFile',fileItem)
   const promiseFile = new Promise((resolve, reject) => {
-    fileItem.file((fileData) => {
-      isSupportedFormat(fileData) ? resolve(readFileAsync(fileData, fileItem)) : resolve(undefined)
-    }, reject)
+    fileItem.file(
+      (fileData) => {
+        isSupportedFormat(fileData) ? resolve(readFileAsync(fileData, fileItem)) : resolve(undefined)
+      },
+      (fileError) => {
+        const message = `${fileError.message} (${fileError.code})`
+        reject(new Error(`Failed to load file: ${fileItem.fullPath} [${message}]`))
+      }
+    )
   })
   return promiseFile
 }

--- a/packages/web/src/ui/flow/flowOut.js
+++ b/packages/web/src/ui/flow/flowOut.js
@@ -1,6 +1,6 @@
 const makeReactions = (inputs) => {
   const { sinks, outputs$ } = inputs
-  const { store, fs, http, i18n, dom, solidWorker, state, dat } = sinks
+  const { store, fs, http, https, i18n, dom, solidWorker, state, dat } = sinks
 
   /* outputs$
     .filter(x => 'sink' in x && x.sink === 'dom')
@@ -28,6 +28,7 @@ const makeReactions = (inputs) => {
   store(outputs$.filter((x) => 'sink' in x && x.sink === 'store'))
   // output to http
   http(outputs$.filter((x) => 'sink' in x && x.sink === 'http'))
+  https(outputs$.filter((x) => 'sink' in x && x.sink === 'https'))
   // data out to file system sink
   // drag & drops of files/folders have DUAL meaning:
   // * ADD this file/folder to the available ones

--- a/packages/web/src/ui/views/examples.js
+++ b/packages/web/src/ui/views/examples.js
@@ -1,4 +1,6 @@
 const html = require('nanohtml')
+const path = require('path')
+const url = require('url')
 
 const examplesData = [
   { file: 'core/primitives/primitives2D.js', title: '2D Primitives' },
@@ -44,10 +46,17 @@ const examples = (state, i18n) => {
   const wrap = 26
   const colp = 100 / Math.floor(examplesData.length / wrap + 1) + '%'
 
-  const baseUrl = window.location.origin
+  const baseUrl = new URL(window.location.href)
+  // normalize the path, removing document names
+  let newpath = path.dirname(baseUrl.pathname)
+  newpath = newpath.endsWith('/') ? newpath : newpath + path.sep
+  baseUrl.pathname = newpath
+  const originUrl = window.location.origin
+
   return examplesData.map((example) => {
     const type = example.type || ''
-    const exampleUrl = `${baseUrl}/examples/${example.file}`
+    const relativeUrl = new URL(`./examples/${example.file}`, baseUrl)
+    const exampleUrl = relativeUrl.href
     return html`
     <tr>
       <td class="examplesSeparator" width="${colp}" valign="top">

--- a/packages/web/src/utils/urlUtils.js
+++ b/packages/web/src/utils/urlUtils.js
@@ -1,10 +1,8 @@
 const url = require('url')
 
-// FIXME url.parse deprecated
 const fetchUriParams = (uri, paramName, defaultValue = undefined) => {
-  const params = url.parse(uri, true)
-  const result = params.query
-  if (paramName in result) return result[paramName]
+  const parts = new URL(uri) // parse URL and QUERY
+  if (parts.searchParams.get(paramName)) return parts.searchParams.get(paramName)
   return defaultValue
 }
 


### PR DESCRIPTION
These changes fix the loading of designs from remote URLs, using the webserver as a proxy cache for the contents of the URLs. This allows:
- URL addresses containing hashes; http://jscad.xyz#http://external.com/data/design.js
- URL addresses containing queries; http://jscad.xyz#uri=http://external.com/data/design.js
- drag and drop of URLs

Testing was performed on MacOS and Windows 10, across the following browsers
- Safari
- Chrome
- Firefox
- Edge
- Opera

Note: The installation of the backend process is required to use this functionality. An additional note was added to the [V2 Summary of Changes](https://openjscad.org/dokuwiki/doku.php?id=changes_v2).

Fixes #688 

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Does your submission pass tests?
Thank you for your help in advance, much appreciated !
