### PR TITLE
perf(modeling): linear unique points in hullPath2

### DIFF
--- a/packages/modeling/src/operations/hulls/hullPath2.js
+++ b/packages/modeling/src/operations/hulls/hullPath2.js
@@ -16,11 +16,15 @@ const hullPath2 = (...geometries) => {
 
   // extract the unique points from the geometries
   const uniquepoints = []
+  const found = {}
   geometries.forEach((geometry) => {
     const points = path2.toPoints(geometry)
     points.forEach((point) => {
-      const index = uniquepoints.findIndex((unique) => vec2.equals(unique, point))
-      if (index < 0) uniquepoints.push(point)
+      const key = point.toString()
+      if (!found[key]) {
+        uniquepoints.push(point)
+        found[key] = true
+      }
     })
   })
 

--- a/packages/modeling/src/operations/hulls/hullPath2.js
+++ b/packages/modeling/src/operations/hulls/hullPath2.js
@@ -16,14 +16,14 @@ const hullPath2 = (...geometries) => {
 
   // extract the unique points from the geometries
   const uniquepoints = []
-  const found = {}
+  const found = new Set()
   geometries.forEach((geometry) => {
     const points = path2.toPoints(geometry)
     points.forEach((point) => {
       const key = point.toString()
-      if (!found[key]) {
+      if (!found.has(key)) {
         uniquepoints.push(point)
-        found[key] = true
+        found.add(key)
       }
     })
   })

--- a/packages/modeling/src/operations/hulls/hullPath2.test.js
+++ b/packages/modeling/src/operations/hulls/hullPath2.test.js
@@ -1,0 +1,16 @@
+const test = require('ava')
+
+const { geom2, path2 } = require('../../geometries')
+
+const hullPath2 = require('./hullPath2')
+
+test('hullPath2', (t) => {
+  const closed = true
+  const geometry1 = path2.fromPoints({ closed }, [[0, 0], [-4, 4], [-4, -4]])
+  const geometry2 = path2.fromPoints({ closed }, [[0, 0], [4, -4], [4, 4]])
+
+  const obs = hullPath2(geometry1, geometry2)
+  t.true(path2.isA(obs))
+  let pts = path2.toPoints(obs)
+  t.is(pts.length, 4)
+})

--- a/packages/modeling/src/operations/hulls/hullPoints2.test.js
+++ b/packages/modeling/src/operations/hulls/hullPoints2.test.js
@@ -42,7 +42,7 @@ test('hullPoints2 bug #114 2 circles with 18 segments', (t) => {
     [7.298133329356933, -1.9283628290596186]
   ]
 
-  // we just want to bwe sure no err happens for this case
+  // we just want to be sure no err happens for this case
   const out = hullPoints2(points)
   t.is(out.length, 19)
 })


### PR DESCRIPTION
The function `hullPath2` has a routine to find unique vertices which was implemented with a quadratic array loop. I re-wrote the function to use a map so that it can run in linear time.

With 100 segments this reduces runtime from 2.3ms to 0.9ms (2.5x speedup).
With 1000 segments this reduces runtime from 23ms to 4.5ms (5x speedup).
With 10000 segments this reduces runtime from 750ms to 34ms (22x speedup).
With 50000 segments this reduces runtime from 11500ms to 140ms (80x speedup).
With 100000 segments this reduces runtime from 45000ms to 290ms (150x speedup).

Performance test code:

```js
const jscad = require('@jscad/modeling')
const { geom2, path2 } = jscad.geometries
const { hull } = jscad.hulls
const { circle } = jscad.primitives
const { translate } = jscad.transforms

const main = () => {
  // construct path2
  const circ = circle({ segments: 10000 })
  const outline = geom2.toOutlines(circ)[0]
  const path = path2.fromPoints({closed: true}, outline)

  // construct hull
  const start = performance.now()
  const obj2d = hull(
    translate([17, 21], path),
    translate([7, 0], path),
  )
  console.log(`Hull time ${performance.now() - start} ms`)
  return obj2d
}

module.exports = { main }
```

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
