### PR TITLE
feat(modeling): new scission() function added to booleans

### DIFF
--- a/packages/modeling/src/operations/booleans/index.js
+++ b/packages/modeling/src/operations/booleans/index.js
@@ -8,6 +8,7 @@
  */
 module.exports = {
   intersect: require('./intersect'),
+  scission: require('./scission'),
   subtract: require('./subtract'),
   union: require('./union')
 }

--- a/packages/modeling/src/operations/booleans/scission.js
+++ b/packages/modeling/src/operations/booleans/scission.js
@@ -1,0 +1,43 @@
+const flatten = require('../../utils/flatten')
+
+// const geom2 = require('../../geometries/geom2')
+const geom3 = require('../../geometries/geom3')
+
+// const scissionGeom2 = require('./scissionGeom2')
+const scissionGeom3 = require('./scissionGeom3')
+
+/**
+ * Scission (divide) the given geometry into the component pieces.
+ *
+ * @param {...Object} geometries - list of geometries
+ * @returns {Array} list of pieces from each geometry
+ * @alias module:modeling/booleans.scission
+ *
+ * @example
+ * let figure = require('./my.stl')
+ * let pieces = scission(figure)
+ *
+ * @example
+ * +-------+            +-------+
+ * |       |            |       |
+ * |   +---+            | A +---+
+ * |   |    +---+   =   |   |    +---+
+ * +---+    |   |       +---+    |   |
+ *      +---+   |            +---+   |
+ *      |       |            |    B  |
+ *      +-------+            +-------+
+ */
+const scission = (...objects) => {
+  objects = flatten(objects)
+  if (objects.length === 0) throw new Error('wrong number of arguments')
+
+  const results = objects.map((object) => {
+    // if (path2.isA(object)) return path2.transform(matrix, object)
+    // if (geom2.isA(object)) return geom2.transform(matrix, object)
+    if (geom3.isA(object)) return scissionGeom3(object)
+    return object
+  })
+  return results.length === 1 ? results[0] : results
+}
+
+module.exports = scission

--- a/packages/modeling/src/operations/booleans/scission.test.js
+++ b/packages/modeling/src/operations/booleans/scission.test.js
@@ -1,0 +1,51 @@
+const test = require('ava')
+
+const { geom3 } = require('../../geometries')
+
+const { cube, torus } = require('../../primitives')
+
+const { scission, union } = require('./index')
+
+test('scission: scission of one or more geom3 objects produces expected geometry', (t) => {
+  const geometry1 = geom3.create()
+  const geometry2 = cube({ size: 5 })
+  const geometry3 = cube({ size: 5, center: [5, 5, 5] })
+
+  // scission of one object
+  const result1 = scission(geometry1)
+  t.is(result1.length, 0) // empty geometry, no pieces
+
+  // scission of three objects
+  const result2 = scission(geometry1, geometry2, geometry3)
+  t.is(result2.length, 3)
+  t.is(result2[0].length, 0)
+  t.is(result2[1].length, 1)
+  t.true(geom3.isA(result2[1][0]))
+  t.is(result2[2].length, 1)
+  t.true(geom3.isA(result2[2][0]))
+})
+
+test('scission: scission of complex geom3 produces expected geometry', (t) => {
+  const geometry1 = torus({ outerRadius: 40, innerRadius: 5, outerSegments: 16, innerSegments: 16 })
+  const geometry2 = torus({ outerRadius: 20, innerRadius: 5, outerSegments: 16, innerSegments: 16 })
+  const geometry3 = union(geometry1, geometry2)
+
+  const pc1 = geom3.toPolygons(geometry1).length
+  const pc2 = geom3.toPolygons(geometry2).length
+  const pc3 = geom3.toPolygons(geometry3).length
+
+  t.is(pc1, 512)
+  t.is(pc2, 512)
+  t.is(pc3, 512) // due to retessellate
+
+  const result1 = scission(geometry3)
+  t.is(result1.length, 2)
+  t.true(geom3.isA(result1[0]))
+  t.true(geom3.isA(result1[1]))
+
+  const rc1 = geom3.toPolygons(result1[0]).length
+  const rc2 = geom3.toPolygons(result1[1]).length
+
+  t.is(rc1, 256)
+  t.is(rc2, 256)
+})

