### PR TITLE
docs(modeling): add docs describing geometries, paths, and polys

### DIFF
--- a/packages/modeling/src/geometries/geom2/index.js
+++ b/packages/modeling/src/geometries/geom2/index.js
@@ -2,6 +2,16 @@
  * Represents a 2D geometry consisting of a list of sides.
  * @see {@link geom2} for data structure information.
  * @module modeling/geometries/geom2
+ *
+ * @example
+ * colorize([0.5,0,1,1], square()) // purple square
+ *
+ * @example
+ * {
+ *   "sides": [[[-1,1],[-1,-1]],[[-1,-1],[1,-1]],[[1,-1],[1,1]],[[1,1],[-1,1]]],
+ *   "transforms": [1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1],
+ *   "color": [0.5,0,1,1]
+ * }
  */
 module.exports = {
   clone: require('./clone'),

--- a/packages/modeling/src/geometries/geom3/index.js
+++ b/packages/modeling/src/geometries/geom3/index.js
@@ -2,6 +2,23 @@
  * Represents a 3D geometry consisting of a list of polygons.
  * @see {@link geom3} for data structure information.
  * @module modeling/geometries/geom3
+ *
+ * @example
+ * colorize([0,0.5,1,0.6], cube()) // transparent ice cube
+ *
+ * @example
+ * {
+ *   "polygons": [
+ *     {"vertices": [[-1,-1,-1], [-1,-1,1], [-1,1,1], [-1,1,-1]]},
+ *     {"vertices": [[1,-1,-1], [1,1,-1], [1,1,1], [1,-1,1]]},
+ *     {"vertices": [[-1,-1,-1], [1,-1,-1], [1,-1,1], [-1,-1,1]]},
+ *     {"vertices": [[-1,1,-1], [-1,1,1], [1,1,1], [1,1,-1]]},
+ *     {"vertices": [[-1,-1,-1], [-1,1,-1], [1,1,-1], [1,-1,-1]]},
+ *     {"vertices": [[-1,-1,1], [1,-1,1], [1,1,1], [-1,1,1]]}
+ *   ],
+ *   "transforms": [1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1],
+ *   "color": [0,0.5,1,0.6]
+ * }
  */
 module.exports = {
   clone: require('./clone'),

--- a/packages/modeling/src/geometries/index.js
+++ b/packages/modeling/src/geometries/index.js
@@ -5,8 +5,8 @@
  * @see {@link geom2} - 2D geometry consisting of sides
  * @see {@link geom3} - 3D geometry consisting of polygons
  * @see {@link path2} - 2D geometry consisting of ordered points
- * @see {@link poly2} - 2D polygon consisting of ordered points
- * @see {@link poly3} - 3D polygon consisting of ordered points
+ * @see {@link poly2} - 2D polygon consisting of ordered vertices
+ * @see {@link poly3} - 3D polygon consisting of ordered vertices
  *
  * @module modeling/geometries
  * @example

--- a/packages/modeling/src/geometries/index.js
+++ b/packages/modeling/src/geometries/index.js
@@ -21,7 +21,7 @@
  * Represents a 3D geometry consisting of a list of polygons.
  *
  * ```js
- * colorize([0.5,0,1,0.4], cube()) // transparent cube
+ * colorize([0,0.5,1,0.6], cube()) // transparent ice cube
  * ````
  *
  * ```json
@@ -35,7 +35,7 @@
  *     {"vertices": [[-1,-1,1], [1,-1,1], [1,1,1], [-1,1,1]]}
  *   ],
  *   "transforms": [1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1],
- *   "color": [0.5,0,1,0.4]
+ *   "color": [0,0.5,1,0.6]
  * }
  * ```
  *
@@ -43,7 +43,7 @@
  * Represents a 2D geometry consisting of a list of ordered points.
  *
  * ```js
- * colorize([0.5,0,1,1], path2.fromPoints({closed: true}, [[0,0], [4,0], [4,3]]))
+ * colorize([0,0,0,1], path2.fromPoints({closed: true}, [[0,0], [4,0], [4,3]]))
  * ````
  *
  * ```json
@@ -51,7 +51,7 @@
  *   "points": [[0,0], [4,0], [4,3]],
  *   "isClosed": true,
  *   "transforms": [1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1],
- *   "color": [0.5,0,1,1]
+ *   "color": [0,0,0,1]
  * }
  * ```
  *

