### PR TITLE
refactor(modeling): linear runtime toOutlines

### DIFF
--- a/packages/modeling/src/geometries/geom2/toOutlines.js
+++ b/packages/modeling/src/geometries/geom2/toOutlines.js
@@ -7,21 +7,16 @@ const toSides = require('./toSides')
  * This allows the edges to be traversed in order.
  */
 const toEdges = (sides) => {
-  const uniquevertices = []
+  const vertices = {}
   const getUniqueVertex = (vertex) => {
-    const i = uniquevertices.findIndex((v) => vec2.equals(v, vertex))
-    if (i < 0) {
-      uniquevertices.push(vertex)
-      return vertex
+    const key = vertex.toString()
+    if (!vertices[key]) {
+      vertices[key] = vertex
     }
-    return uniquevertices[i]
+    return vertices[key]
   }
 
-  const edges = []
-  sides.forEach((side) => {
-    edges.push([getUniqueVertex(side[0]), getUniqueVertex(side[1])])
-  })
-  return edges
+  return sides.map((side) => side.map(getUniqueVertex))
 }
 
 /**


### PR DESCRIPTION
The `toEdges` function inside `geom2.toOutlines` includes a quadratic runtime loop to find unique vertices. I re-wrote the function to use a map so that it can run in linear time.

For a circle with 100 segments this reduces runtime from 0.9ms to 0.4ms (2x speedup). 
For a circle with 1000 segments this reduces runtime from 12ms to 2ms (6x speedup). 
For a circle with 10000 segments this reduces runtime from 150ms to 16ms (9x speedup). 
For a circle with 50000 segments this reduces runtime from 4400ms to 90ms (50x speedup). 
For a circle with 100000 segments this reduces runtime from 16000ms to 160ms (100x speedup). 

This helps performance more as the complexity of the design increases. But it is also still faster on small geometry.

Performance test code:

```js
const jscad = require('@jscad/modeling')

const { toOutlines } = jscad.geometries.geom2
const { circle } = jscad.primitives

const main = () => {
  const geometry2 = circle({ radius: 5, segments: 10000 })
  const start = performance.now()
  const outlines = toOutlines(geometry2)
  console.log(`Outline generated ${performance.now() - start} ms`)
  return geometry2
}

module.exports = { main }
```

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
