### PR TITLE
refactor(modeling): Use hypot instead of sqrt

### DIFF
--- a/packages/io/test/helpers/nearlyEqual.js
+++ b/packages/io/test/helpers/nearlyEqual.js
@@ -8,6 +8,10 @@ const nearlyEqual = (t, a, b, epsilon, failMessage) => {
   const absA = Math.abs(a)
   const absB = Math.abs(b)
   const diff = Math.abs(a - b)
+  if (Number.isNaN(diff)) {
+    failMessage = failMessage === undefined ? 'difference is not a number' : failMessage
+    t.fail(failMessage + '(' + a + ',' + b + ')')
+  }
   if (a === 0 || b === 0 || diff < Number.EPSILON) {
   // a or b is zero or both are extremely close to it
   // relative error is less meaningful here

--- a/packages/io/x3d-deserializer/tests/helpers/Rotation4.js
+++ b/packages/io/x3d-deserializer/tests/helpers/Rotation4.js
@@ -64,7 +64,7 @@ Rotation4.prototype = {
     this.z_ = z
     this.angle_ = angle
 
-    let scale = Math.sqrt(x * x + y * y + z * z)
+    let scale = Math.hypot(x, y, z)
 
     if (scale === 0) {
       this.value.set(0, 0, 0, 1)

--- a/packages/modeling/src/maths/mat4/fromRotation.js
+++ b/packages/modeling/src/maths/mat4/fromRotation.js
@@ -19,7 +19,7 @@ const { EPSILON } = require('./constants')
  */
 const fromRotation = (out, rad, axis) => {
   let [x, y, z] = axis
-  let len = Math.sqrt(x * x + y * y + z * z)
+  let len = Math.hypot(x, y, z)
 
   if (Math.abs(len) < EPSILON) {
     // axis is 0,0,0 or almost

--- a/packages/modeling/src/maths/mat4/rotate.js
+++ b/packages/modeling/src/maths/mat4/rotate.js
@@ -12,7 +12,7 @@ const copy = require('./copy')
  */
 const rotate = (out, matrix, radians, axis) => {
   let [x, y, z] = axis
-  let len = Math.sqrt(x * x + y * y + z * z)
+  let len = Math.hypot(x, y, z)
 
   if (Math.abs(len) < 0.000001) {
     // axis is 0,0,0 or almost

--- a/packages/modeling/src/maths/vec2/length.test.js
+++ b/packages/modeling/src/maths/vec2/length.test.js
@@ -25,5 +25,15 @@ test('vec2: length() should return correct values', (t) => {
   const length5 = length(vec5)
   nearlyEqual(t, length5, 2.23606, EPS)
 
+  // huge vector
+  const vec6 = fromValues(1e200, 1e200)
+  const length6 = length(vec6)
+  nearlyEqual(t, length6, Math.SQRT2 * 1e200, EPS)
+
+  // tiny vector
+  const vec7 = fromValues(1e-200, 1e-200)
+  const length7 = length(vec7)
+  nearlyEqual(t, length7, Math.SQRT2 * 1e-200, EPS)
+
   t.true(true)
 })

--- a/packages/modeling/src/maths/vec3/angle.js
+++ b/packages/modeling/src/maths/vec3/angle.js
@@ -15,8 +15,8 @@ const angle = (a, b) => {
   const bx = b[0]
   const by = b[1]
   const bz = b[2]
-  const mag1 = Math.sqrt(ax * ax + ay * ay + az * az)
-  const mag2 = Math.sqrt(bx * bx + by * by + bz * bz)
+  const mag1 = Math.hypot(ax, ay, az)
+  const mag2 = Math.hypot(bx, by, bz)
   const mag = mag1 * mag2
   const cosine = mag && dot(a, b) / mag
   return Math.acos(Math.min(Math.max(cosine, -1), 1))

--- a/packages/modeling/src/maths/vec3/angle.test.js
+++ b/packages/modeling/src/maths/vec3/angle.test.js
@@ -25,5 +25,22 @@ test('vec3: angle() should return correct values', (t) => {
   const angle4 = angle(veca4, vec4)
   nearlyEqual(t, angle4, 3.14159, EPS)
 
+  const vec5a = fromValues(1, 0, 0)
+  const vec5b = fromValues(1, 1, 0)
+  const angle5 = angle(vec5a, vec5b)
+  nearlyEqual(t, angle5, 0.785398, EPS)
+
+  // tiny values
+  const vec6a = fromValues(1, 0, 0)
+  const vec6b = fromValues(1e-200, 1e-200, 0)
+  const angle6 = angle(vec6a, vec6b)
+  nearlyEqual(t, angle6, 0.785398, EPS)
+
+  // huge values
+  const vec7a = fromValues(1, 0, 0)
+  const vec7b = fromValues(1e200, 1e200, 0)
+  const angle7 = angle(vec7a, vec7b)
+  nearlyEqual(t, angle7, 0.785398, EPS)
+
   t.true(true)
 })

--- a/packages/modeling/src/maths/vec3/length.test.js
+++ b/packages/modeling/src/maths/vec3/length.test.js
@@ -41,5 +41,15 @@ test('vec3: length() should return correct values', (t) => {
   const length9 = length(vec9)
   nearlyEqual(t, length9, 3.74165, EPS)
 
+  // huge vector
+  const vec10 = fromValues(1e200, 0, 1e200)
+  const length10 = length(vec10)
+  nearlyEqual(t, length10, Math.SQRT2 * 1e200, EPS)
+
+  // tiny vector
+  const vec11 = fromValues(1e-200, 0, 1e-200)
+  const length11 = length(vec11)
+  nearlyEqual(t, length11, Math.SQRT2 * 1e-200, EPS)
+
   t.true(true)
 })

--- a/packages/modeling/src/primitives/geodesicSphere.js
+++ b/packages/modeling/src/primitives/geodesicSphere.js
@@ -79,7 +79,7 @@ const geodesicSphere = (options) => {
 
         // -- normalize
         for (let k = 0; k < 3; k++) {
-          const r = Math.sqrt(q[k][0] * q[k][0] + q[k][1] * q[k][1] + q[k][2] * q[k][2])
+          const r = Math.hypot(q[k][0], q[k][1], q[k][2])
           for (let l = 0; l < 3; l++) {
             q[k][l] /= r
           }
@@ -95,7 +95,7 @@ const geodesicSphere = (options) => {
 
           // -- normalize
           for (let k = 0; k < 3; k++) {
-            const r = Math.sqrt(q[k][0] * q[k][0] + q[k][1] * q[k][1] + q[k][2] * q[k][2])
+            const r = Math.hypot(q[k][0], q[k][1], q[k][2])
             for (let l = 0; l < 3; l++) {
               q[k][l] /= r
             }

--- a/packages/modeling/test/helpers/nearlyEqual.js
+++ b/packages/modeling/test/helpers/nearlyEqual.js
@@ -1,7 +1,6 @@
 // Compare two numeric values for near equality.
 // the given test is fails if the numeric values are outside the given epsilon
 const nearlyEqual = (t, a, b, epsilon, failMessage) => {
-// console.log('nearEqual(t,'+a+','+b+','+epsilon+')')
   if (a === b) { // shortcut, also handles infinities and NaNs
     return true
   }
@@ -10,11 +9,9 @@ const nearlyEqual = (t, a, b, epsilon, failMessage) => {
   const absB = Math.abs(b)
   const diff = Math.abs(a - b)
   if (Number.isNaN(diff)) {
-    return false
+    failMessage = failMessage === undefined ? 'difference is not a number' : failMessage
+    t.fail(failMessage + '(' + a + ',' + b + ')')
   }
-  // console.log(absA)
-  // console.log(absB)
-  // console.log(diff)
   if (a === 0 || b === 0 || diff < Number.EPSILON) {
   // a or b is zero or both are extremely close to it
   // relative error is less meaningful here
@@ -25,7 +22,6 @@ const nearlyEqual = (t, a, b, epsilon, failMessage) => {
   }
   // use relative error
   const relative = (diff / Math.min((absA + absB), Number.MAX_VALUE))
-  // console.log(relative)
   if (relative > epsilon) {
     failMessage = failMessage === undefined ? 'Numbers outside of epsilon' : failMessage
     t.fail(failMessage + '(' + a + ',' + b + ')')


### PR DESCRIPTION
This PR changes `Math.sqrt(x*x + y*y + z*z)` into `Math.hypot(x, y, z)`.

See [MDN: Math.hypot](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/hypot) for details.

Math.hypot has benefits of: not overflowing on large numbers, more accurate floating point math for small numbers, and generally nicer to read. It seems wise to code defensively, to avoid as many floating point bugs as possible.

I added a test case to demonstrate the problem.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
