### PR TITLE
Update orbitControls.js

### DIFF
--- a/packages/utils/regl-renderer/src/controls/orbitControls.js
+++ b/packages/utils/regl-renderer/src/controls/orbitControls.js
@@ -248,9 +248,8 @@ const pan = ({ controls, camera, speed = 1 }, delta) => {
   ]
   const unPanStart = unproject([], panStart, viewport, invProjView)
   const unPanEnd = unproject([], panEnd, viewport, invProjView)
-  // TODO scale by the correct near/far value instead of 1000 ?
-  // const planesDiff = camera.far - camera.near
   const eyeDistance = vec3.distance(camera.position, camera.eye)
+
   const offset = vec3.subtract([], unPanStart, unPanEnd).map((x) => x * speed * eyeDistance * controls.scale)
 
   return {

--- a/packages/utils/regl-renderer/src/controls/orbitControls.js
+++ b/packages/utils/regl-renderer/src/controls/orbitControls.js
@@ -250,7 +250,8 @@ const pan = ({ controls, camera, speed = 1 }, delta) => {
   const unPanEnd = unproject([], panEnd, viewport, invProjView)
   // TODO scale by the correct near/far value instead of 1000 ?
   // const planesDiff = camera.far - camera.near
-  const offset = vec3.subtract([], unPanStart, unPanEnd).map((x) => x * speed * 250 * controls.scale)
+  const eyeDistance = vec3.distance(camera.position, camera.eye)
+  const offset = vec3.subtract([], unPanStart, unPanEnd).map((x) => x * speed * eyeDistance * controls.scale)
 
   return {
     controls,


### PR DESCRIPTION
### All Submissions:
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?

a small fix that modifies pan so it is scaled based on current zoom (distance camera<->eye).

There is a comment near my change that somebody left there
```
  // TODO scale by the correct near/far value instead of 1000 ?
  // const planesDiff = camera.far - camera.near
```

but when I inspected near and far, it was the same regardless of zoom. Maybe this is related to some other aspect.

It is a simple improvement, please test if you find problems with the change.

