### PR TITLE
V2 : enhance SVG deserializer for mirror transforms

### DIFF
--- a/packages/io/svg-deserializer/index.js
+++ b/packages/io/svg-deserializer/index.js
@@ -173,9 +173,18 @@ const objectify = (options, group) => {
           if ('translate' in t) { tt = t }
         }
         if (ts !== null) {
-          const x = ts.scale[0]
-          const y = ts.scale[1]
+          let x = Math.abs(ts.scale[0])
+          let y = Math.abs(ts.scale[1])
           shape = transforms.scale([x, y, 1], shape)
+          // and mirror if necessary
+          x = ts.scale[0]
+          y = ts.scale[1]
+          if (x < 0) {
+            shape = transforms.mirrorX(shape)
+          }
+          if (y < 0) {
+            shape = transforms.mirrorY(shape)
+          }
         }
         if (tr !== null) {
           const z = 0 - tr.rotate * 0.017453292519943295 // radians
@@ -263,9 +272,18 @@ const codify = (options, group) => {
         if ('translate' in t) { tt = t }
       }
       if (ts !== null) {
-        const x = ts.scale[0]
-        const y = ts.scale[1]
+        let x = Math.abs(ts.scale[0])
+        let y = Math.abs(ts.scale[1])
         code += `${indent}${on} = transforms.scale([${x}, ${y}, 1], ${on})\n`
+        // and mirror if necessary
+        x = ts.scale[0]
+        y = ts.scale[1]
+        if (x < 0) {
+          code += `${indent}${on} = transforms.mirrorX(${on})\n`
+        }
+        if (y < 0) {
+          code += `${indent}${on} = transforms.mirrorY(${on})\n`
+        }
       }
       if (tr !== null) {
         const z = 0 - tr.rotate * 0.017453292519943295 // radians

--- a/packages/io/svg-deserializer/index.js
+++ b/packages/io/svg-deserializer/index.js
@@ -162,23 +162,23 @@ const objectify = (options, group) => {
       if ('transforms' in obj) {
         // NOTE: SVG specifications require that transforms are applied in the order given.
         // But these are applied in the order as required by JSCAD
-        let tr = null
-        let ts = null
-        let tt = null
+        let rotateAttribute = null
+        let scaleAttribute = null
+        let translateAttribute = null
 
         for (let j = 0; j < obj.transforms.length; j++) {
           const t = obj.transforms[j]
-          if ('rotate' in t) { tr = t }
-          if ('scale' in t) { ts = t }
-          if ('translate' in t) { tt = t }
+          if ('rotate' in t) { rotateAttribute = t }
+          if ('scale' in t) { scaleAttribute = t }
+          if ('translate' in t) { translateAttribute = t }
         }
-        if (ts !== null) {
-          let x = Math.abs(ts.scale[0])
-          let y = Math.abs(ts.scale[1])
+        if (scaleAttribute !== null) {
+          let x = Math.abs(scaleAttribute.scale[0])
+          let y = Math.abs(scaleAttribute.scale[1])
           shape = transforms.scale([x, y, 1], shape)
           // and mirror if necessary
-          x = ts.scale[0]
-          y = ts.scale[1]
+          x = scaleAttribute.scale[0]
+          y = scaleAttribute.scale[1]
           if (x < 0) {
             shape = transforms.mirrorX(shape)
           }
@@ -186,13 +186,13 @@ const objectify = (options, group) => {
             shape = transforms.mirrorY(shape)
           }
         }
-        if (tr !== null) {
-          const z = 0 - tr.rotate * 0.017453292519943295 // radians
+        if (rotateAttribute !== null) {
+          const z = 0 - rotateAttribute.rotate * 0.017453292519943295 // radians
           shape = transforms.rotateZ(z, shape)
         }
-        if (tt !== null) {
-          const x = cagLengthX(tt.translate[0], svgUnitsPmm, svgUnitsX)
-          const y = (0 - cagLengthY(tt.translate[1], svgUnitsPmm, svgUnitsY))
+        if (translateAttribute !== null) {
+          const x = cagLengthX(translateAttribute.translate[0], svgUnitsPmm, svgUnitsX)
+          const y = (0 - cagLengthY(translateAttribute.translate[1], svgUnitsPmm, svgUnitsY))
           shape = transforms.translate([x, y, 0], shape)
         }
       }
@@ -261,23 +261,23 @@ const codify = (options, group) => {
     if ('transforms' in obj) {
       // NOTE: SVG specifications require that transforms are applied in the order given.
       // But these are applied in the order as required by JSCAD
-      let tr = null
-      let ts = null
-      let tt = null
+      let rotateAttribute = null
+      let scaleAttribute = null
+      let translateAttribute = null
 
       for (let j = 0; j < obj.transforms.length; j++) {
         const t = obj.transforms[j]
-        if ('rotate' in t) { tr = t }
-        if ('scale' in t) { ts = t }
-        if ('translate' in t) { tt = t }
+        if ('rotate' in t) { rotateAttribute = t }
+        if ('scale' in t) { scaleAttribute = t }
+        if ('translate' in t) { translateAttribute = t }
       }
-      if (ts !== null) {
-        let x = Math.abs(ts.scale[0])
-        let y = Math.abs(ts.scale[1])
+      if (scaleAttribute !== null) {
+        let x = Math.abs(scaleAttribute.scale[0])
+        let y = Math.abs(scaleAttribute.scale[1])
         code += `${indent}${on} = transforms.scale([${x}, ${y}, 1], ${on})\n`
         // and mirror if necessary
-        x = ts.scale[0]
-        y = ts.scale[1]
+        x = scaleAttribute.scale[0]
+        y = scaleAttribute.scale[1]
         if (x < 0) {
           code += `${indent}${on} = transforms.mirrorX(${on})\n`
         }
@@ -285,13 +285,13 @@ const codify = (options, group) => {
           code += `${indent}${on} = transforms.mirrorY(${on})\n`
         }
       }
-      if (tr !== null) {
-        const z = 0 - tr.rotate * 0.017453292519943295 // radians
+      if (rotateAttribute !== null) {
+        const z = 0 - rotateAttribute.rotate * 0.017453292519943295 // radians
         code += `${indent}${on} = transforms.rotateZ(${z}, ${on})\n`
       }
-      if (tt !== null) {
-        const x = cagLengthX(tt.translate[0], svgUnitsPmm, svgUnitsX)
-        const y = (0 - cagLengthY(tt.translate[1], svgUnitsPmm, svgUnitsY))
+      if (translateAttribute !== null) {
+        const x = cagLengthX(translateAttribute.translate[0], svgUnitsPmm, svgUnitsX)
+        const y = (0 - cagLengthY(translateAttribute.translate[1], svgUnitsPmm, svgUnitsY))
         code += `${indent}${on} = transforms.translate([${x}, ${y}, 0], ${on})\n`
       }
     }

--- a/packages/io/svg-deserializer/index.js
+++ b/packages/io/svg-deserializer/index.js
@@ -161,22 +161,30 @@ const objectify = (options, group) => {
     shapes = shapes.map((shape) => {
       if ('transforms' in obj) {
         // NOTE: SVG specifications require that transforms are applied in the order given.
+        // But these are applied in the order as required by JSCAD
+        let tr = null
+        let ts = null
+        let tt = null
+
         for (let j = 0; j < obj.transforms.length; j++) {
           const t = obj.transforms[j]
-          if ('rotate' in t) {
-            const z = 0 - t.rotate
-            shape = transforms.rotateZ(z, shape)
-          }
-          if ('scale' in t) {
-            const x = t.scale[0]
-            const y = t.scale[1]
-            shape = transforms.scale([x, y, 1], shape)
-          }
-          if ('translate' in t) {
-            const x = cagLengthX(t.translate[0], svgUnitsPmm, svgUnitsX)
-            const y = (0 - cagLengthY(t.translate[1], svgUnitsPmm, svgUnitsY))
-            shape = transforms.translate([x, y, 0], shape)
-          }
+          if ('rotate' in t) { tr = t }
+          if ('scale' in t) { ts = t }
+          if ('translate' in t) { tt = t }
+        }
+        if (ts !== null) {
+          const x = ts.scale[0]
+          const y = ts.scale[1]
+          shape = transforms.scale([x, y, 1], shape)
+        }
+        if (tr !== null) {
+          const z = 0 - tr.rotate * 0.017453292519943295 // radians
+          shape = transforms.rotateZ(z, shape)
+        }
+        if (tt !== null) {
+          const x = cagLengthX(tt.translate[0], svgUnitsPmm, svgUnitsX)
+          const y = (0 - cagLengthY(tt.translate[1], svgUnitsPmm, svgUnitsY))
+          shape = transforms.translate([x, y, 0], shape)
         }
       }
       if (target === 'path' && obj.stroke) {
@@ -243,22 +251,30 @@ const codify = (options, group) => {
 
     if ('transforms' in obj) {
       // NOTE: SVG specifications require that transforms are applied in the order given.
+      // But these are applied in the order as required by JSCAD
+      let tr = null
+      let ts = null
+      let tt = null
+
       for (let j = 0; j < obj.transforms.length; j++) {
         const t = obj.transforms[j]
-        if ('rotate' in t) {
-          const z = 0 - t.rotate * 0.017453292519943295 // radians
-          code += `${indent}${on} = transforms.rotateZ(${z}, ${on})\n`
-        }
-        if ('scale' in t) {
-          const x = t.scale[0]
-          const y = t.scale[1]
-          code += `${indent}${on} = transforms.scale([${x}, ${y}, 1], ${on})\n`
-        }
-        if ('translate' in t) {
-          const x = cagLengthX(t.translate[0], svgUnitsPmm, svgUnitsX)
-          const y = (0 - cagLengthY(t.translate[1], svgUnitsPmm, svgUnitsY))
-          code += `${indent}${on} = transforms.translate([${x}, ${y}, 0], ${on})\n`
-        }
+        if ('rotate' in t) { tr = t }
+        if ('scale' in t) { ts = t }
+        if ('translate' in t) { tt = t }
+      }
+      if (ts !== null) {
+        const x = ts.scale[0]
+        const y = ts.scale[1]
+        code += `${indent}${on} = transforms.scale([${x}, ${y}, 1], ${on})\n`
+      }
+      if (tr !== null) {
+        const z = 0 - tr.rotate * 0.017453292519943295 // radians
+        code += `${indent}${on} = transforms.rotateZ(${z}, ${on})\n`
+      }
+      if (tt !== null) {
+        const x = cagLengthX(tt.translate[0], svgUnitsPmm, svgUnitsX)
+        const y = (0 - cagLengthY(tt.translate[1], svgUnitsPmm, svgUnitsY))
+        code += `${indent}${on} = transforms.translate([${x}, ${y}, 0], ${on})\n`
       }
     }
     if (target === 'path' && obj.stroke) {

--- a/packages/io/svg-deserializer/shapesMapGeometry.js
+++ b/packages/io/svg-deserializer/shapesMapGeometry.js
@@ -22,12 +22,12 @@ const shapesMapGeometry = (obj, objectify, params) => {
         x = (x + (w / 2)).toFixed(4) // position the object via the center
         y = (y - (h / 2)).toFixed(4) // position the object via the center
         if (rx === 0) {
-          shape = transforms.center({ center: [x, y, 0] }, primitives.rectangle({ size: [w / 2, h / 2] }))
+          shape = transforms.center({ center: [x, y, 0] }, primitives.rectangle({ size: [w, h] }))
         } else {
-          shape = transforms.center({ center: [x, y, 0] }, primitives.roundedRectangle({ segments, size: [w / 2, h / 2], roundRadius: rx }))
+          shape = transforms.center({ center: [x, y, 0] }, primitives.roundedRectangle({ segments, size: [w, h], roundRadius: rx }))
         }
         if (target === 'path') {
-          shape = geometries.path2.fromPoints({ }, geometries.geom2.toPoints(shape))
+          shape = geometries.path2.fromPoints({ closed: true }, geometries.geom2.toPoints(shape))
         }
       }
       return shape
@@ -42,7 +42,7 @@ const shapesMapGeometry = (obj, objectify, params) => {
       if (r > 0) {
         shape = transforms.center({ center: [x, y, 0] }, primitives.circle({ segments, radius: r }))
         if (target === 'path') {
-          shape = geometries.path2.fromPoints({}, geometries.geom2.toPoints(shape))
+          shape = geometries.path2.fromPoints({ closed: true }, geometries.geom2.toPoints(shape))
         }
       }
       return shape
@@ -58,7 +58,7 @@ const shapesMapGeometry = (obj, objectify, params) => {
       if (rx > 0 && ry > 0) {
         shape = transforms.center({ center: [cx, cy, 0] }, primitives.ellipse({ segments, radius: [rx, ry] }))
         if (target === 'path') {
-          shape = geometries.path2.fromPoints({}, geometries.geom2.toPoints(shape))
+          shape = geometries.path2.fromPoints({ closed: true }, geometries.geom2.toPoints(shape))
         }
       }
       return shape

--- a/packages/io/svg-deserializer/svgElementHelpers.js
+++ b/packages/io/svg-deserializer/svgElementHelpers.js
@@ -66,6 +66,7 @@ const svgTransforms = function (cag, element) {
       let o
       switch (n) {
         case 'translate':
+          if (a.length === 1) a.push(0) // as per SVG
           o = { translate: [a[0], a[1]] }
           cag.transforms.push(o)
           break
@@ -284,6 +285,16 @@ const svgGroup = function (element) {
   // presentation attributes
   svgPresentation(obj, element)
 
+  if ('X' in element || 'Y' in element) {
+    let x = '0'
+    let y = '0'
+    if ('X' in element) x = element.X
+    if ('Y' in element) y = element.Y
+    if (!('transforms' in obj)) obj.transforms = []
+    const o = { translate: [x, y] }
+    obj.transforms.push(o)
+  }
+
   obj.objects = []
   return obj
 }
@@ -410,9 +421,13 @@ const svgUse = function (element, { svgObjects }) {
   // presentation attributes
   svgPresentation(obj, element)
 
-  if ('X' in element && 'Y' in element) {
+  if ('X' in element || 'Y' in element) {
+    let x = '0'
+    let y = '0'
+    if ('X' in element) x = element.X
+    if ('Y' in element) y = element.Y
     if (!('transforms' in obj)) obj.transforms = []
-    const o = { translate: [element.X, element.Y] }
+    const o = { translate: [x, y] }
     obj.transforms.push(o)
   }
 


### PR DESCRIPTION
These changes enhance the SVG deserializer to support mirror transforms. 

Some small changes were also made:
- corrected order of transforms
- corrected translate transforms with a single value
- added conversion of X / Y attributes on GROUP / USE entities into translate transforms 
- corrected size of rectangles when instantiating to objects

Fixes #704 
Fixes #523 

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Does your submission pass tests?

Additional testing with the SVG sample files was also conducted via the WEB UI.