### PR TITLE
fix(modeling): Compute face normals from average of all vertex normals

### DIFF
--- a/packages/modeling/src/geometries/poly3/faceNormal.d.ts
+++ b/packages/modeling/src/geometries/poly3/faceNormal.d.ts
@@ -1,0 +1,5 @@
+import Vec3 from '../../maths/vec3/type'
+
+export default faceNormal
+
+declare function faceNormal(vertices: Array<Vec3>): Vec3

--- a/packages/modeling/src/geometries/poly3/faceNormal.js
+++ b/packages/modeling/src/geometries/poly3/faceNormal.js
@@ -1,0 +1,39 @@
+const vec3 = require('../../maths/vec3')
+
+/**
+ * Calculate normal vector for a single vertex.
+ */
+const vertexNormal = (vertices, index) => {
+  const a = vertices[index]
+  const b = vertices[(index + 1) % vertices.length]
+  const c = vertices[(index + 2) % vertices.length]
+  const ba = vec3.subtract(vec3.create(), b, a)
+  const ca = vec3.subtract(vec3.create(), c, a)
+  vec3.cross(ba, ba, ca)
+  vec3.normalize(ba, ba)
+  return ba
+}
+
+/**
+ * Calculate normal vector for a face.
+ * The normal vector is not always well defined.
+ * A polygon may be non-planar. Vertices may be colinear.
+ * To handle these cases we compute the average of the vertex normals.
+ */
+const faceNormal = (vertices) => {
+  if (vertices.length === 3) {
+    // optimization for triangles, which are always coplanar
+    return vertexNormal(vertices, 1)
+  } else {
+    // average of vertex normals
+    const normal = vec3.create()
+    vertices.forEach((v, i) => {
+      vec3.add(normal, normal, vertexNormal(vertices, i))
+    })
+    // renormalize normal vector
+    vec3.normalize(normal, normal)
+    return normal
+  }
+}
+
+module.exports = faceNormal

--- a/packages/modeling/src/geometries/poly3/faceNormal.js
+++ b/packages/modeling/src/geometries/poly3/faceNormal.js
@@ -1,34 +1,38 @@
 const vec3 = require('../../maths/vec3')
 
