### PR TITLE
fix(web): changed the file system watcher to use setTimeout(), and calculate dynamic delays

### DIFF
--- a/packages/web/src/sideEffects/localFs/index.js
+++ b/packages/web/src/sideEffects/localFs/index.js
@@ -10,7 +10,7 @@ const makeLocalFsSideEffect = async (params) => {
     let currentFileTree
     let rawData
     let watcher
-    const watcherDelay = 5000 // milliseconds
+    let watcherDelay = 5000 // milliseconds
 
     // every time a new command is recieved (observable)
     commands$.forEach((command) => {
@@ -23,12 +23,15 @@ const makeLocalFsSideEffect = async (params) => {
       }
 
       const read = async () => {
-         // disable old watcher
-         if (watcher) {
-           clearInterval(watcher)
-           watcher = 0
-         }
-        rawData = data
+        // reset state
+        currentFileTree = undefined
+        rawData = undefined
+        if (watcher) {
+          clearTimeout(watcher)
+          watcher = 0
+        }
+        if (!(data.length && (data[0] instanceof File))) rawData = data // only watch live FileSystem data
+
         currentFileTree = await walkFileTree(data)
         commandResponses.callback({ type, id, data: currentFileTree })
       }
@@ -41,7 +44,8 @@ const makeLocalFsSideEffect = async (params) => {
 
         const { enabled } = options
         if (enabled) {
-          watcher = setInterval(() => {
+          const walkAndCheck = () => {
+            const startMs = Date.now()
             walkFileTree(rawData)
               .catch((error) => {
                 console.error('failed to read files', error)
@@ -54,12 +58,16 @@ const makeLocalFsSideEffect = async (params) => {
                   currentFileTree = newFileTree
                   commandResponses.callback({ type: 'read', id: 'loadRemote', data: currentFileTree, path, changed: whatChanged })
                 }
+
+                const endMs = Date.now()
+                watcherDelay = Math.max((endMs - startMs) * 2, 1000)
+                watcher = setTimeout(walkAndCheck, watcherDelay)
               })
-          }, watcherDelay)
+          }
+          watcher = setTimeout(walkAndCheck, watcherDelay)
         } else {
           if (watcher) {
-            // disable watcher
-            clearInterval(watcher)
+            clearTimeout(watcher)
             watcher = 0
           }
         }


### PR DESCRIPTION
These changes correct the file system watcher, which was hard-coded to 5000 ms intervals. These changes calculate a dynamic delay based on the performance of the comparison (old vs new filesystem), which can take significant cycles for large projects.

For small projects, the minimum delay will take affect; 1000 ms / 1 second.

Fixes #710 
Fixes #661 

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Does your submission pass tests?

Additional testing was completed against Safari, FireFox, and Chrome on MacOS.


> Note: please do NOT include build files (those generate by the build-xxx commands) with your PR,

Thank you for your help in advance, much appreciated !