--- a/packages/modeling/src/geometries/index.js
+++ b/packages/modeling/src/geometries/index.js
@@ -1,6 +1,86 @@
 /**
  * Geometries are objects that represent the contents of primitives or the results of operations.
- * Note: Geometries are consider immutable, so never change the contents directly.
+ * Note: Geometries are considered immutable, so never change the contents directly.
+ *
+ * ## geom2
+ * Represents a 2D geometry consisting of a list of sides.
+ *
+ * ```js
+ * colorize([0.5,0,1,1], square()) // purple square
+ * ```
+ *
+ * ```json
+ * {
+ *   "sides": [[[-1,1],[-1,-1]],[[-1,-1],[1,-1]],[[1,-1],[1,1]],[[1,1],[-1,1]]],
+ *   "transforms": [1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1],
+ *   "color": [0.5,0,1,1]
+ * }
+ * ```
+ *
+ * ## geom3
+ * Represents a 3D geometry consisting of a list of polygons.
+ *
+ * ```js
+ * colorize([0.5,0,1,0.4], cube()) // transparent cube
+ * ````
+ *
+ * ```json
+ * {
+ *   "polygons": [
+ *     {"vertices": [[-1,-1,-1], [-1,-1,1], [-1,1,1], [-1,1,-1]]},
+ *     {"vertices": [[1,-1,-1], [1,1,-1], [1,1,1], [1,-1,1]]},
+ *     {"vertices": [[-1,-1,-1], [1,-1,-1], [1,-1,1], [-1,-1,1]]},
+ *     {"vertices": [[-1,1,-1], [-1,1,1], [1,1,1], [1,1,-1]]},
+ *     {"vertices": [[-1,-1,-1], [-1,1,-1], [1,1,-1], [1,-1,-1]]},
+ *     {"vertices": [[-1,-1,1], [1,-1,1], [1,1,1], [-1,1,1]]}
+ *   ],
+ *   "transforms": [1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1],
+ *   "color": [0.5,0,1,0.4]
+ * }
+ * ```
+ *
+ * ## path2
+ * Represents a 2D geometry consisting of a list of ordered points.
+ *
+ * ```js
+ * colorize([0.5,0,1,1], path2.fromPoints({closed: true}, [[0,0], [4,0], [4,3]]))
+ * ````
+ *
+ * ```json
+ * {
+ *   "points": [[0,0], [4,0], [4,3]],
+ *   "isClosed": true,
+ *   "transforms": [1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1],
+ *   "color": [0.5,0,1,1]
+ * }
+ * ```
+ *
+ * ## poly2
+ * Represents a 2D polygon consisting of a list of ordered vertices.
+ *
+ * ```js
+ * poly2.create([[0,0], [4,0], [4,3]])
+ * ```
+ *
+ * ```json
+ * {
+ *   "vertices": [[0,0], [4,0], [4,3]]
+ * }
+ * ```
+ *
+ * ## poly3
+ * Represents a convex 3D polygon consisting of a list of ordered vertices.
+ *
+ * ```js
+ * poly3.create([[0,0,0], [4,0,0], [4,3,12]])
+ * ```
+ *
+ * ```json
+ * {
+ *   "vertices": [[0,0,0], [4,0,0], [4,3,12]]
+ * }
+ * ```
+ *
  * @module modeling/geometries
  * @example
  * const { geom2, geom3, path2, poly2, poly3 } = require('@jscad/modeling').geometries

--- a/packages/modeling/src/geometries/index.js
+++ b/packages/modeling/src/geometries/index.js
@@ -2,84 +2,11 @@
  * Geometries are objects that represent the contents of primitives or the results of operations.
  * Note: Geometries are considered immutable, so never change the contents directly.
  *
- * ## geom2
- * Represents a 2D geometry consisting of a list of sides.
- *
- * ```js
- * colorize([0.5,0,1,1], square()) // purple square
- * ```
- *
- * ```json
- * {
- *   "sides": [[[-1,1],[-1,-1]],[[-1,-1],[1,-1]],[[1,-1],[1,1]],[[1,1],[-1,1]]],
- *   "transforms": [1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1],
- *   "color": [0.5,0,1,1]
- * }
- * ```
- *
- * ## geom3
- * Represents a 3D geometry consisting of a list of polygons.
- *
- * ```js
- * colorize([0,0.5,1,0.6], cube()) // transparent ice cube
- * ````
- *
- * ```json
- * {
- *   "polygons": [
- *     {"vertices": [[-1,-1,-1], [-1,-1,1], [-1,1,1], [-1,1,-1]]},
- *     {"vertices": [[1,-1,-1], [1,1,-1], [1,1,1], [1,-1,1]]},
- *     {"vertices": [[-1,-1,-1], [1,-1,-1], [1,-1,1], [-1,-1,1]]},
- *     {"vertices": [[-1,1,-1], [-1,1,1], [1,1,1], [1,1,-1]]},
- *     {"vertices": [[-1,-1,-1], [-1,1,-1], [1,1,-1], [1,-1,-1]]},
- *     {"vertices": [[-1,-1,1], [1,-1,1], [1,1,1], [-1,1,1]]}
- *   ],
- *   "transforms": [1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1],
- *   "color": [0,0.5,1,0.6]
- * }
- * ```
- *
- * ## path2
- * Represents a 2D geometry consisting of a list of ordered points.
- *
- * ```js
- * colorize([0,0,0,1], path2.fromPoints({closed: true}, [[0,0], [4,0], [4,3]]))
- * ````
- *
- * ```json
- * {
- *   "points": [[0,0], [4,0], [4,3]],
- *   "isClosed": true,
- *   "transforms": [1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1],
- *   "color": [0,0,0,1]
- * }
- * ```
- *
- * ## poly2
- * Represents a 2D polygon consisting of a list of ordered vertices.
- *
- * ```js
- * poly2.create([[0,0], [4,0], [4,3]])
- * ```
- *
- * ```json
- * {
- *   "vertices": [[0,0], [4,0], [4,3]]
- * }
- * ```
- *
- * ## poly3
- * Represents a convex 3D polygon consisting of a list of ordered vertices.
- *
- * ```js
- * poly3.create([[0,0,0], [4,0,0], [4,3,12]])
- * ```
- *
- * ```json
- * {
- *   "vertices": [[0,0,0], [4,0,0], [4,3,12]]
- * }
- * ```
+ * @see {@link geom2} - 2D geometry consisting of sides
+ * @see {@link geom3} - 3D geometry consisting of polygons
+ * @see {@link path2} - 2D geometry consisting of ordered points
+ * @see {@link poly2} - 2D polygon consisting of ordered points
+ * @see {@link poly3} - 3D polygon consisting of ordered points
  *
  * @module modeling/geometries
  * @example

--- a/packages/modeling/src/geometries/path2/index.js
+++ b/packages/modeling/src/geometries/path2/index.js
@@ -2,6 +2,17 @@
  * Represents a 2D geometry consisting of a list of ordered points.
  * @see {@link path2} for data structure information.
  * @module modeling/geometries/path2
+ *
+ * @example
+ * colorize([0,0,0,1], path2.fromPoints({ closed: true }, [[0,0], [4,0], [4,3]]))
+ *
+ * @example
+ * {
+ *   "points": [[0,0], [4,0], [4,3]],
+ *   "isClosed": true,
+ *   "transforms": [1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1],
+ *   "color": [0,0,0,1]
+ * }
  */
 module.exports = {
   appendArc: require('./appendArc'),

--- a/packages/modeling/src/geometries/poly2/index.js
+++ b/packages/modeling/src/geometries/poly2/index.js
@@ -2,6 +2,12 @@
  * Represents a 2D polygon consisting of a list of ordered vertices.
  * @see {@link poly2} for data structure information.
  * @module modeling/geometries/poly2
+ *
+ * @example
+ * poly2.create([[0,0], [4,0], [4,3]])
+ *
+ * @example
+ * {"vertices": [[0,0], [4,0], [4,3]]}
  */
 module.exports = {
   arePointsInside: require('./arePointsInside'),

--- a/packages/modeling/src/geometries/poly3/index.js
+++ b/packages/modeling/src/geometries/poly3/index.js
@@ -1,5 +1,5 @@
 /**
- * Represents a convex 3D polygon consisting of a list of vertices.
+ * Represents a convex 3D polygon consisting of a list of ordered vertices.
  * @see {@link poly3} for data structure information.
  * @module modeling/geometries/poly3
  */

--- a/packages/modeling/src/geometries/poly3/index.js
+++ b/packages/modeling/src/geometries/poly3/index.js
@@ -2,6 +2,12 @@
  * Represents a convex 3D polygon consisting of a list of ordered vertices.
  * @see {@link poly3} for data structure information.
  * @module modeling/geometries/poly3
+ *
+ * @example
+ * poly3.create([[0,0,0], [4,0,0], [4,3,12]])
+ *
+ * @example
+ * {"vertices": [[0,0,0], [4,0,0], [4,3,12]]}
  */
 module.exports = {
   clone: require('./clone'),


### PR DESCRIPTION
I find it hard to remember the differences between geom, paths, and polygons. So I made some docs that makes for a easy reference. I put it in the jsdoc so that it would appear in the API Reference. If you think this belongs elsewhere, let me know.

![Screenshot at 2022-02-19 13-49-39](https://user-images.githubusercontent.com/1766297/154820268-57d2c0f4-a919-4d27-a894-40ad5a132cc4.png)

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
