### PR TITLE
Fix DXF serialization for near-black colors

### DIFF
--- a/packages/io/dxf-serializer/index.js
+++ b/packages/io/dxf-serializer/index.js
@@ -462,7 +462,7 @@ const getColorNumber = (object, options) => {
     // find the closest Autocad color number
     const index = options.colorIndex
     let closest = 255 + 255 + 255
-    for (let i = 0; i < index.length; i++) {
+    for (let i = 1; i < index.length; i++) {
       const rgb = index[i]
       const diff = Math.abs(r - rgb[0]) + Math.abs(g - rgb[1]) + Math.abs(b - rgb[2])
       if (diff < closest) {


### PR DESCRIPTION
I was exporting my jscad designs with color, and everything was working except the color black (also near-black colors since dxf is paletted)

For example:

```
const { colorize, cssColors } = require('@jscad/modeling').colors
const { cuboid } = require('@jscad/modeling').primitives

function main() {
  return colorize([0, 0, 0], cuboid({}))
}

module.exports = { main }
```

Load the js directly into jscad and the color works:

![black](https://user-images.githubusercontent.com/1766297/135707023-0774176f-0530-4c06-977d-94d7dfac8769.png)

But if you export it to a DXF file and then open that DXF file in jscad you see:

![blue](https://user-images.githubusercontent.com/1766297/135707043-d9778567-a5dc-4004-9ced-f09d36127514.png)

Investigation showed that `getColorNumber` in the [serializer](https://github.com/jscad/OpenJSCAD.org/blob/master/packages/io/dxf-serializer/index.js#L465) was searching from 0 to 255 through the color index. However the [deserializer](https://github.com/jscad/OpenJSCAD.org/blob/master/packages/io/dxf-deserializer/helpers.js#L54) requires that the index be at least 1.

It appears that colorindex 0 was just added as a convenience but was not intended to be used. colorindex 250 is also black [0,0,0] and works when deserialized too. So I just changed the serializer here.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?


> Note: please do NOT include build files (those generate by the build-xxx commands) with your PR,

Thank you for your help in advance, much appreciated !
