### PR TITLE
Fix 912 concat and appendArc

### DIFF
--- a/packages/io/svg-deserializer/tests/instantiate.test.js
+++ b/packages/io/svg-deserializer/tests/instantiate.test.js
@@ -247,10 +247,10 @@ test('deserialize : instantiate svg (path: arc) to objects', (t) => {
   t.is(observed.length, 2)
   shape = observed[0]
   t.is(shape.points.length, 15) // segments double on a 3/4 circle
-  t.deepEqual(measurements.measureBoundingBox(shape), [[64.91110599999999, -77.611103, 0], [90.21850570104527, -52.30370029895471, 0]])
+  t.deepEqual(measurements.measureBoundingBox(shape), [[64.91110599999999, -77.611105, 0], [90.21850570104527, -52.30370029895471, 0]])
   shape = observed[1]
   t.is(shape.points.length, 15) // segments double on a 3/4 circle
-  t.deepEqual(measurements.measureBoundingBox(shape), [[50.79999599999999, -136.03302387090216, 0], [72.27222493929787, -110.6793647936299, 0]])
+  t.deepEqual(measurements.measureBoundingBox(shape), [[50.799996, -136.03302387090216, 0], [72.27222493929787, -110.6793647936299, 0]])
 })
 
 // ################################
@@ -434,16 +434,16 @@ test('deserialize : instantiate shape with a hole to objects', (t) => {
   let observed = deserializer.deserialize({ output: 'geometry', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(observed.length, 2)
   let shape = observed[0]
-  t.is(shape.sides.length, 39)
+  t.is(shape.sides.length, 38)
   shape = observed[1]
-  t.is(shape.sides.length, 39)
+  t.is(shape.sides.length, 38)
 
   observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 2)
   shape = observed[0]
-  t.is(shape.points.length, 39)
+  t.is(shape.points.length, 38)
   shape = observed[1]
-  t.is(shape.points.length, 39)
+  t.is(shape.points.length, 38)
 })
 
 // ################################
@@ -458,12 +458,12 @@ test('deserialize : instantiate shape with a nested hole to objects', (t) => {
   let observed = deserializer.deserialize({ output: 'geometry', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(observed.length, 4)
   let shape = observed[0]
-  t.is(shape.sides.length, 39)
+  t.is(shape.sides.length, 38)
 
   observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 4)
   shape = observed[0]
-  t.is(shape.points.length, 39)
+  t.is(shape.points.length, 38)
 })
 
 // ################################

--- a/packages/modeling/src/geometries/path2/appendArc.js
+++ b/packages/modeling/src/geometries/path2/appendArc.js
@@ -121,7 +121,7 @@ const appendArc = (options, geometry) => {
     // Ok, we have the center point and angle range (from theta1, deltatheta radians) so we can create the ellipse
     let numsteps = Math.ceil(Math.abs(deltatheta) / (2 * Math.PI) * segments) + 1
     if (numsteps < 1) numsteps = 1
-    for (let step = 1; step <= numsteps; step++) {
+    for (let step = 1; step < numsteps; step++) {
       const theta = theta1 + step / numsteps * deltatheta
       const costheta = Math.cos(theta)
       const sintheta = Math.sin(theta)
@@ -130,6 +130,8 @@ const appendArc = (options, geometry) => {
       vec2.add(point, point, center)
       newpoints.push(point)
     }
+    // ensure end point is precisely what user gave as parameter
+    if (numsteps) newpoints.push(options.endpoint)
   }
   newpoints = points.concat(newpoints)
   const result = fromPoints({}, newpoints)

--- a/packages/modeling/src/geometries/path2/appendArc.test.js
+++ b/packages/modeling/src/geometries/path2/appendArc.test.js
@@ -68,3 +68,19 @@ test('appendArc: appending to a path produces a new path', (t) => {
   pts = toPoints(obs)
   t.is(pts.length, 2)
 })
+
+test('appendArc: appending to a path produces exact endpoint', (t) => {
+  let p1 = fromPoints({}, [[18, 1.8], [1, 3]])
+  const endpoint = [1, -3]
+
+  p1 = appendArc({
+    endpoint,
+    radius: [4, 4],
+    segments: 36,
+    large: true
+  }, p1)
+
+  const pts = toPoints(p1)
+
+  t.deepEqual(pts[pts.length - 1], endpoint)
+})

--- a/packages/modeling/src/geometries/path2/concat.js
+++ b/packages/modeling/src/geometries/path2/concat.js
@@ -26,7 +26,7 @@ const concat = (...paths) => {
   let newpoints = []
   paths.forEach((path) => {
     const tmp = toPoints(path)
-    if (newpoints.length > 0 && equals(tmp[0], newpoints[newpoints.length - 1])) tmp.shift()
+    if (newpoints.length > 0 && tmp.length > 0 && equals(tmp[0], newpoints[newpoints.length - 1])) tmp.shift()
     newpoints = newpoints.concat(tmp)
   })
   return fromPoints({ closed: isClosed }, newpoints)

--- a/packages/modeling/src/geometries/path2/concat.js
+++ b/packages/modeling/src/geometries/path2/concat.js
@@ -1,8 +1,9 @@
 const fromPoints = require('./fromPoints')
 const toPoints = require('./toPoints')
-
+const equals = require('../../maths/vec2/equals')
 /**
  * Concatenate the given paths.
+ * If both contain the same point at the junction, merge it into one.
  * A concatenation of zero paths is an empty, open path.
  * A concatenation of one closed path to a series of open paths produces a closed path.
  * A concatenation of a path to a closed path is an error.
@@ -24,7 +25,9 @@ const concat = (...paths) => {
   }
   let newpoints = []
   paths.forEach((path) => {
-    newpoints = newpoints.concat(toPoints(path))
+    const tmp = toPoints(path)
+    if (newpoints.length > 0 && equals(tmp[0], newpoints[newpoints.length - 1])) tmp.shift()
+    newpoints = newpoints.concat(tmp)
   })
   return fromPoints({ closed: isClosed }, newpoints)
 }

--- a/packages/modeling/src/geometries/path2/concat.js
+++ b/packages/modeling/src/geometries/path2/concat.js
@@ -1,6 +1,6 @@
 const fromPoints = require('./fromPoints')
 const toPoints = require('./toPoints')
-const equals = require('../../maths/vec2/equals')
+const { equals } = require('../../maths/vec2')
 /**
  * Concatenate the given paths.
  * If both contain the same point at the junction, merge it into one.

--- a/packages/modeling/src/geometries/path2/concat.test.js
+++ b/packages/modeling/src/geometries/path2/concat.test.js
@@ -6,6 +6,10 @@ test('concat: No paths produces an empty open path', (t) => {
   t.true(equals(concat(), fromPoints({ closed: false }, [])))
 })
 
+test('concat: empty paths produces an empty open path', (t) => {
+  t.true(equals(concat(fromPoints({}, []), fromPoints({}, [])), fromPoints({ closed: false }, [])))
+})
+
 test('concat: Two open paths produces a open path', (t) => {
   t.true(equals(concat(fromPoints({ closed: false }, [[0, 0]]),
     fromPoints({ closed: false }, [[1, 1]])),


### PR DESCRIPTION
fixes #912 
there is duplicate point at the joint, but not 100% equal `[1, -3]` vs `[0.9999999999999978, -3.0000000000000018]`


First issue is that path2.concat does not remove duplicate point when adding paths

Second issue is that appendArc does not produce the exact same endpoint as user asked for.

On route is to fix equality check using epsilon, and other is to force appendArc to respect the desired endpoint.

This PR  forces appendArc to respect the desired endpoint.


### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?