### PR TITLE
fix(web): enhanced createContext() for older browsers

### DIFF
--- a/packages/web/src/ui/views/viewer.js
+++ b/packages/web/src/ui/views/viewer.js
@@ -195,7 +195,9 @@ const viewer = (state, i18n) => {
 const createContext = (canvas, contextAttributes) => {
   const get = (type) => {
     try {
-      return { gl: canvas.getContext(type, contextAttributes), type }
+      // NOTE: older browsers may return null from getContext()
+      const context = canvas.getContext(type)
+      return context ? { gl: context, type } : null
     } catch (e) {
       return null
     }


### PR DESCRIPTION
Upon testing the latest changes to master, an issue was found during testing Safari 12.0.2 (old version). The call to canvas.getContext() was returning 'null' rather then throwing an exception. This created an unusable canvas element.

https://en.wikipedia.org/wiki/Safari_(software)#Safari_15

These changes check the result of getContext(), which should allow older versions of browsers to detect the context correctly.

These changes have been tested with:
- Safari 12.0.2 Mac OS 10.14.2 and Safari 14.1.2 on Mac OS 10.14.6 (latest)
- Firefox 91.0.2
- Chrome 92.0.4515
- Explorer 92.0.902

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Does your submission pass tests?