### PR TITLE
cache measurements using WeakMap

### DIFF
--- a/packages/modeling/src/measurements/measureArea.js
+++ b/packages/modeling/src/measurements/measureArea.js
@@ -5,6 +5,8 @@ const geom3 = require('../geometries/geom3')
 const path2 = require('../geometries/path2')
 const poly3 = require('../geometries/poly3')
 
+const cache = new WeakMap()
+
 /*
  * Measure the area of the given geometry.
  * NOTE: paths are infinitely narrow and do not have an area
@@ -23,12 +25,14 @@ const measureAreaOfPath2 = () => 0
  * @returns {Number} area of the geometry
  */
 const measureAreaOfGeom2 = (geometry) => {
-  if (geometry.area) return geometry.area
+  if (cache.has(geometry)) return cache.get(geometry)
 
   const sides = geom2.toSides(geometry)
-  const area = sides.reduce((area, side) => area + (side[0][0] * side[1][1] - side[0][1] * side[1][0]), 0)
-  geometry.area = area * 0.5
-  return geometry.area
+  const area = 0.5 * sides.reduce((area, side) => area + (side[0][0] * side[1][1] - side[0][1] * side[1][0]), 0)
+
+  cache.set(geometry, area)
+
+  return area
 }
 
 /*
@@ -38,11 +42,14 @@ const measureAreaOfGeom2 = (geometry) => {
  * @returns {Number} area of the geometry
  */
 const measureAreaOfGeom3 = (geometry) => {
-  if (geometry.area) return geometry.area
+  if (cache.has(geometry)) return cache.get(geometry)
 
   const polygons = geom3.toPolygons(geometry)
-  geometry.area = polygons.reduce((area, polygon) => area + poly3.measureArea(polygon), 0)
-  return geometry.area
+  const area = polygons.reduce((area, polygon) => area + poly3.measureArea(polygon), 0)
+
+  cache.set(geometry, area)
+
+  return area
 }
 
 /**

--- a/packages/modeling/src/measurements/measureBoundingBox.js
+++ b/packages/modeling/src/measurements/measureBoundingBox.js
@@ -8,12 +8,14 @@ const geom3 = require('../geometries/geom3')
 const path2 = require('../geometries/path2')
 const poly3 = require('../geometries/poly3')
 
+const cache = new WeakMap()
+
 /*
  * Measure the min and max bounds of the given (path2) geometry.
  * @return {Array[]} the min and max bounds for the geometry
  */
 const measureBoundingBoxOfPath2 = (geometry) => {
-  if (geometry.boundingBox) return geometry.boundingBox
+  if (cache.has(geometry)) return cache.get(geometry)
 
   const points = path2.toPoints(geometry)
 
@@ -32,8 +34,11 @@ const measureBoundingBoxOfPath2 = (geometry) => {
   minpoint = [minpoint[0], minpoint[1], 0]
   maxpoint = [maxpoint[0], maxpoint[1], 0]
 
-  geometry.boundingBox = [minpoint, maxpoint]
-  return geometry.boundingBox
+  const boundingBox = [minpoint, maxpoint]
+
+  cache.set(geometry, boundingBox)
+
+  return boundingBox
 }
 
 /*
@@ -41,7 +46,7 @@ const measureBoundingBoxOfPath2 = (geometry) => {
  * @return {Array[]} the min and max bounds for the geometry
  */
 const measureBoundingBoxOfGeom2 = (geometry) => {
-  if (geometry.boundingBox) return geometry.boundingBox
+  if (cache.has(geometry)) return cache.get(geometry)
 
   const points = geom2.toPoints(geometry)
 
@@ -61,8 +66,11 @@ const measureBoundingBoxOfGeom2 = (geometry) => {
   minpoint = [minpoint[0], minpoint[1], 0]
   maxpoint = [maxpoint[0], maxpoint[1], 0]
 
-  geometry.boundingBox = [minpoint, maxpoint]
-  return geometry.boundingBox
+  const boundingBox = [minpoint, maxpoint]
+
+  cache.set(geometry, boundingBox)
+
+  return boundingBox
 }
 
 /*
@@ -70,7 +78,7 @@ const measureBoundingBoxOfGeom2 = (geometry) => {
  * @return {Array[]} the min and max bounds for the geometry
  */
 const measureBoundingBoxOfGeom3 = (geometry) => {
-  if (geometry.boundingBox) return geometry.boundingBox
+  if (cache.has(geometry)) return cache.get(geometry)
 
   const polygons = geom3.toPolygons(geometry)
 
@@ -91,8 +99,11 @@ const measureBoundingBoxOfGeom3 = (geometry) => {
   minpoint = [minpoint[0], minpoint[1], minpoint[2]]
   maxpoint = [maxpoint[0], maxpoint[1], maxpoint[2]]
 
-  geometry.boundingBox = [minpoint, maxpoint]
-  return geometry.boundingBox
+  const boundingBox = [minpoint, maxpoint]
+
+  cache.set(geometry, boundingBox)
+
+  return boundingBox
 }
 
 /**

--- a/packages/modeling/src/measurements/measureEpsilon.js
+++ b/packages/modeling/src/measurements/measureEpsilon.js
@@ -3,15 +3,20 @@ const calculateEpsilonFromBounds = require('./calculateEpsilonFromBounds')
 const { geom2, geom3, path2 } = require('../geometries')
 const measureBoundingBox = require('./measureBoundingBox')
 
+const cache = new WeakMap()
+
 /*
  * Measure the epsilon of the given (path2) geometry.
  * @return {Number} the epsilon (precision) of the geometry
  */
 const measureEpsilonOfPath2 = (geometry) => {
-  if (geometry.epsilon) return geometry.epsilon
+  if (cache.has(geometry)) return cache.get(geometry)
 
-  geometry.epsilon = calculateEpsilonFromBounds(measureBoundingBox(geometry), 2)
-  return geometry.epsilon
+  const epsilon = calculateEpsilonFromBounds(measureBoundingBox(geometry), 2)
+
+  cache.set(geometry, epsilon)
+
+  return epsilon
 }
 
 /*
@@ -19,10 +24,13 @@ const measureEpsilonOfPath2 = (geometry) => {
  * @return {Number} the epsilon (precision) of the geometry
  */
 const measureEpsilonOfGeom2 = (geometry) => {
-  if (geometry.epsilon) return geometry.epsilon
+  if (cache.has(geometry)) return cache.get(geometry)
 
-  geometry.epsilon = calculateEpsilonFromBounds(measureBoundingBox(geometry), 2)
-  return geometry.epsilon
+  const epsilon = calculateEpsilonFromBounds(measureBoundingBox(geometry), 2)
+
+  cache.set(geometry, epsilon)
+
+  return epsilon
 }
 
 /*
@@ -30,10 +38,13 @@ const measureEpsilonOfGeom2 = (geometry) => {
  * @return {Float} the epsilon (precision) of the geometry
  */
 const measureEpsilonOfGeom3 = (geometry) => {
-  if (geometry.epsilon) return geometry.epsilon
+  if (cache.has(geometry)) return cache.get(geometry)
 
-  geometry.epsilon = calculateEpsilonFromBounds(measureBoundingBox(geometry), 3)
-  return geometry.epsilon
+  const epsilon = calculateEpsilonFromBounds(measureBoundingBox(geometry), 3)
+
+  cache.set(geometry, epsilon)
+
+  return epsilon
 }
 
 /**

--- a/packages/modeling/src/measurements/measureVolume.js
+++ b/packages/modeling/src/measurements/measureVolume.js
@@ -5,6 +5,8 @@ const geom3 = require('../geometries/geom3')
 const path2 = require('../geometries/path2')
 const poly3 = require('../geometries/poly3')
 
+const cache = new WeakMap()
+
 /*
  * Measure the volume of the given geometry.
  * NOTE: paths are infinitely narrow and do not have an volume
@@ -30,11 +32,15 @@ const measureVolumeOfGeom2 = () => 0
  * @returns {Number} volume of the geometry
  */
 const measureVolumeOfGeom3 = (geometry) => {
-  if (geometry.volume) return geometry.volume
+  if (cache.has(geometry)) return cache.get(geometry)
 
   const polygons = geom3.toPolygons(geometry)
-  geometry.volume = polygons.reduce((volume, polygon) => volume + poly3.measureSignedVolume(polygon), 0)
-  return geometry.volume
+
+  const volume = polygons.reduce((volume, polygon) => volume + poly3.measureSignedVolume(polygon), 0)
+
+  cache.set(geometry, volume)
+
+  return volume
 }
 
 /**


### PR DESCRIPTION
here's a pull request to cache measurements using WeakMap references to object rather than mutating object. :cake: 

ref: https://github.com/jscad/OpenJSCAD.org/issues/562#issuecomment-734054731

i haven't run the whole performance suite for comparison yet, so far the numbers seem very slightly better but hard to tell if that's just random performance jitter. i do think this change makes the code cleaner and less surprising, but that's just my personal opinion so not sure if others agree.

### Checklist:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