-/**
- * Calculate normal vector for a single vertex.
- */
-const vertexNormal = (vertices, index) => {
-  const a = vertices[index]
-  const b = vertices[(index + 1) % vertices.length]
-  const c = vertices[(index + 2) % vertices.length]
-  const ba = vec3.subtract(vec3.create(), b, a)
-  const ca = vec3.subtract(vec3.create(), c, a)
-  vec3.cross(ba, ba, ca)
-  vec3.normalize(ba, ba)
-  return ba
-}
 
 /**
  * Calculate normal vector for a face.
  * The normal vector is not always well defined.
  * A polygon may be non-planar. Vertices may be colinear.
- * To handle these cases we compute the average of the vertex normals.
+ * To handle these cases we compute the average vertex normal.
  */
 const faceNormal = (vertices) => {
-  if (vertices.length === 3) {
+  const len = vertices.length
+
+  // Calculate normal vector for a single vertex
+  // Inline to avoid allocations
+  const ba = vec3.create()
+  const ca = vec3.create()
+  const vertexNormal = (index) => {
+    const a = vertices[index]
+    const b = vertices[(index + 1) % len]
+    const c = vertices[(index + 2) % len]
+    vec3.subtract(ba, b, a) // ba = b - a
+    vec3.subtract(ca, c, a) // ca = c - a
+    vec3.cross(ba, ba, ca) // ba = ba x ca
+    vec3.normalize(ba, ba)
+    return ba
+  }
+
+  if (len === 3) {
     // optimization for triangles, which are always coplanar
-    return vertexNormal(vertices, 1)
+    return vertexNormal(0)
   } else {
-    // average of vertex normals
+    // sum of vertex normals
     const normal = vec3.create()
     vertices.forEach((v, i) => {
-      vec3.add(normal, normal, vertexNormal(vertices, i))
+      vec3.add(normal, normal, vertexNormal(i))
     })
     // renormalize normal vector
     vec3.normalize(normal, normal)

--- a/packages/modeling/src/geometries/poly3/faceNormal.test.js
+++ b/packages/modeling/src/geometries/poly3/faceNormal.test.js
@@ -1,0 +1,38 @@
+const test = require('ava')
+
+const faceNormal = require('./faceNormal')
+
+test('poly3: faceNormal() should return a new vec3 with correct values', (t) => {
+  // simple triangle
+  t.deepEqual(
+    faceNormal([
+      [ 0, 0, 0 ],
+      [ 2, 0, 0 ],
+      [ 0, 1, 0 ],
+    ], 0),
+    [0, 0, 1]
+  )
+
+  // colinear vertices
+  t.deepEqual(
+    faceNormal([
+      [ 0, 0, 0 ],
+      [ 1, 0, 0 ],
+      [ 2, 0, 0 ],
+      [ 0, 1, 0 ],
+    ], 0),
+    [0, 0, 1]
+  )
+
+  // duplicate vertices
+  t.deepEqual(
+    faceNormal([
+      [ 0, 0, 0 ],
+      [ 0, 0, 0 ],
+      [ 0, 0, 0 ],
+      [ 2, 0, 0 ],
+      [ 0, 1, 0 ],
+    ], 0),
+    [0, 0, 1]
+  )
+})

--- a/packages/modeling/src/geometries/poly3/measureArea.js
+++ b/packages/modeling/src/geometries/poly3/measureArea.js
@@ -1,4 +1,5 @@
 const vec3 = require('../../maths/vec3')
+const faceNormal = require('./faceNormal')
 
 /**
  * Measure the area of the given polygon.
@@ -14,19 +15,13 @@ const measureArea = (poly3) => {
   }
   const vertices = poly3.vertices
 
-  // calculate a real normal
-  const a = vertices[0]
-  const b = vertices[1]
-  const c = vertices[2]
-  const ba = vec3.subtract(vec3.create(), b, a)
-  const ca = vec3.subtract(vec3.create(), c, a)
-  const normal = vec3.cross(ba, ba, ca)
+  // calculate a normal vector
+  const normal = faceNormal(vertices)
 
-  // determin direction of projection
+  // determine direction of projection
   const ax = Math.abs(normal[0])
   const ay = Math.abs(normal[1])
   const az = Math.abs(normal[2])
-  const an = Math.sqrt((ax * ax) + (ay * ay) + (az * az)) // length of normal
 
   let coord = 3 // ignore Z coordinates
   if ((ax > ay) && (ax > az)) {
@@ -50,7 +45,7 @@ const measureArea = (poly3) => {
       }
       area += (vertices[0][1] * (vertices[1][2] - vertices[n - 1][2]))
       // scale to get area
-      area *= (an / (2 * normal[0]))
+      area /= (2 * normal[0])
       break
 
     case 2: // ignore Y coordinates
@@ -62,7 +57,7 @@ const measureArea = (poly3) => {
       }
       area += (vertices[0][2] * (vertices[1][0] - vertices[n - 1][0]))
       // scale to get area
-      area *= (an / (2 * normal[1]))
+      area /= (2 * normal[1])
       break
 
     case 3: // ignore Z coordinates
@@ -75,7 +70,7 @@ const measureArea = (poly3) => {
       }
       area += (vertices[0][0] * (vertices[1][1] - vertices[n - 1][1]))
       // scale to get area
-      area *= (an / (2 * normal[2]))
+      area /= (2 * normal[2])
       break
   }
   return area

--- a/packages/modeling/src/geometries/poly3/measureArea.js
+++ b/packages/modeling/src/geometries/poly3/measureArea.js
@@ -23,6 +23,11 @@ const measureArea = (poly3) => {
   const ay = Math.abs(normal[1])
   const az = Math.abs(normal[2])
 
+  if (ax + ay + az === 0) {
+    // normal does not exist
+    return 0
+  }
+
   let coord = 3 // ignore Z coordinates
   if ((ax > ay) && (ax > az)) {
     coord = 1 // ignore X coordinates

--- a/packages/modeling/src/geometries/poly3/measureArea.test.js
+++ b/packages/modeling/src/geometries/poly3/measureArea.test.js
@@ -37,10 +37,20 @@ test('poly3: measureArea() should return correct values', (t) => {
   let ret4 = measureArea(ply4)
   t.is(ret4, 19.5)
 
-  // colinear vertices
+  // colinear vertices non-zero area
   let ply5 = fromPoints([[0, 0, 0], [1, 0, 0], [2, 0, 0], [0, 1, 0]])
   let ret5 = measureArea(ply5)
   t.is(ret5, 1)
+
+  // colinear vertices empty area
+  let ply6 = fromPoints([[0, 0, 0], [1, 0, 0], [2, 0, 0]])
+  let ret6 = measureArea(ply6)
+  t.is(ret6, 0)
+
+  // duplicate vertices empty area
+  let ply7 = fromPoints([[0, 0, 0], [0, 0, 0], [0, 0, 0]])
+  let ret7 = measureArea(ply7)
+  t.is(ret7, 0)
 
   // rotated to various angles
   let rotation = mat4.fromZRotation(mat4.create(), (45 * 0.017453292519943295))

--- a/packages/modeling/src/geometries/poly3/measureArea.test.js
+++ b/packages/modeling/src/geometries/poly3/measureArea.test.js
@@ -37,6 +37,11 @@ test('poly3: measureArea() should return correct values', (t) => {
   let ret4 = measureArea(ply4)
   t.is(ret4, 19.5)
 
+  // colinear vertices
+  let ply5 = fromPoints([[0, 0, 0], [1, 0, 0], [2, 0, 0], [0, 1, 0]])
+  let ret5 = measureArea(ply5)
+  t.is(ret5, 1)
+
   // rotated to various angles
   let rotation = mat4.fromZRotation(mat4.create(), (45 * 0.017453292519943295))
   ply1 = transform(rotation, ply1)


### PR DESCRIPTION
Fix for #951 "faces are lost during generalize({snap: true}, ...)"

There is a bug in `poly3.measureArea` which returns `NaN` in the case where the first three vertices are colinear. This can be demonstrated with:


```js
console.log("colinear area", poly3.measureArea(poly3.fromPoints([
  [ 0, 0, 0 ],
  [ 1, 0, 0 ],
  [ 2, 0, 0 ],
  [ 0, 1, 0 ],
])))
```

```js
colinear area NaN
```

The problem is that jscad takes the first three vertices and computes the vertex normal for only `vertices[1]`. This is not always defined though (for example when colinear). In general, a polygon may not have a defined normal vector. However it's fairly common to use the average of the vertex normals as the face normal.

With the changes in this PR, the above code returns the expected value:

```js
colinear area 1
```

Considerations: this is more computationally expensive. It computes the normal for all vertices instead of just one. It also has to normalize each normal vector for the math to work out. I made a special case for faster triangles, which are coplanar by definition.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
