### PR TITLE
fix(modeling): change geometry transforms to preserve user attributes

### DIFF
--- a/packages/modeling/src/colors/colorize.js
+++ b/packages/modeling/src/colors/colorize.js
@@ -52,10 +52,10 @@ const colorize = (color, ...objects) => {
   if (objects.length === 0) throw new Error('wrong number of arguments')
 
   const results = objects.map((object) => {
-    if (geom2.isA(object)) return colorGeom2(color, object)
-    if (geom3.isA(object)) return colorGeom3(color, object)
-    if (path2.isA(object)) return colorPath2(color, object)
-    if (poly3.isA(object)) return colorPoly3(color, object)
+    // if (geom2.isA(object)) return colorGeom2(color, object)
+    // if (geom3.isA(object)) return colorGeom3(color, object)
+    // if (path2.isA(object)) return colorPath2(color, object)
+    // if (poly3.isA(object)) return colorPoly3(color, object)
 
     object.color = color
     return object

--- a/packages/modeling/src/colors/colorize.test.js
+++ b/packages/modeling/src/colors/colorize.test.js
@@ -43,23 +43,15 @@ test('color (rgba on geometry)', (t) => {
   const obs = colorize([1, 1, 0.5, 0.8], obj0, obj1, obj2, obj3)
   t.is(obs.length, 4)
 
-  let exp = geom2.clone(obj0)
-  exp.color = [1, 1, 0.5, 0.8]
-  t.not(obj0, obs[0])
-  t.deepEqual(obs[0], exp)
+  t.is(obj0, obs[0])
+  t.deepEqual(obs[0].color, [1, 1, 0.5, 0.8])
 
-  exp = geom3.clone(obj1)
-  exp.color = [1, 1, 0.5, 0.8]
-  t.not(obj1, obs[1])
-  t.deepEqual(obs[1], exp)
+  t.is(obj1, obs[1])
+  t.deepEqual(obs[1].color, [1, 1, 0.5, 0.8])
 
-  exp = path2.clone(obj2)
-  exp.color = [1, 1, 0.5, 0.8]
-  t.not(obj2, obs[2])
-  t.deepEqual(obs[2], exp)
+  t.is(obj2, obs[2])
+  t.deepEqual(obs[2].color, [1, 1, 0.5, 0.8])
 
-  exp = poly3.clone(obj3)
-  exp.color = [1, 1, 0.5, 0.8]
-  t.not(obj3, obs[3])
-  t.deepEqual(obs[3], exp)
+  t.is(obj3, obs[3])
+  t.deepEqual(obs[3].color, [1, 1, 0.5, 0.8])
 })

--- a/packages/modeling/src/geometries/geom2/applyTransforms.js
+++ b/packages/modeling/src/geometries/geom2/applyTransforms.js
@@ -19,7 +19,7 @@ const applyTransforms = (geometry) => {
     const p1 = vec2.transform(vec2.create(), side[1], geometry.transforms)
     return [p0, p1]
   })
-  mat4.identity(geometry.transforms)
+  geometry.transforms = mat4.create()
   return geometry
 }
 

--- a/packages/modeling/src/geometries/geom2/transform.js
+++ b/packages/modeling/src/geometries/geom2/transform.js
@@ -15,10 +15,8 @@ const create = require('./create')
  * let newgeometry = transform(fromZRotation(degToRad(90)), geometry)
  */
 const transform = (matrix, geometry) => {
-  const newgeometry = create(geometry.sides) // reuse the sides
-
-  mat4.multiply(newgeometry.transforms, matrix, geometry.transforms)
-  return newgeometry
+  const transforms = mat4.multiply(mat4.create(), matrix, geometry.transforms)
+  return Object.assign({}, geometry, { transforms })
 }
 
 module.exports = transform

--- a/packages/modeling/src/geometries/geom3/applyTransforms.js
+++ b/packages/modeling/src/geometries/geom3/applyTransforms.js
@@ -17,7 +17,7 @@ const applyTransforms = (geometry) => {
   // const isMirror = mat4.isMirroring(geometry.transforms)
   // TBD if (isMirror) newvertices.reverse()
   geometry.polygons = geometry.polygons.map((polygon) => poly3.transform(geometry.transforms, polygon))
-  mat4.identity(geometry.transforms)
+  geometry.transforms = mat4.create()
   return geometry
 }
 

--- a/packages/modeling/src/geometries/geom3/transform.js
+++ b/packages/modeling/src/geometries/geom3/transform.js
@@ -15,11 +15,8 @@ const create = require('./create')
  * let newgeometry = transform(fromXRotation(degToRad(90)), geometry)
  */
 const transform = (matrix, geometry) => {
-  const newgeometry = create(geometry.polygons) // reuse the polygons
-  newgeometry.isRetesselated = geometry.isRetesselated
-
-  mat4.multiply(newgeometry.transforms, matrix, geometry.transforms)
-  return newgeometry
+  const transforms = mat4.multiply(mat4.create(), matrix, geometry.transforms)
+  return Object.assign({}, geometry, { transforms })
 }
 
 module.exports = transform

--- a/packages/modeling/src/geometries/path2/applyTransforms.js
+++ b/packages/modeling/src/geometries/path2/applyTransforms.js
@@ -13,7 +13,7 @@ const applyTransforms = (geometry) => {
   if (mat4.isIdentity(geometry.transforms)) return geometry
 
   geometry.points = geometry.points.map((point) => vec2.transform(vec2.create(), point, geometry.transforms))
-  mat4.identity(geometry.transforms)
+  geometry.transforms = mat4.create()
   return geometry
 }
 

--- a/packages/modeling/src/geometries/path2/transform.js
+++ b/packages/modeling/src/geometries/path2/transform.js
@@ -15,11 +15,8 @@ const create = require('./create')
  * let newpath = transform(fromZRotation(Math.PI / 4), path)
  */
 const transform = (matrix, geometry) => {
-  const newgeometry = create(geometry.points) // reuse the points
-  newgeometry.isClosed = geometry.isClosed
-
-  mat4.multiply(newgeometry.transforms, matrix, geometry.transforms)
-  return newgeometry
+  const transforms = mat4.multiply(mat4.create(), matrix, geometry.transforms)
+  return Object.assign({}, geometry, { transforms })
 }
 
 module.exports = transform


### PR DESCRIPTION
This is another try at retaining user attributes after transforming geometries. The changes are based on several attempts (See other PRs) and analysis below.

The changes are minimal, and all tests pass without changes. Except the tests for colorize() which was changed.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Does your submission pass tests?