### PR TITLE
Preserve color across transforms

### DIFF
--- a/packages/modeling/src/geometries/geom2/transform.js
+++ b/packages/modeling/src/geometries/geom2/transform.js
@@ -16,6 +16,9 @@ const create = require('./create')
  */
 const transform = (matrix, geometry) => {
   const newgeometry = create(geometry.sides) // reuse the sides
+  if (geometry.color) {
+    newgeometry.color = geometry.color
+  }
 
   mat4.multiply(newgeometry.transforms, matrix, geometry.transforms)
   return newgeometry

--- a/packages/modeling/src/geometries/geom3/transform.js
+++ b/packages/modeling/src/geometries/geom3/transform.js
@@ -17,6 +17,9 @@ const create = require('./create')
 const transform = (matrix, geometry) => {
   const newgeometry = create(geometry.polygons) // reuse the polygons
   newgeometry.isRetesselated = geometry.isRetesselated
+  if (geometry.color) {
+    newgeometry.color = geometry.color
+  }
 
   mat4.multiply(newgeometry.transforms, matrix, geometry.transforms)
   return newgeometry

--- a/packages/modeling/src/geometries/path2/transform.js
+++ b/packages/modeling/src/geometries/path2/transform.js
@@ -17,6 +17,9 @@ const create = require('./create')
 const transform = (matrix, geometry) => {
   const newgeometry = create(geometry.points) // reuse the points
   newgeometry.isClosed = geometry.isClosed
+  if (geometry.color) {
+    newgeometry.color = geometry.color
+  }
 
   mat4.multiply(newgeometry.transforms, matrix, geometry.transforms)
   return newgeometry


### PR DESCRIPTION
Fixes #594 - V2 color lost if translate sphere

Transform operations preserve the underlying polygons but not the color. It's understandable that boolean operations should reset the color, but for simple transformations it makes sense to preserve color. This is especially helpful when making copies of objects that will be placed in a scene. Example:

```
const jscad = require('@jscad/modeling')
const { colorize, cssColors } = jscad.colors
const { sphere } = jscad.primitives
const { translate } = jscad.transforms

function main() {
  const eye = [
    colorize(cssColors.darkgreen, sphere({center: [0, 3, 0], radius: 2})),
    colorize(cssColors.white, sphere({radius: 4})),
  ]
  return [
    eye,
    translate([10, 0, 0], eye)
  ]
}

module.exports = { main }
```

Before:

![before](https://user-images.githubusercontent.com/1766297/135697493-aa6f3de9-ff69-4b02-9094-ede51504cc1b.png)

After:

![after](https://user-images.githubusercontent.com/1766297/135697497-92114069-e5a5-482f-ade5-923b18bf2379.png)

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?


> Note: please do NOT include build files (those generate by the build-xxx commands) with your PR,

Thank you for your help in advance, much appreciated !
