### PR TITLE
Expose array utils

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,6 +1,8 @@
 {
   "source" : {
     "include": [
+      "packages/utils/array-utils/src",
+
       "packages/modeling/src/colors",
       "packages/modeling/src/curves/bezier",
       "packages/modeling/src/geometries",

--- a/packages/cli/cli.conversions.test.js
+++ b/packages/cli/cli.conversions.test.js
@@ -38,12 +38,13 @@ test.beforeEach(t => {
 // the script should produce ALL geometry types
 const createJscad = (id) => {
   const jscadScript = `// test script ${id}
+const { flatten } = require('@jscad/array-utils')
 const { primitives } = require('@jscad/modeling')
 
 const getParameterDefinitions = () => {
-  return [
+  return flatten([
     { name: 'segments', caption: 'Segements:', type: 'int', initial: 10, min: 5, max: 20, step: 1 }
-  ]
+  ])
 }
 
 const main = (params) => {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@jscad/core": "2.2.0",
     "@jscad/io": "2.0.2",
+    "@jscad/array-utils": "2.1.0",
     "@jscad/modeling": "2.1.0"
   },
   "devDependencies": {

--- a/packages/core/src/code-loading/webRequire.js
+++ b/packages/core/src/code-loading/webRequire.js
@@ -51,19 +51,18 @@ const makeWebRequire = (filesAndFolders, options) => {
   const apiModule = apiMainPath === '@jscad/modeling' ? require('@jscad/modeling') : require('./vtreeApi')
 
   // preset core modules
+  // FIXME this list of modules should be an option, replacing apiMainPath
   const coreModules = {
     '@jscad/io': {
       exports: require('@jscad/io')
     },
-    // ALIAS for now !!
-    '@jscad/api': {
-      exports: apiModule
+    '@jscad/array-utils': {
+      exports: require('@jscad/array-utils')
     },
     '@jscad/modeling': {
       exports: apiModule
     },
-    // fake fs module ! only useable with the currently available files & folders
-    // that have been drag & dropped / created
+    // expose the fake fs module
     fs: {
       exports: fakeFs
     }


### PR DESCRIPTION
These changes expose the array utilities. Designs can now require(''@jscad/array-utils) and use the available functions. This includes both CLI and WEB applications. (Part 2 of the re-organization of array utilities)

In addition, documentation for the API will be generated going forward.

NOTE: DO NOT SQUASH AS THERE ARE MULTIPLE COMMITS

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Does your submission pass tests?

Additional testing of the WEB application was performed manually.