--- a/packages/modeling/src/operations/booleans/scissionGeom3.js
+++ b/packages/modeling/src/operations/booleans/scissionGeom3.js
@@ -1,0 +1,93 @@
+const vec3 = require('../../maths/vec3')
+const measureEpsilon = require('../../measurements/measureEpsilon')
+
+const geom3 = require('../../geometries/geom3')
+
+// returns array numerically sorted and duplicates removed
+const sortNb = (array) => array.sort((a, b) => a - b).filter((item, pos, ary) => !pos || item !== ary[pos - 1])
+
+const insertMapping = (map, point, polygonIndex) => {
+  const key = `${point}`
+  const mapping = map.get(key)
+  if (mapping === undefined) {
+    map.set(key, [polygonIndex])
+  } else {
+    mapping.push(polygonIndex)
+  }
+}
+
+const findMapping = (map, point) => {
+  const key = `${point}`
+  return map.get(key)
+}
+
+const scissionGeom3 = (geometry) => {
+  // construit table de correspondance entre polygones
+  // build polygons lookup table
+  const eps = measureEpsilon(geometry)
+  const polygons = geom3.toPolygons(geometry)
+  const pl = polygons.length
+
+  const polygonIndexesPerPoint = new Map()
+  const temp = vec3.create()
+  polygons.forEach((polygon, polygonIndex) => {
+    polygon.vertices.forEach((point) => {
+      insertMapping(polygonIndexesPerPoint, vec3.snap(temp, point, eps), polygonIndex)
+    })
+  })
+
+  const zz = polygons.map((polygon, polygonIndex) => {
+    const indexes = []
+    polygon.vertices.forEach((point) => {
+      indexes.push(...findMapping(polygonIndexesPerPoint, vec3.snap(temp, point, eps)))
+    })
+    return { e: 1, d: sortNb(indexes) } // for each polygon, push the list of indexes
+  })
+
+  polygonIndexesPerPoint.clear()
+
+  // regroupe les correspondances des polygones se touchant
+  // boucle ne s'arrêtant que quand deux passages retournent le même nb de polygones
+  // merge lookup data from linked polygons as long as possible
+  let merges = 0
+  for (let i = 0; i < zz.length; i++) {
+    const mapi = zz[i]
+    // merge mappings if necessary
+    if (mapi.e > 0) {
+      const indexes = new Array(pl)
+      indexes[i] = true // include ourself
+      do {
+        merges = 0
+        // loop through the known indexes
+        indexes.forEach((e, j) => {
+          const mapj = zz[j]
+          // merge this mapping if necessary
+          if (mapj.e > 0) {
+            mapj.e = -1 // merged
+            for (let d = 0; d < mapj.d.length; d++) {
+              indexes[mapj.d[d]] = true
+            }
+            merges++
+          }
+        })
+      } while (merges > 0)
+      mapi.indexes = indexes
+    }
+  }
+
+  // construit le tableau des geometry à retourner
+  // build array of geometry to return
+  const newgeometries = []
+  const zzl = zz.length
+  for (let i = 0; i < zzl; i++) {
+    if (zz[i].indexes) {
+      const newpolygons = []
+      zz[i].indexes.forEach((e, p) => newpolygons.push(polygons[p]))
+      newgeometries.push(geom3.create(newpolygons))
+    }
+  }
+
+  return newgeometries
+}
+
+module.exports = scissionGeom3


### PR DESCRIPTION
These changes add a new function to the booleans, called scission(). This new function cuts/divideds/scissions the given geometry into component pieces.

This is useful to pull apart larger designs into pieces, especially STL mesh imports. As well as special times when the results of boolean operations need to be split into pieces. See #517 splitting of solid into pieces 

BIG THANKS to @giboneet for the initial implementation.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Does your submission pass tests?