### PR TITLE
reorg(modeling): changed to use caches (WeakMap) for measurements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "10"
   - "12"
   - "14"
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "10"
   - "12"
   - "14"
 sudo: false

--- a/packages/modeling/src/measurements/measureArea.js
+++ b/packages/modeling/src/measurements/measureArea.js
@@ -5,6 +5,8 @@ const geom3 = require('../geometries/geom3')
 const path2 = require('../geometries/path2')
 const poly3 = require('../geometries/poly3')
 
+const cache = new WeakMap()
+
 /*
  * Measure the area of the given geometry.
  * NOTE: paths are infinitely narrow and do not have an area
@@ -23,12 +25,16 @@ const measureAreaOfPath2 = () => 0
  * @returns {Number} area of the geometry
  */
 const measureAreaOfGeom2 = (geometry) => {
-  if (geometry.area) return geometry.area
+  let area = cache.get(geometry)
+  if (area) return area
 
   const sides = geom2.toSides(geometry)
-  const area = sides.reduce((area, side) => area + (side[0][0] * side[1][1] - side[0][1] * side[1][0]), 0)
-  geometry.area = area * 0.5
-  return geometry.area
+  area = sides.reduce((area, side) => area + (side[0][0] * side[1][1] - side[0][1] * side[1][0]), 0)
+  area *= 0.5
+
+  cache.set(geometry, area)
+
+  return area
 }
 
 /*
@@ -38,11 +44,15 @@ const measureAreaOfGeom2 = (geometry) => {
  * @returns {Number} area of the geometry
  */
 const measureAreaOfGeom3 = (geometry) => {
-  if (geometry.area) return geometry.area
+  let area = cache.get(geometry)
+  if (area) return area
 
   const polygons = geom3.toPolygons(geometry)
-  geometry.area = polygons.reduce((area, polygon) => area + poly3.measureArea(polygon), 0)
-  return geometry.area
+  area = polygons.reduce((area, polygon) => area + poly3.measureArea(polygon), 0)
+
+  cache.set(geometry, area)
+
+  return area
 }
 
 /**

--- a/packages/modeling/src/measurements/measureArea.js
+++ b/packages/modeling/src/measurements/measureArea.js
@@ -9,7 +9,6 @@ const cache = new WeakMap()
 
 /*
  * Measure the area of the given geometry.
- *
  * NOTE: paths are infinitely narrow and do not have an area
  *
  * @param {path2} geometry - geometry to measure

--- a/packages/modeling/src/measurements/measureArea.js
+++ b/packages/modeling/src/measurements/measureArea.js
@@ -9,6 +9,7 @@ const cache = new WeakMap()
 
 /*
  * Measure the area of the given geometry.
+ *
  * NOTE: paths are infinitely narrow and do not have an area
  *
  * @param {path2} geometry - geometry to measure

--- a/packages/modeling/src/measurements/measureBoundingBox.js
+++ b/packages/modeling/src/measurements/measureBoundingBox.js
@@ -8,12 +8,15 @@ const geom3 = require('../geometries/geom3')
 const path2 = require('../geometries/path2')
 const poly3 = require('../geometries/poly3')
 
+const cache = new WeakMap()
+
 /*
  * Measure the min and max bounds of the given (path2) geometry.
  * @return {Array[]} the min and max bounds for the geometry
  */
 const measureBoundingBoxOfPath2 = (geometry) => {
-  if (geometry.boundingBox) return geometry.boundingBox
+  let boundingBox = cache.get(geometry)
+  if (boundingBox) return boundingBox
 
   const points = path2.toPoints(geometry)
 
@@ -32,8 +35,11 @@ const measureBoundingBoxOfPath2 = (geometry) => {
   minpoint = [minpoint[0], minpoint[1], 0]
   maxpoint = [maxpoint[0], maxpoint[1], 0]
 
-  geometry.boundingBox = [minpoint, maxpoint]
-  return geometry.boundingBox
+  boundingBox = [minpoint, maxpoint]
+
+  cache.set(geometry, boundingBox)
+
+  return boundingBox
 }
 
 /*
@@ -41,7 +47,8 @@ const measureBoundingBoxOfPath2 = (geometry) => {
  * @return {Array[]} the min and max bounds for the geometry
  */
 const measureBoundingBoxOfGeom2 = (geometry) => {
-  if (geometry.boundingBox) return geometry.boundingBox
+  let boundingBox = cache.get(geometry)
+  if (boundingBox) return boundingBox
 
   const points = geom2.toPoints(geometry)
 
@@ -61,8 +68,11 @@ const measureBoundingBoxOfGeom2 = (geometry) => {
   minpoint = [minpoint[0], minpoint[1], 0]
   maxpoint = [maxpoint[0], maxpoint[1], 0]
 
-  geometry.boundingBox = [minpoint, maxpoint]
-  return geometry.boundingBox
+  boundingBox = [minpoint, maxpoint]
+
+  cache.set(geometry, boundingBox)
+
+  return boundingBox
 }
 
 /*
@@ -70,7 +80,8 @@ const measureBoundingBoxOfGeom2 = (geometry) => {
  * @return {Array[]} the min and max bounds for the geometry
  */
 const measureBoundingBoxOfGeom3 = (geometry) => {
-  if (geometry.boundingBox) return geometry.boundingBox
+  let boundingBox = cache.get(geometry)
+  if (boundingBox) return boundingBox
 
   const polygons = geom3.toPolygons(geometry)
 
@@ -91,8 +102,11 @@ const measureBoundingBoxOfGeom3 = (geometry) => {
   minpoint = [minpoint[0], minpoint[1], minpoint[2]]
   maxpoint = [maxpoint[0], maxpoint[1], maxpoint[2]]
 
-  geometry.boundingBox = [minpoint, maxpoint]
-  return geometry.boundingBox
+  boundingBox = [minpoint, maxpoint]
+
+  cache.set(geometry, boundingBox)
+
+  return boundingBox
 }
 
 /**

--- a/packages/modeling/src/measurements/measureEpsilon.js
+++ b/packages/modeling/src/measurements/measureEpsilon.js
@@ -1,6 +1,7 @@
 const flatten = require('../utils/flatten')
-const calculateEpsilonFromBounds = require('./calculateEpsilonFromBounds')
 const { geom2, geom3, path2 } = require('../geometries')
+
+const calculateEpsilonFromBounds = require('./calculateEpsilonFromBounds')
 const measureBoundingBox = require('./measureBoundingBox')
 
 /*
@@ -8,10 +9,7 @@ const measureBoundingBox = require('./measureBoundingBox')
  * @return {Number} the epsilon (precision) of the geometry
  */
 const measureEpsilonOfPath2 = (geometry) => {
-  if (geometry.epsilon) return geometry.epsilon
-
-  geometry.epsilon = calculateEpsilonFromBounds(measureBoundingBox(geometry), 2)
-  return geometry.epsilon
+  return calculateEpsilonFromBounds(measureBoundingBox(geometry), 2)
 }
 
 /*
@@ -19,10 +17,7 @@ const measureEpsilonOfPath2 = (geometry) => {
  * @return {Number} the epsilon (precision) of the geometry
  */
 const measureEpsilonOfGeom2 = (geometry) => {
-  if (geometry.epsilon) return geometry.epsilon
-
-  geometry.epsilon = calculateEpsilonFromBounds(measureBoundingBox(geometry), 2)
-  return geometry.epsilon
+  return calculateEpsilonFromBounds(measureBoundingBox(geometry), 2)
 }
 
 /*
@@ -30,10 +25,7 @@ const measureEpsilonOfGeom2 = (geometry) => {
  * @return {Float} the epsilon (precision) of the geometry
  */
 const measureEpsilonOfGeom3 = (geometry) => {
-  if (geometry.epsilon) return geometry.epsilon
-
-  geometry.epsilon = calculateEpsilonFromBounds(measureBoundingBox(geometry), 3)
-  return geometry.epsilon
+  return calculateEpsilonFromBounds(measureBoundingBox(geometry), 3)
 }
 
 /**

--- a/packages/modeling/src/measurements/measureVolume.js
+++ b/packages/modeling/src/measurements/measureVolume.js
@@ -5,6 +5,8 @@ const geom3 = require('../geometries/geom3')
 const path2 = require('../geometries/path2')
 const poly3 = require('../geometries/poly3')
 
+const cache = new WeakMap()
+
 /*
  * Measure the volume of the given geometry.
  * NOTE: paths are infinitely narrow and do not have an volume
@@ -30,11 +32,15 @@ const measureVolumeOfGeom2 = () => 0
  * @returns {Number} volume of the geometry
  */
 const measureVolumeOfGeom3 = (geometry) => {
-  if (geometry.volume) return geometry.volume
+  let volume = cache.get(geometry)
+  if (volume) return volume
 
   const polygons = geom3.toPolygons(geometry)
-  geometry.volume = polygons.reduce((volume, polygon) => volume + poly3.measureSignedVolume(polygon), 0)
-  return geometry.volume
+  volume = polygons.reduce((volume, polygon) => volume + poly3.measureSignedVolume(polygon), 0)
+
+  cache.set(geometry, volume)
+
+  return volume
 }
 
 /**


### PR DESCRIPTION
These changes update the measurements to use caches (WeakMap) instead of setting attributes on geometries. Previous performance tests have shown that the caches are just as fast as setting attributes.

NOTE: This is part of the effort of support users that want to set attributes, such as name or color.

Changes based on a previous PR #738 by @ahdinosaur 

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Does your submission pass tests?