### PR TITLE
fix(modeling): corrected vec2.rotate, and enhanced test cases

### DIFF
--- a/packages/modeling/src/maths/utils/clamp.d.ts
+++ b/packages/modeling/src/maths/utils/clamp.d.ts
@@ -1,3 +1,0 @@
-export default clamp
-
-declare function clamp(value: number, min: number, max: number): number

--- a/packages/modeling/src/maths/utils/clamp.js
+++ b/packages/modeling/src/maths/utils/clamp.js
@@ -1,4 +1,0 @@
-
-const clamp = (value, min, max) => Math.min(Math.max(value, min), max)
-
-module.exports = clamp

--- a/packages/modeling/src/maths/utils/index.d.ts
+++ b/packages/modeling/src/maths/utils/index.d.ts
@@ -1,6 +1,5 @@
 export { default as aboutEqualNormals } from './aboutEqualNormals'
 export { default as area } from './area'
-export { default as clamp } from './clamp'
 export { default as interpolateBetween2DPointsForY } from './interpolateBetween2DPointsForY'
 export { default as intersect } from './intersect'
 export { default as solve2Linear } from './solve2Linear'

--- a/packages/modeling/src/maths/utils/index.js
+++ b/packages/modeling/src/maths/utils/index.js
@@ -7,7 +7,6 @@
 module.exports = {
   aboutEqualNormals: require('./aboutEqualNormals'),
   area: require('./area'),
-  clamp: require('./clamp'),
   interpolateBetween2DPointsForY: require('./interpolateBetween2DPointsForY'),
   intersect: require('./intersect'),
   solve2Linear: require('./solve2Linear')

--- a/packages/modeling/src/maths/utils/quantizeForSpace.d.ts
+++ b/packages/modeling/src/maths/utils/quantizeForSpace.d.ts
@@ -1,3 +1,0 @@
-export default quantizeForSpace
-
-declare function quantizeForSpace(value: number): number

--- a/packages/modeling/src/maths/utils/quantizeForSpace.js
+++ b/packages/modeling/src/maths/utils/quantizeForSpace.js
@@ -1,6 +1,0 @@
-const { spatialResolution } = require('../constants')
-
-// Quantize values for use in spatial coordinates, and so on.
-const quantizeForSpace = (value) => (Math.round(value * spatialResolution) / spatialResolution)
-
-module.exports = quantizeForSpace

--- a/packages/modeling/src/maths/vec2/rotate.js
+++ b/packages/modeling/src/maths/vec2/rotate.js
@@ -10,7 +10,7 @@
  */
 const rotate = (out, vector, origin, radians) => {
   const x = vector[0] - origin[0]
-  const y = vector[1] - origin[0]
+  const y = vector[1] - origin[1]
   const c = Math.cos(radians)
   const s = Math.sin(radians)
 

--- a/packages/modeling/src/maths/vec2/rotate.test.js
+++ b/packages/modeling/src/maths/vec2/rotate.test.js
@@ -22,7 +22,7 @@ test('vec2: rotate() called with three paramerters should update a vec2 with cor
   t.true(compareVectors(ret3, [2, -1], 1e-15))
 
   const obs4 = fromValues(0, 0)
-  const ret4 = rotate(obs4, [-1, 2], [0, 0], -radians)
-  t.true(compareVectors(obs4, [2, 1], 1e-15))
-  t.true(compareVectors(ret4, [2, 1], 1e-15))
+  const ret4 = rotate(obs4, [-1, 2], [-3, -3], -radians)
+  t.true(compareVectors(obs4, [2, -5], 1e-15))
+  t.true(compareVectors(ret4, [2, -5], 1e-15))
 })


### PR DESCRIPTION
I found this little bug while looking at some examples.

In addition, clamp and quantitzeForSpace were dropped from math/utils as these functions are not used / supported.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Does your submission pass tests?