### PR TITLE
refactor(cli): linting the cli package

### DIFF
--- a/packages/cli/cli.conversions.test.js
+++ b/packages/cli/cli.conversions.test.js
@@ -4,7 +4,7 @@ const path = require('path')
 const { execSync } = require('child_process')
 const fs = require('fs')
 
-test.afterEach.always(t => {
+test.afterEach.always((t) => {
   // remove files
   try {
     if (t.context.file1Path) fs.unlinkSync(t.context.file1Path)
@@ -23,7 +23,7 @@ test.afterEach.always(t => {
   } catch (err) {}
 })
 
-test.beforeEach(t => {
+test.beforeEach((t) => {
   const cliName = './cli.js'
   t.context = {
     cliPath: path.resolve(__dirname, cliName)
@@ -68,7 +68,7 @@ module.exports = { main, getParameterDefinitions }
   return filePath
 }
 
-test('cli (conversions STL)', t => {
+test('cli (conversions STL)', (t) => {
   const testID = 11
 
   // convert from JSCAD script to STL
@@ -101,7 +101,7 @@ test('cli (conversions STL)', t => {
   t.true(fs.existsSync(file3Path))
 })
 
-test('cli (conversions DXF)', t => {
+test('cli (conversions DXF)', (t) => {
   const testID = 12
 
   // convert from JSCAD to DXF
@@ -134,7 +134,7 @@ test('cli (conversions DXF)', t => {
   t.true(fs.existsSync(file3Path))
 })
 
-test('cli (conversions AMF)', t => {
+test('cli (conversions AMF)', (t) => {
   const testID = 13
 
   // convert from JSCAD to AMF
@@ -167,7 +167,7 @@ test('cli (conversions AMF)', t => {
   t.true(fs.existsSync(file3Path))
 })
 
-test('cli (conversions JSON)', t => {
+test('cli (conversions JSON)', (t) => {
   const testID = 14
 
   // convert from JSCAD to JSON
@@ -200,7 +200,7 @@ test('cli (conversions JSON)', t => {
   t.true(fs.existsSync(file3Path))
 })
 
-test('cli (conversions SVG)', t => {
+test('cli (conversions SVG)', (t) => {
   const testID = 15
 
   // convert from JSCAD to SVG
@@ -233,7 +233,7 @@ test('cli (conversions SVG)', t => {
   t.true(fs.existsSync(file3Path))
 })
 
-test('cli (conversions X3D)', t => {
+test('cli (conversions X3D)', (t) => {
   const testID = 16
 
   // convert from JSCAD to X3D

--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -59,8 +59,8 @@ const src = fs.readFileSync(inputFile, inputFile.match(/\.stl$/i) ? 'binary' : '
 // -- convert from JSCAD script into the desired output format
 // -- and write it to disk
 generateOutputData(src, params, { outputFile, outputFormat, inputFile, inputFormat, version, addMetaData, inputIsDirectory })
-  .then(outputData => writeOutput(outputFile, outputData))
-  .catch(error => {
+  .then((outputData) => writeOutput(outputFile, outputData))
+  .catch((error) => {
     console.error(error)
     process.exit(1)
   })

--- a/packages/cli/cli.parameters.test.js
+++ b/packages/cli/cli.parameters.test.js
@@ -4,7 +4,7 @@ const path = require('path')
 const { execSync } = require('child_process')
 const fs = require('fs')
 
-test.afterEach.always(t => {
+test.afterEach.always((t) => {
   // remove files
   try {
     if (t.context.inputPath) fs.unlinkSync(t.context.inputPath)
@@ -19,7 +19,7 @@ test.afterEach.always(t => {
   } catch (err) {}
 })
 
-test.beforeEach(t => {
+test.beforeEach((t) => {
   const cliName = './cli.js'
   t.context = {
     cliPath: path.resolve(__dirname, cliName)
@@ -63,7 +63,7 @@ module.exports = { main, getParameterDefinitions }
   return filePath
 }
 
-test('cli (single input file)', t => {
+test('cli (single input file)', (t) => {
   const testID = 1
 
   const inputPath = createJscad(testID)
@@ -84,7 +84,7 @@ test('cli (single input file)', t => {
   t.true(fs.existsSync(outputPath))
 })
 
-test('cli (single input file, output format)', t => {
+test('cli (single input file, output format)', (t) => {
   const testID = 2
 
   const inputPath = createJscad(testID)
@@ -105,7 +105,7 @@ test('cli (single input file, output format)', t => {
   t.true(fs.existsSync(outputPath))
 })
 
-test('cli (single input file, output filename)', t => {
+test('cli (single input file, output filename)', (t) => {
   const testID = 3
 
   const inputPath = createJscad(testID)
@@ -126,7 +126,7 @@ test('cli (single input file, output filename)', t => {
   t.true(fs.existsSync(outputPath))
 })
 
-test('cli (folder, output format)', t => {
+test('cli (folder, output format)', (t) => {
   const testID = 4
 
   const inputPath = createJscad(testID)
@@ -161,7 +161,7 @@ test('cli (folder, output format)', t => {
   t.true(fs.existsSync(outputPath))
 })
 
-test('cli (single input file, parameters)', t => {
+test('cli (single input file, parameters)', (t) => {
   const testID = 5
 
   const inputPath = createJscad(testID)
@@ -182,7 +182,7 @@ test('cli (single input file, parameters)', t => {
   t.true(fs.existsSync(outputPath))
 })
 
-test('cli (no parameters)', t => {
+test('cli (no parameters)', (t) => {
   const cliPath = t.context.cliPath
 
   const cmd = `node ${cliPath}`
@@ -191,11 +191,11 @@ test('cli (no parameters)', t => {
   })
 })
 
-test('cli (single input file, invalid jscad)', t => {
+test('cli (single input file, invalid jscad)', (t) => {
   const testID = 6
 
   const inputPath = createJscad(testID)
-  fs.writeFileSync(inputPath, "INVALID")
+  fs.writeFileSync(inputPath, 'INVALID')
   t.true(fs.existsSync(inputPath))
 
   t.context.inputPath = inputPath

--- a/packages/cli/src/env.js
+++ b/packages/cli/src/env.js
@@ -1,13 +1,13 @@
 const version = require('../package.json').version
 
-function env () {
-  var env = 'OpenJSCAD ' + version
+const env = () => {
+  let env = 'OpenJSCAD ' + version
   if (typeof document !== 'undefined') {
-    var w = document.defaultView
+    const w = document.defaultView
     env = env + ' [' + w.navigator.userAgent + ']'
   } else {
     if (typeof require === 'function') {
-      var os = require('os')
+      const os = require('os')
       env = env + ' [' + os.type() + ':' + os.release() + ',' + os.platform() + ':' + os.arch() + ']'
     }
   }

--- a/packages/cli/src/generateOutputData.js
+++ b/packages/cli/src/generateOutputData.js
@@ -60,7 +60,7 @@ const generateOutputData = (source, params, options) => {
       }
     }
   })
-    .then(solids => {
+    .then((solids) => {
       const serializerOptions = Object.assign({ format: outputFormat }, params)
       return solidsAsBlob(solids, serializerOptions)
     })

--- a/packages/cli/src/parseArgs.js
+++ b/packages/cli/src/parseArgs.js
@@ -5,7 +5,7 @@ const { supportedInputExtensions, supportedOutputExtensions, supportedOutputForm
 
 const env = require('./env')
 
-const parseArgs = args => {
+const parseArgs = (args) => {
   const inputExtensions = supportedInputExtensions()
   const outputExtensions = supportedOutputExtensions()
   const outputFormats = supportedOutputFormats()
@@ -28,17 +28,15 @@ const parseArgs = args => {
   let addMetaData = false // wether to add metadata to outputs or not : ie version info, timestamp etc
   let inputIsDirectory = false // did we pass in a folder or a file ?
 
-  const isValidInputFileFormat = input => {
+  const isValidInputFileFormat = (input) => {
     if (input === undefined || input === null || !(typeof input === 'string')) {
       return false
     }
-    return inputExtensions.reduce((acc, format) => {
-      return input.toLowerCase().endsWith('.' + format) || acc
-    }, false)
+    return inputExtensions.reduce((acc, format) => input.toLowerCase().endsWith('.' + format) || acc, false)
   }
-  const getFileExtensionFromString = input => (input.substring(input.lastIndexOf('.') + 1)).toLowerCase()
+  const getFileExtensionFromString = (input) => (input.substring(input.lastIndexOf('.') + 1)).toLowerCase()
 
-  const parseBool = input => input.toLowerCase() === 'true'
+  const parseBool = (input) => input.toLowerCase() === 'true'
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '-of') { // -of <format>

--- a/packages/cli/src/parseArgs.js
+++ b/packages/cli/src/parseArgs.js
@@ -54,8 +54,6 @@ const parseArgs = args => {
       params[RegExp.$1] = RegExp.$2
     } else if (args[i].match(/^--(\w+)$/)) { // params for main()
       params[RegExp.$1] = args[++i]
-    } else if (args[i].match(/^--(\w+)$/)) { // params for main()
-      params[RegExp.$1] = args[++i]
     } else if (isValidInputFileFormat(args[i])) {
       inputFile = args[i]
       inputFormat = getFileExtensionFromString(args[i])

--- a/packages/cli/src/writeOutput.js
+++ b/packages/cli/src/writeOutput.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 
 const writeOutputDataToFile = (outputFile, outputData) => {
   fs.writeFile(outputFile, outputData.asBuffer(),
-    function (err) {
+    (err) => {
       if (err) {
         console.log('err', err)
       } else {


### PR DESCRIPTION
I noticed there was a duplicate regex check in the cli `parseArgs` function. This PR removes the duplicate, and fixes all lint warnings within the cli package.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?

