### PR TITLE
fix(modeling): compute planes from average of all vertex normals

### DIFF
--- a/packages/modeling/src/geometries/poly3/isConvex.js
+++ b/packages/modeling/src/geometries/poly3/isConvex.js
@@ -13,7 +13,7 @@ const areVerticesConvex = (vertices) => {
   const numvertices = vertices.length
   if (numvertices > 2) {
     // note: plane ~= normal point
-    const normal = plane.fromPoints(plane.create(), vertices[0], vertices[1], vertices[2])
+    const normal = plane.fromPoints(plane.create(), ...vertices)
     let prevprevpos = vertices[numvertices - 2]
     let prevpos = vertices[numvertices - 1]
     for (let i = 0; i < numvertices; i++) {

--- a/packages/modeling/src/geometries/poly3/measureArea.js
+++ b/packages/modeling/src/geometries/poly3/measureArea.js
@@ -1,5 +1,5 @@
 const vec3 = require('../../maths/vec3')
-const plane = require('../../maths/plane')
+const plane = require('./plane')
 
 /**
  * Measure the area of the given polygon.
@@ -16,7 +16,7 @@ const measureArea = (poly3) => {
   const vertices = poly3.vertices
 
   // calculate a normal vector
-  const normal = plane.fromPoints(plane.create(), ...vertices)
+  const normal = plane(poly3)
 
   // determine direction of projection
   const ax = Math.abs(normal[0])

--- a/packages/modeling/src/geometries/poly3/measureArea.js
+++ b/packages/modeling/src/geometries/poly3/measureArea.js
@@ -1,4 +1,5 @@
 const vec3 = require('../../maths/vec3')
+const plane = require('../../maths/plane')
 
 /**
  * Measure the area of the given polygon.
@@ -14,19 +15,18 @@ const measureArea = (poly3) => {
   }
   const vertices = poly3.vertices
 
-  // calculate a real normal
-  const a = vertices[0]
-  const b = vertices[1]
-  const c = vertices[2]
-  const ba = vec3.subtract(vec3.create(), b, a)
-  const ca = vec3.subtract(vec3.create(), c, a)
-  const normal = vec3.cross(ba, ba, ca)
+  // calculate a normal vector
+  const normal = plane.fromPoints(plane.create(), ...vertices)
 
-  // determin direction of projection
+  // determine direction of projection
   const ax = Math.abs(normal[0])
   const ay = Math.abs(normal[1])
   const az = Math.abs(normal[2])
-  const an = Math.sqrt((ax * ax) + (ay * ay) + (az * az)) // length of normal
+
+  if (ax + ay + az === 0) {
+    // normal does not exist
+    return 0
+  }
 
   let coord = 3 // ignore Z coordinates
   if ((ax > ay) && (ax > az)) {
@@ -50,7 +50,7 @@ const measureArea = (poly3) => {
       }
       area += (vertices[0][1] * (vertices[1][2] - vertices[n - 1][2]))
       // scale to get area
-      area *= (an / (2 * normal[0]))
+      area /= (2 * normal[0])
       break
 
     case 2: // ignore Y coordinates
@@ -62,7 +62,7 @@ const measureArea = (poly3) => {
       }
       area += (vertices[0][2] * (vertices[1][0] - vertices[n - 1][0]))
       // scale to get area
-      area *= (an / (2 * normal[1]))
+      area /= (2 * normal[1])
       break
 
     case 3: // ignore Z coordinates
@@ -75,7 +75,7 @@ const measureArea = (poly3) => {
       }
       area += (vertices[0][0] * (vertices[1][1] - vertices[n - 1][1]))
       // scale to get area
-      area *= (an / (2 * normal[2]))
+      area /= (2 * normal[2])
       break
   }
   return area

--- a/packages/modeling/src/geometries/poly3/measureArea.test.js
+++ b/packages/modeling/src/geometries/poly3/measureArea.test.js
@@ -37,6 +37,21 @@ test('poly3: measureArea() should return correct values', (t) => {
   let ret4 = measureArea(ply4)
   t.is(ret4, 19.5)
 
+  // colinear vertices non-zero area
+  let ply5 = fromPoints([[0, 0, 0], [1, 0, 0], [2, 0, 0], [0, 1, 0]])
+  let ret5 = measureArea(ply5)
+  t.is(ret5, 1)
+
+  // colinear vertices empty area
+  let ply6 = fromPoints([[0, 0, 0], [1, 0, 0], [2, 0, 0]])
+  let ret6 = measureArea(ply6)
+  t.is(ret6, 0)
+
+  // duplicate vertices empty area
+  let ply7 = fromPoints([[0, 0, 0], [0, 0, 0], [0, 0, 0]])
+  let ret7 = measureArea(ply7)
+  t.is(ret7, 0)
+
   // rotated to various angles
   let rotation = mat4.fromZRotation(mat4.create(), (45 * 0.017453292519943295))
   ply1 = transform(rotation, ply1)

--- a/packages/modeling/src/geometries/poly3/plane.js
+++ b/packages/modeling/src/geometries/poly3/plane.js
@@ -2,8 +2,7 @@ const mplane = require('../../maths/plane/')
 
 const plane = (polygon) => {
   if (!polygon.plane) {
-    const vertices = polygon.vertices
-    polygon.plane = mplane.fromPoints(mplane.create(), vertices[0], vertices[1], vertices[2])
+    polygon.plane = mplane.fromPoints(mplane.create(), ...polygon.vertices)
   }
   return polygon.plane
 }

--- a/packages/modeling/src/maths/plane/fromPoints.js
+++ b/packages/modeling/src/maths/plane/fromPoints.js
@@ -10,17 +10,39 @@ const vec3 = require('../vec3')
  * @returns {plane} out
  * @alias module:modeling/maths/plane.fromPoints
  */
-const fromPoints = (out, a, b, c) => {
-  const ba = vec3.subtract(vec3.create(), b, a)
-  const ca = vec3.subtract(vec3.create(), c, a)
-  vec3.cross(ba, ba, ca)
-  vec3.normalize(ba, ba) // normal part
-  const w = vec3.dot(ba, a)
+const fromPoints = (out, ...vertices) => {
+  const len = vertices.length
 
-  out[0] = ba[0]
-  out[1] = ba[1]
-  out[2] = ba[2]
-  out[3] = w
+  // Calculate normal vector for a single vertex
+  // Inline to avoid allocations
+  const ba = vec3.create()
+  const ca = vec3.create()
+  const vertexNormal = (index) => {
+    const a = vertices[index]
+    const b = vertices[(index + 1) % len]
+    const c = vertices[(index + 2) % len]
+    vec3.subtract(ba, b, a) // ba = b - a
+    vec3.subtract(ca, c, a) // ca = c - a
+    vec3.cross(ba, ba, ca) // ba = ba x ca
+    vec3.normalize(ba, ba)
+    return ba
+  }
+
+  out[0] = 0
+  out[1] = 0
+  out[2] = 0
+  if (len === 3) {
+    // optimization for triangles, which are always coplanar
+    vec3.copy(out, vertexNormal(0))
+  } else {
+    // sum of vertex normals
+    vertices.forEach((v, i) => {
+      vec3.add(out, out, vertexNormal(i))
+    })
+    // renormalize normal vector
+    vec3.normalize(out, out)
+  }
+  out[3] = vec3.dot(out, vertices[0])
   return out
 }
 

--- a/packages/modeling/src/maths/plane/fromPoints.test.js
+++ b/packages/modeling/src/maths/plane/fromPoints.test.js
@@ -13,4 +13,8 @@ test('plane: fromPoints() should return a new plane with correct values', (t) =>
   // planes created from the same points results in an invalid plane
   const obs3 = fromPoints(obs1, [0, 6, 0], [0, 6, 0], [0, 6, 0])
   t.true(compareVectors(obs3, [0 / 0, 0 / 0, 0 / 0, 0 / 0]))
+
+  // polygon with co-linear vertices
+  const obs4 = fromPoints(obs1, [0, 0, 0], [1, 0, 0], [2, 0, 0], [0, 1, 0])
+  t.true(compareVectors(obs4, [0, 0, 1, 0]))
 })

--- a/packages/modeling/src/operations/expansions/expand.test.js
+++ b/packages/modeling/src/operations/expansions/expand.test.js
@@ -120,7 +120,7 @@ test('expand: expanding of a geom3 produces expected changes to polygons', (t) =
   const geometry2 = sphere({ radius: 5, segments: 8 })
   const obs2 = expand({ delta: 5 }, geometry2)
   const pts2 = geom3.toPoints(obs2)
-  t.is(pts2.length, 2059)
+  t.is(pts2.length, 2065)
 })
 
 test('expand (options): offsetting of a complex geom2 produces expected offset geom2', (t) => {

--- a/packages/modeling/src/operations/modifiers/snapPolygons.test.js
+++ b/packages/modeling/src/operations/modifiers/snapPolygons.test.js
@@ -66,5 +66,5 @@ test('snapPolygons: snap of polygons produces expected results', (t) => {
     [-24.4445, 19.3468, 46.475100000000005],
     [-23.7054, 18.7986, 39.5645]
   ])
-  t.deepEqual(results[3], exp3)
+  t.deepEqual(results[3].vertices, exp3.vertices)
 })


### PR DESCRIPTION
I made a new PR so that the change to `plane.fromPoints` could be considered separately from #952. In my opinion #952 should be closed in favor of this PR, but I will leave both open for discussion.

This is a fix for #951 "faces are lost during generalize({snap: true}, ...)".

There is a bug in `plane.fromPoints` which returns an undefined plane in the case where the first three vertices are co-linear. This can be demonstrated with:


```js
const { plane } = require("@jscad/modeling").maths
console.log("plane", plane.fromPoints(plane.create(),
  [ 0, 0, 0 ],
  [ 1, 0, 0 ],
  [ 2, 0, 0 ],
  [ 0, 1, 0 ],
))
```

```js
plane [0, 0, 0, 0]
```

The problem is that jscad takes the first three vertices and computes the vertex normal for only `vertices[1]`. This is not always defined though (for example when co-linear). In general, a polygon may not have a defined normal vector. However it's fairly common to use the average of the vertex normals as the face normal.

With the changes in this PR, the above code returns the expected value:

```js
plane [0, 0, 1, 0]
```

Considerations: this is more "correct" but also computationally expensive. It computes the normal for all vertices instead of just one. It also has to normalize each normal vector for the math to work out. I made a special case for faster triangles, which are co-planar by definition.


### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
