### PR TITLE
[experiment] v2: generate typescript declarations from jsdoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "coverage": "npm run bootstrap && lerna run --concurrency 1 --stream coverage",
     "test": "npm run bootstrap && lerna run --stream test",
     "lint": "standardx 'packages/**/*.js'",
+    "typescript:build": "tsc --project tsconfig.build.json",
+    "typescript:clean": "rimraf 'packages/**/!(type).d.ts'",
+    "typescript": "npm run typescript:clean && npm run typescript:build",
     "bootstrap": "lerna bootstrap --hoist nyc --hoist ava --ignore-prepublish --no-ci",
     "changed": "lerna changed",
     "clean": "lerna clean",
@@ -43,7 +46,9 @@
     "jsdoc": "3.6.4",
     "lerna": "3.22.1",
     "nyc": "15.1.0",
-    "standardx": "5.0.0"
+    "rimraf": "^3.0.2",
+    "standardx": "5.0.0",
+    "typescript": "^4.0.5"
   },
   "collective": {
     "type": "opencollective",

--- a/packages/modeling/src/geometries/geom2/create.js
+++ b/packages/modeling/src/geometries/geom2/create.js
@@ -1,15 +1,22 @@
+/**
+ * @typedef { import("../../maths/mat4/type") } mat4
+ * @typedef { import("../../maths/vec2/type") } vec2
+ * @typedef { import("./type") } geom2
+ * @typedef {[vec2, vec2]} side
+ * @typedef {Array<side>} sides
+ */
+
 const mat4 = require('../../maths/mat4')
 
 /**
  * Represents a 2D geometry consisting of a list of sides.
- * @typedef {Object} geom2
- * @property {Array} sides - list of sides, each side containing two points
+ * @property {sides} sides - list of sides, each side containing two points
  * @property {mat4} transforms - transforms to apply to the sides, see transform()
  */
 
 /**
  * Create a new 2D geometry composed of unordered sides (two connected points).
- * @param {Array} [sides] - list of sides where each side is an array of two points
+ * @param {sides} [sides] - list of sides where each side is an array of two points
  * @returns {geom2} a new empty geometry
  * @alias module:modeling/geometries/geom2.create
  */

--- a/packages/modeling/src/geometries/geom2/type.d.ts
+++ b/packages/modeling/src/geometries/geom2/type.d.ts
@@ -3,7 +3,7 @@ import Mat4 from '../../maths/mat4/type'
 
 export interface Geom2 {
   sides: Array<[Vec2, Vec2]>
-  transforms?: Mat4
+  transforms: Mat4
 }
 
 export default Geom2

--- a/packages/modeling/src/geometries/geom2/type.d.ts
+++ b/packages/modeling/src/geometries/geom2/type.d.ts
@@ -1,0 +1,9 @@
+import Vec2 from '../../maths/vec2/type'
+import Mat4 from '../../maths/mat4/type'
+
+export interface Geom2 {
+  sides: Array<[Vec2, Vec2]>
+  transforms?: Mat4
+}
+
+export default Geom2

--- a/packages/modeling/src/maths/mat4/type.d.ts
+++ b/packages/modeling/src/maths/mat4/type.d.ts
@@ -1,0 +1,8 @@
+export type Mat4 = [
+  number, number, number, number,
+  number, number, number, number,
+  number, number, number, number,
+  number, number, number, number,
+]
+
+export default Mat4

--- a/packages/modeling/src/maths/vec2/type.d.ts
+++ b/packages/modeling/src/maths/vec2/type.d.ts
@@ -1,0 +1,3 @@
+export type Vec2 = [number, number]
+
+export default Vec2

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "include": [
+    "packages/modeling/src/geometries/geom2",
+    "packages/modeling/src/maths/vec2",
+    "packages/modeling/src/maths/mat4"
+  ],
+  "exclude": [
+    "**/.d.ts"
+  ],
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "emitDeclarationOnly": true
+  }
+}


### PR DESCRIPTION
hallo! :smiley_cat: 

i'm quietly in love with OpenJSCAD, been eagerly awaiting the new v2 release. :tada: 

i've also become a fan of TypeScript in the last couple years, so would love to help contribute TypeScript types here.

this is an super early pull request to get feedback, more of a conversation starter than anything. :seedling: 

in https://github.com/jscad/OpenJSCAD.org/issues/403 there was a mention about generating types from the (jsdoc) code, so i thought i'd start with that, and that's what i tried here. turns out this is a [recent feature built-in to TypeScript](https://www.typescriptlang.org/docs/handbook/declaration-files/dts-from-js.html).

there are some caveats though with how the jsdoc needs to be written: https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html, specifically with `@typedef`, so i didn't want to go any further until i confirmed this is the preferred approach and that this doesn't break the jsdoc documentation generated. i tried to write enough of an example so you see what i mean.

the alternative approach would be to manually write `.d.ts` files alongside the `.js` files. while this might seem like more work, in many ways i think this could be easier, as TypeScript wouldn't impede on jsdoc, and would mean we could write the types in a more TypeScript fluent way. this is for example how i believe Three.js does their TypeScript types. so another question is whether y'all would be keen to include `.d.ts` files within the code base.

anyways, curious to hear what y'all think. cheers! :purple_heart: 