### PR TITLE
V2 : initial implementation of the built-in editor

### DIFF
--- a/packages/web/css/codemirror.css
+++ b/packages/web/css/codemirror.css
@@ -1,0 +1,349 @@
+/* BASICS */
+
+.CodeMirror {
+  /* Set height, width, borders, and global font properties here */
+  font-family: monospace;
+  height: 100%;
+  color: black;
+  direction: ltr;
+}
+
+/* PADDING */
+
+.CodeMirror-lines {
+  padding: 4px 0; /* Vertical padding around content */
+}
+.CodeMirror pre.CodeMirror-line,
+.CodeMirror pre.CodeMirror-line-like {
+  padding: 0 4px; /* Horizontal padding of content */
+}
+
+.CodeMirror-scrollbar-filler, .CodeMirror-gutter-filler {
+  background-color: white; /* The little square between H and V scrollbars */
+}
+
+/* GUTTER */
+
+.CodeMirror-gutters {
+  border-right: 1px solid #ddd;
+  background-color: #f7f7f7;
+  white-space: nowrap;
+}
+.CodeMirror-linenumbers {}
+.CodeMirror-linenumber {
+  padding: 0 3px 0 5px;
+  min-width: 20px;
+  text-align: right;
+  color: #999;
+  white-space: nowrap;
+}
+
+.CodeMirror-guttermarker { color: black; }
+.CodeMirror-guttermarker-subtle { color: #999; }
+
+/* CURSOR */
+
+.CodeMirror-cursor {
+  border-left: 1px solid black;
+  border-right: none;
+  width: 0;
+}
+/* Shown when moving in bi-directional text */
+.CodeMirror div.CodeMirror-secondarycursor {
+  border-left: 1px solid silver;
+}
+.cm-fat-cursor .CodeMirror-cursor {
+  width: auto;
+  border: 0 !important;
+  background: #7e7;
+}
+.cm-fat-cursor div.CodeMirror-cursors {
+  z-index: 1;
+}
+.cm-fat-cursor-mark {
+  background-color: rgba(20, 255, 20, 0.5);
+  -webkit-animation: blink 1.06s steps(1) infinite;
+  -moz-animation: blink 1.06s steps(1) infinite;
+  animation: blink 1.06s steps(1) infinite;
+}
+.cm-animate-fat-cursor {
+  width: auto;
+  border: 0;
+  -webkit-animation: blink 1.06s steps(1) infinite;
+  -moz-animation: blink 1.06s steps(1) infinite;
+  animation: blink 1.06s steps(1) infinite;
+  background-color: #7e7;
+}
+@-moz-keyframes blink {
+  0% {}
+  50% { background-color: transparent; }
+  100% {}
+}
+@-webkit-keyframes blink {
+  0% {}
+  50% { background-color: transparent; }
+  100% {}
+}
+@keyframes blink {
+  0% {}
+  50% { background-color: transparent; }
+  100% {}
+}
+
+/* Can style cursor different in overwrite (non-insert) mode */
+.CodeMirror-overwrite .CodeMirror-cursor {}
+
+.cm-tab { display: inline-block; text-decoration: inherit; }
+
+.CodeMirror-rulers {
+  position: absolute;
+  left: 0; right: 0; top: -50px; bottom: 0;
+  overflow: hidden;
+}
+.CodeMirror-ruler {
+  border-left: 1px solid #ccc;
+  top: 0; bottom: 0;
+  position: absolute;
+}
+
+/* DEFAULT THEME */
+
+.cm-s-default .cm-header {color: blue;}
+.cm-s-default .cm-quote {color: #090;}
+.cm-negative {color: #d44;}
+.cm-positive {color: #292;}
+.cm-header, .cm-strong {font-weight: bold;}
+.cm-em {font-style: italic;}
+.cm-link {text-decoration: underline;}
+.cm-strikethrough {text-decoration: line-through;}
+
+.cm-s-default .cm-keyword {color: #708;}
+.cm-s-default .cm-atom {color: #219;}
+.cm-s-default .cm-number {color: #164;}
+.cm-s-default .cm-def {color: #00f;}
+.cm-s-default .cm-variable,
+.cm-s-default .cm-punctuation,
+.cm-s-default .cm-property,
+.cm-s-default .cm-operator {}
+.cm-s-default .cm-variable-2 {color: #05a;}
+.cm-s-default .cm-variable-3, .cm-s-default .cm-type {color: #085;}
+.cm-s-default .cm-comment {color: #a50;}
+.cm-s-default .cm-string {color: #a11;}
+.cm-s-default .cm-string-2 {color: #f50;}
+.cm-s-default .cm-meta {color: #555;}
+.cm-s-default .cm-qualifier {color: #555;}
+.cm-s-default .cm-builtin {color: #30a;}
+.cm-s-default .cm-bracket {color: #997;}
+.cm-s-default .cm-tag {color: #170;}
+.cm-s-default .cm-attribute {color: #00c;}
+.cm-s-default .cm-hr {color: #999;}
+.cm-s-default .cm-link {color: #00c;}
+
+.cm-s-default .cm-error {color: #f00;}
+.cm-invalidchar {color: #f00;}
+
+.CodeMirror-composing { border-bottom: 2px solid; }
+
+/* Default styles for common addons */
+
+div.CodeMirror span.CodeMirror-matchingbracket {color: #0b0;}
+div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #a22;}
+.CodeMirror-matchingtag { background: rgba(255, 150, 0, .3); }
+.CodeMirror-activeline-background {background: #e8f2ff;}
+
+/* STOP */
+
+/* The rest of this file contains styles related to the mechanics of
+   the editor. You probably shouldn't touch them. */
+
+.CodeMirror {
+  position: relative;
+  overflow: hidden;
+  background: white;
+}
+
+.CodeMirror-scroll {
+  overflow: scroll !important; /* Things will break if this is overridden */
+  /* 50px is the magic margin used to hide the element's real scrollbars */
+  /* See overflow: hidden in .CodeMirror */
+  margin-bottom: -50px; margin-right: -50px;
+  padding-bottom: 50px;
+  height: 100%;
+  outline: none; /* Prevent dragging from highlighting the element */
+  position: relative;
+}
+.CodeMirror-sizer {
+  position: relative;
+  border-right: 50px solid transparent;
+}
+
+/* The fake, visible scrollbars. Used to force redraw during scrolling
+   before actual scrolling happens, thus preventing shaking and
+   flickering artifacts. */
+.CodeMirror-vscrollbar, .CodeMirror-hscrollbar, .CodeMirror-scrollbar-filler, .CodeMirror-gutter-filler {
+  position: absolute;
+  z-index: 6;
+  display: none;
+}
+.CodeMirror-vscrollbar {
+  right: 0; top: 0;
+  overflow-x: hidden;
+  overflow-y: scroll;
+}
+.CodeMirror-hscrollbar {
+  bottom: 0; left: 0;
+  overflow-y: hidden;
+  overflow-x: scroll;
+}
+.CodeMirror-scrollbar-filler {
+  right: 0; bottom: 0;
+}
+.CodeMirror-gutter-filler {
+  left: 0; bottom: 0;
+}
+
+.CodeMirror-gutters {
+  position: absolute; left: 0; top: 0;
+  min-height: 100%;
+  z-index: 3;
+}
+.CodeMirror-gutter {
+  white-space: normal;
+  height: 100%;
+  display: inline-block;
+  vertical-align: top;
+  margin-bottom: -50px;
+}
+.CodeMirror-gutter-wrapper {
+  position: absolute;
+  z-index: 4;
+  background: none !important;
+  border: none !important;
+}
+.CodeMirror-gutter-background {
+  position: absolute;
+  top: 0; bottom: 0;
+  z-index: 4;
+}
+.CodeMirror-gutter-elt {
+  position: absolute;
+  cursor: default;
+  z-index: 4;
+}
+.CodeMirror-gutter-wrapper ::selection { background-color: transparent }
+.CodeMirror-gutter-wrapper ::-moz-selection { background-color: transparent }
+
+.CodeMirror-lines {
+  cursor: text;
+  min-height: 1px; /* prevents collapsing before first draw */
+}
+.CodeMirror pre.CodeMirror-line,
+.CodeMirror pre.CodeMirror-line-like {
+  /* Reset some styles that the rest of the page might have set */
+  -moz-border-radius: 0; -webkit-border-radius: 0; border-radius: 0;
+  border-width: 0;
+  background: transparent;
+  font-family: inherit;
+  font-size: inherit;
+  margin: 0;
+  white-space: pre;
+  word-wrap: normal;
+  line-height: inherit;
+  color: inherit;
+  z-index: 2;
+  position: relative;
+  overflow: visible;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-font-variant-ligatures: contextual;
+  font-variant-ligatures: contextual;
+}
+.CodeMirror-wrap pre.CodeMirror-line,
+.CodeMirror-wrap pre.CodeMirror-line-like {
+  word-wrap: break-word;
+  white-space: pre-wrap;
+  word-break: normal;
+}
+
+.CodeMirror-linebackground {
+  position: absolute;
+  left: 0; right: 0; top: 0; bottom: 0;
+  z-index: 0;
+}
+
+.CodeMirror-linewidget {
+  position: relative;
+  z-index: 2;
+  padding: 0.1px; /* Force widget margins to stay inside of the container */
+}
+
+.CodeMirror-widget {}
+
+.CodeMirror-rtl pre { direction: rtl; }
+
+.CodeMirror-code {
+  outline: none;
+}
+
+/* Force content-box sizing for the elements where we expect it */
+.CodeMirror-scroll,
+.CodeMirror-sizer,
+.CodeMirror-gutter,
+.CodeMirror-gutters,
+.CodeMirror-linenumber {
+  -moz-box-sizing: content-box;
+  box-sizing: content-box;
+}
+
+.CodeMirror-measure {
+  position: absolute;
+  width: 100%;
+  height: 0;
+  overflow: hidden;
+  visibility: hidden;
+}
+
+.CodeMirror-cursor {
+  position: absolute;
+  pointer-events: none;
+}
+.CodeMirror-measure pre { position: static; }
+
+div.CodeMirror-cursors {
+  visibility: hidden;
+  position: relative;
+  z-index: 3;
+}
+div.CodeMirror-dragcursors {
+  visibility: visible;
+}
+
+.CodeMirror-focused div.CodeMirror-cursors {
+  visibility: visible;
+}
+
+.CodeMirror-selected { background: #d9d9d9; }
+.CodeMirror-focused .CodeMirror-selected { background: #d7d4f0; }
+.CodeMirror-crosshair { cursor: crosshair; }
+.CodeMirror-line::selection, .CodeMirror-line > span::selection, .CodeMirror-line > span > span::selection { background: #d7d4f0; }
+.CodeMirror-line::-moz-selection, .CodeMirror-line > span::-moz-selection, .CodeMirror-line > span > span::-moz-selection { background: #d7d4f0; }
+
+.cm-searching {
+  background-color: #ffa;
+  background-color: rgba(255, 255, 0, .4);
+}
+
+/* Used to force a border model for a node */
+.cm-force-border { padding-right: .1px; }
+
+@media print {
+  /* Hide the cursor when printing */
+  .CodeMirror div.CodeMirror-cursors {
+    visibility: hidden;
+  }
+}
+
+/* See issue #2901 */
+.cm-tab-wrap-hack:after { content: ''; }
+
+/* Help users use markselection to safely style text background */
+span.CodeMirror-selectedtext { background: none; }

--- a/packages/web/css/demo.css
+++ b/packages/web/css/demo.css
@@ -262,8 +262,7 @@ section.popup-menu {
   position: absolute;
   top: 40px;
   right: 15px;
-  max-width: 500px;
-  max-height: 70%;
+  height: 80%;
 }
 
 section.popup-menu h2 {
@@ -306,14 +305,17 @@ section.popup-menu ul {
 }
 
 #editor {
-  width: 50%;
-  height: 80%;
   padding: 1px;
   font-size: 0.9em;
+  width: 50%;
+}
+
+textarea {
+  height: inherit;
+  width: inherit;
 }
 
 #help {
-  height: 50%;
 }
 
 #help a {

--- a/packages/web/data/keybindings.json
+++ b/packages/web/data/keybindings.json
@@ -9,6 +9,6 @@
 
   {"key": "p", "command": "setProjectionType", "args": "perspective" },
   {"key": "o", "command": "setProjectionType", "args": "orthographic" },
-  {"key": "shift+enter", "command": "reEvaluateCode", "when": "editorTextFocus"},
-  {"key": "f5", "command": "reEvaluateCode", "when": "editorTextFocus"}
+
+  {"key": "shift+enter", "command": "editorCommand", "args": "reevaluate"}
 ]

--- a/packages/web/locales/de.json
+++ b/packages/web/locales/de.json
@@ -62,7 +62,8 @@
   "perspective":"Perspektive",
   "orthographic":"Orthographic",
 
-  "reEvaluateCode":"Reload script",
+  "editorCommand":"Editor command",
+  "reevaluate":"Kompilieren",
 
   "always":"Immer"
 }

--- a/packages/web/locales/en.json
+++ b/packages/web/locales/en.json
@@ -62,7 +62,8 @@
   "perspective":"Perspective",
   "orthographic":"Orthographic",
 
-  "reEvaluateCode":"Reload script",
+  "editorCommand":"Editor command",
+  "reevaluate":"Compile",
 
   "always":"Always"
 }

--- a/packages/web/locales/fr.json
+++ b/packages/web/locales/fr.json
@@ -62,7 +62,8 @@
   "perspective":"Perspective",
   "orthographic":"Orthographique",
 
-  "reEvaluateCode":"Reload script",
+  "editorCommand":"Éditeur commande",
+  "reevaluate":"Compiler",
 
-  "always":"Toujours",
+  "always":"Toujours"
 }

--- a/packages/web/locales/ja.json
+++ b/packages/web/locales/ja.json
@@ -62,7 +62,8 @@
   "perspective":"透視図",
   "orthographic":"正投影図",
 
-  "reEvaluateCode":"Reload script",
+  "editorCommand":"エディタ コマンド",
+  "reevaluate":"コンパイル",
 
   "Documentation":"ドキュメント",
   "User Guide":"ユーザー ガイド",

--- a/packages/web/src/index.js
+++ b/packages/web/src/index.js
@@ -106,6 +106,9 @@ async function makeJscad (targetElement, options) {
   // increase the count of jscad instances in this page
   instances += 1
 
+  setTimeout(() => { document.getElementById("toggleAxes").click() }, 100)
+  setTimeout(() => { document.getElementById("toggleAxes").click() }, 200)
+
   // we return a function to allow setting/modifying params
   const mainParams = observableUtils.callbackToObservable()
   // mainParams.stream.forEach(x => console.log('setting params', x))

--- a/packages/web/src/sideEffects/http/index.js
+++ b/packages/web/src/sideEffects/http/index.js
@@ -4,6 +4,8 @@ const path = require('path')
 const { callbackToObservable } = require('@jscad/core').observableUtils
 const { getFileExtensionFromString } = require('@jscad/core').utils
 
+const { formats } = require('@jscad/io/formats')
+
 const makeLogger = require('../../utils/logger')
 
 const XMLHttpRequest = window.XMLHttpRequest
@@ -106,7 +108,8 @@ const readFile = (url, onerror, onsucess) => {
       const name = path.basename(url)
       const fullPath = `/${name}` // fake path for fake filesystem lookup
       const ext = getFileExtensionFromString(fullPath)
-      const fileEntry = { name, ext, source, fullPath }
+      const mimetype = formats[ext] ? formats[ext].mimetype : ''
+      const fileEntry = { name, ext, mimetype, source, fullPath }
       onsucess(fileEntry)
     }
   }

--- a/packages/web/src/ui/flow/shortcuts.js
+++ b/packages/web/src/ui/flow/shortcuts.js
@@ -20,6 +20,7 @@ const reducers = {
   // set a specific shortcut
   setShortcut: (state, shortcutData) => {
     const alreadyExists = (key) => state.shortcuts.filter((shortcut) => shortcut.key === key).length > 0
+
     const shortcuts = state.shortcuts.map((shortcut) => {
       const match = shortcut.command === shortcutData.command && shortcut.args === shortcutData.args
       if (!match) {

--- a/packages/web/src/ui/flow/shortcuts.js
+++ b/packages/web/src/ui/flow/shortcuts.js
@@ -138,11 +138,12 @@ const actions = ({ sources }) => {
 
   // to make sure the key event was fired in the scope of the current jscad instance
   const myKey = sources.dom.element.getAttribute('key')
-  // FIXME: use dom source
-  const keyUps$ = most.fromEvent('keyup', document)
+
+  const keyUps$ = most.fromEvent('keyup', sources.dom.element)
     .filter((event) => isKeyEventScopeValid(myKey, event.target))
-    .multicast()// sources.dom.select(document).events('keyup') /
-  const keyDown$ = most.fromEvent('keydown', document)
+    .multicast()
+
+  const keyDown$ = most.fromEvent('keydown', sources.dom.element)
     .filter((event) => isKeyEventScopeValid(myKey, event.target))
     .multicast()
 

--- a/packages/web/src/ui/views/editor2.js
+++ b/packages/web/src/ui/views/editor2.js
@@ -22,7 +22,7 @@ let wrapper
 const createFileTree = (editor) => {
   const source = editor.getValue()
   if (source && source.length > 0) {
-    return [{ ext: 'js', fullPath: '/changes.js', mimetype: '', name: 'changes.js', source }]
+    return [{ ext: 'js', fullPath: '/changes.js', mimetype: 'javascript', name: 'changes.js', source }]
   }
   return null
 }

--- a/packages/web/src/ui/views/editor2.js
+++ b/packages/web/src/ui/views/editor2.js
@@ -1,61 +1,110 @@
 const html = require('nanohtml')
+
 const CodeMirror = require('codemirror')
-require('codemirror/addon/hint/show-hint')
+require('codemirror/mode/javascript/javascript')
 require('codemirror/addon/hint/javascript-hint')
 
-// const hint = require('./hint')
-// const hintJs = require('./hint-js')
+const editorOptions = {
+  mode: 'javascript',
+  indentUnit: 2,
+  smartIndent: false,
+  indentWithTabs: false,
+  lineNumbers: true,
+  autofocus: true
+}
 
-let cm
+let editor
+let wrapper
 
+/*
+ * Create a file tree from the contents of the editor
+ */
+const createFileTree = (editor) => {
+  const source = editor.getValue()
+  if (source && source.length > 0) {
+    return [{ ext: 'js', fullPath: '/changes.js', mimetype: '', name: 'changes.js', source }]
+  }
+  return null
+}
+
+/*
+ * Create a HTML wrapper for the editor (single instance)
+ */
+const createWrapper = (state, callbackToStream) => {
+  if (!wrapper) {
+    wrapper = html`
+    <section class='popup-menu' id='editor' key='editor' style='visibility:${state.activeTool === 'editor' ? 'visible' : 'hidden'}'>
+      <textarea></textarea>
+    </section>
+    `
+    wrapper.onkeydown = (e) => e.stopPropagation()
+    wrapper.onkeyup = (e) => e.stopPropagation()
+
+    // and add the editor
+    editor = CodeMirror.fromTextArea(wrapper.firstChild, editorOptions)
+    editor.setOption("extraKeys", {
+      Tab: (cm) => {
+        const spaces = Array(cm.getOption("indentUnit") + 1).join(" ")
+        cm.replaceSelection(spaces)
+      },
+      "Shift-Enter": (cm) => {
+        const fileTree = createFileTree(cm)
+        if (fileTree) callbackToStream.callback({ type: 'read', id: 'loadRemote', data: fileTree })
+      }
+    })
+
+    // inject style sheet for the editor
+    const head = document.getElementsByTagName('HEAD')[0]
+    const link = document.createElement('LINK')
+    link.rel = 'stylesheet'
+    link.href = './css/codemirror.css'
+    head.appendChild(link)
+  }
+  return wrapper
+}
+
+/*
+ * Create the editor wrapper for handling changes to file contents.
+ *
+ * Note: Only the contents of a single file are loaded into the editor. No projects.
+ * Note: Only the contents of javascript files are loaded into the editor. No external formats.
+ */
 const editorWrapper = (state, editorCallbackToStream) => {
-  const el = html`
-  <section class='popup-menu' id='editor' key='editor' style='visibility:${state.activeTool === 'editor' ? 'visible' : 'hidden'}'>
-  </section>`
-  // el.onadd = console.log.bind(console, 'button added to page!')
-  // el.onadd = console.log.bind(console, ' added to page!')
-  // el.onupdate = console.log.bind(console, ' updated in page!')
-  // el.ondiscard = console.log.bind(console, ' discarded from page!')
+  const el = createWrapper(state, editorCallbackToStream)
 
-  // console.log('el onupdate?', el.onupdate)
-  el.onupdate = function () {
-    // console.log('update')
-    cm.refresh()
-  }// console.log.bind(console, ' updated in page!')
+  // and adjust the state
+  if (state.activeTool === 'editor') {
+    el.style.visibility = 'visible'
+    el.focus()
 
-  CodeMirror.commands.autocomplete = (cm) => {
-    console.log('autocomplete')
-    const doc = cm.getDoc()
-    const POS = doc.getCursor()
-    const mode = CodeMirror.innerMode(cm.getMode(), cm.getTokenAt(POS).state).mode.name
+    editor.focus()
+    editor.scrollIntoView({line: 0, ch: 0})
+    // editor.refresh()
+  } else {
+    el.style.visibility = 'hidden'
+  }
 
-    console.log('foo', cm.getTokenAt(POS))
-    if (mode === 'xml') { // html depends on xml
-      CodeMirror.showHint(cm, CodeMirror.hint.html)
-    } else if (mode === 'javascript') {
-      CodeMirror.showHint(cm, CodeMirror.hint.javascript)
-    } else if (mode === 'css') {
-      CodeMirror.showHint(cm, CodeMirror.hint.css)
+  // and adjust the contents if any
+  if (state.design && state.design.filesAndFolders) {
+    if (state.design.filesAndFolders.length === 1) {
+      const file0 = state.design.filesAndFolders[0]
+      let source = file0.source ? file0.source : ''
+      if (file0.mimetype) {
+        if (file0.mimetype.indexOf('javascript') < 0) source = '// imported from external format'
+      } else {
+        source = '// imported from project'
+      }
+      const prevsource = editor.getValue()
+      if (source !== prevsource) {
+        editor.focus()
+        editor.setValue(source)
+        editor.setCursor(0, 0)
+        //editor.execCommand('goDocStart')
+        editor.refresh()
+      }
     }
   }
 
-  /* var onload = require('on-load')
-  onload(el, function (_el) {
-    console.log('in the dom')
-    cm = CodeMirror(_el, {
-      value: state.design.source,
-      mode: {name: 'javascript', globalVars: true},
-      // mode: 'javascript',
-      lineNumbers: true,
-      tabSize: 2,
-      theme: 'monokai',
-      smartIndent: true,
-      extraKeys: {'Ctrl-Space': 'autocomplete'}
-    })
-    cm.refresh()
-  }, function (el) {
-    console.log('out of the dom')
-  }) */
   return el
 }
 

--- a/packages/web/src/ui/views/shortcuts.js
+++ b/packages/web/src/ui/views/shortcuts.js
@@ -5,8 +5,9 @@ const shortcuts = (state, i18n) => {
   const bindingsList = keybindings.map((binding, index) => {
     const { command, key, args, tmpKey, error } = binding
 
-    // if we are in the midst of assigning a keypress (inProgress) display 'type & hit enter'
-    // if we already have a temporary key use that one instead
+    // if in the midst of assigning a keypress (inProgress) display placeholder
+    // OR
+    // if a temporary key has been assigned use that
     const placeholder = (tmpKey && tmpKey.length > 0) ? tmpKey : i18n.translate('type and hit enter')
     const value = binding.inProgress ? '' : key
 


### PR DESCRIPTION
These changes enable the editor for single file designs. The editor is based on the CodeMirror library, which supports various languages and options. This initial version has support for:
- javascript syntax only
- line numbers

There's no support for projects, so a small message is shown as a comment.
There's no support for conversions from STL to JSCAD source, etc, so a small message is shown as a comment.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Does your submission pass tests?

Additional testing performed manually across browsers.