### PR TITLE
fix(web): handle parameter definition exceptions

### DIFF
--- a/packages/web/src/ui/views/designParameters.js
+++ b/packages/web/src/ui/views/designParameters.js
@@ -4,10 +4,11 @@ const { createParamControls } = require('./parameterControls')
 
 const designParameters = (state, paramsCallbacktoStream, i18n) => {
   const { parameterValues, parameterDefinitions, parameterDefaults } = state.design
-  const { controls } = createParamControls(
-    Object.assign({}, parameterDefaults, parameterValues), parameterDefinitions, paramsCallbacktoStream.callback
-  )
-  return html`
+  try {
+    const { controls } = createParamControls(
+      Object.assign({}, parameterDefaults, parameterValues), parameterDefinitions, paramsCallbacktoStream.callback
+    )
+    return html`
   <section id='params' style='visibility:${state.design.parameterDefinitions.length === 0 ? 'hidden' : 'visible'};color:${state.themes.themeSettings.secondaryTextColor}'>
     <span id='paramsTable'>
       <table>
@@ -22,6 +23,10 @@ const designParameters = (state, paramsCallbacktoStream, i18n) => {
     </span>
   </section>
 `
+  } catch (e) {
+    e.stack = undefined // remove unhelpful stacktrace
+    state.status.error = e
+  }
 }
 
 module.exports = designParameters


### PR DESCRIPTION
There is a UI bug when a user provides malformed parameter definitions. An exception is thrown internally, but the UI gets stuck with the message:
> processing, please wait

This PR catches exceptions thrown inside the `designParameters` function. If an exception is thrown, it gets added to the `status` object so it can be displayed to the user. After applying this PR, the user message becomes more helpful:
> ERROR: Definition of choice parameter (tooling) should include a 'values' parameter

Example script:
```js
const { cuboid } = require("@jscad/modeling").primitives

function getParameterDefinitions() {
  return [{name: "tooling", type: "choice", caption: "Tooling"}] // Oops forgot "values"
}

function main(params) {
  return cuboid({})
}
module.exports = { getParameterDefinitions, main }
```

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
