### PR TITLE
perf(modeling): expand performance and bug fix

### DIFF
--- a/packages/modeling/src/operations/expansions/expand.test.js
+++ b/packages/modeling/src/operations/expansions/expand.test.js
@@ -120,7 +120,7 @@ test('expand: expanding of a geom3 produces expected changes to polygons', (t) =
   const geometry2 = sphere({ radius: 5, segments: 8 })
   const obs2 = expand({ delta: 5 }, geometry2)
   const pts2 = geom3.toPoints(obs2)
-  t.is(pts2.length, 2065)
+  t.is(pts2.length, 1612)
 })
 
 test('expand (options): offsetting of a complex geom2 produces expected offset geom2', (t) => {

--- a/packages/modeling/src/operations/expansions/expandShell.js
+++ b/packages/modeling/src/operations/expansions/expandShell.js
@@ -29,15 +29,22 @@ const mapPlaneToVertex = (map, vertex, plane) => {
   }
 }
 
+/**
+ * Collect all planes adjacent to each edge.
+ * Combine undirected edges, no need for duplicate cylinders.
+ */
 const mapPlaneToEdge = (map, edge, plane) => {
-  const i = map.findIndex((item) => (vec3.equals(item[0], edge[0]) && vec3.equals(item[1], edge[1])) || (vec3.equals(item[0], edge[1]) && vec3.equals(item[1], edge[0])))
-  if (i < 0) {
+  const key0 = edge[0].toString()
+  const key1 = edge[1].toString()
+  // Sort keys to make edges undirected
+  const key = key0 < key1 ? `${key0},${key1}` : `${key1},${key0}`
+  if (!map.has(key)) {
     const entry = [edge, [plane]]
-    map.push(entry)
-    return
+    map.set(key, entry)
+  } else {
+    const planes = map.get(key)[1]
+    planes.push(plane)
   }
-  const planes = map[i][1]
-  planes.push(plane)
 }
 
 const addUniqueAngle = (map, angle) => {
@@ -65,7 +72,7 @@ const expandShell = (options, geometry) => {
 
   let result = geom3.create()
   const vertices2planes = new Map() // {vertex: [vertex, [plane, ...]]}
-  const edges2planes = [] // contents: [[vertex, vertex], [plane, ...]]
+  const edges2planes = new Map() // {edge: [[vertex, vertex], [plane, ...]]}
 
   const v1 = vec3.create()
   const v2 = vec3.create()

--- a/packages/modeling/src/operations/expansions/expandShell.js
+++ b/packages/modeling/src/operations/expansions/expandShell.js
@@ -15,16 +15,18 @@ const unionGeom3Sub = require('../booleans/unionGeom3Sub')
 
 const extrudePolygon = require('./extrudePolygon')
 
+/**
+ * Collect all planes adjacent to each vertex
+ */
 const mapPlaneToVertex = (map, vertex, plane) => {
-  const i = map.findIndex((item) => vec3.equals(item[0], vertex))
-  if (i < 0) {
+  const key = vertex.toString()
+  if (!map.has(key)) {
     const entry = [vertex, [plane]]
-    map.push(entry)
-    return map.length
+    map.set(key, entry)
+  } else {
+    const planes = map.get(key)[1]
+    planes.push(plane)
   }
-  const planes = map[i][1]
-  planes.push(plane)
-  return i
 }
 
 const mapPlaneToEdge = (map, edge, plane) => {
@@ -32,20 +34,17 @@ const mapPlaneToEdge = (map, edge, plane) => {
   if (i < 0) {
     const entry = [edge, [plane]]
     map.push(entry)
-    return map.length
+    return
   }
   const planes = map[i][1]
   planes.push(plane)
-  return i
 }
 
 const addUniqueAngle = (map, angle) => {
   const i = map.findIndex((item) => item === angle)
   if (i < 0) {
     map.push(angle)
-    return map.length
   }
-  return i
 }
 
 /*
@@ -65,7 +64,7 @@ const expandShell = (options, geometry) => {
   const { delta, segments } = Object.assign({ }, defaults, options)
 
   let result = geom3.create()
-  const vertices2planes = [] // contents: [vertex, [plane, ...]]
+  const vertices2planes = new Map() // {vertex: [vertex, [plane, ...]]}
   const edges2planes = [] // contents: [[vertex, vertex], [plane, ...]]
 
   const v1 = vec3.create()


### PR DESCRIPTION
There is a bug in [expandShell.js](https://github.com/jscad/OpenJSCAD.org/blob/b06288af2fe8f7b007e4b10eac413c74bd6c1bfa/packages/modeling/src/operations/expansions/expandShell.js#L31) where the edge check in findIndex is always false, because it is comparing an edge to a vertex.

The result of that bug is that two cylinders are added to the expansion for each edge, instead of just one. Two cylinders on each edge is unnecessary and slows the computation down. This new code produces cleaner geometry too.

I also changed the functions to avoid linear searches for unique vertices and edges. Actually that's where I started, I only noticed the bug after I accidentally fixed it.

The following example (which is a real test from [expand.test.js](https://github.com/jscad/OpenJSCAD.org/blob/c8a37ad6430aec8361a5e121730b34629c0d969c/packages/modeling/src/operations/expansions/expand.test.js#L120-L123)) reduced runtime from 4200ms on master, to 1600ms on this branch. This is a 10% reduction in total `npm test` time! (23s -> 20s)

```js
const jscad = require('@jscad/modeling')
const { expand } = jscad.expansions
const { sphere } = jscad.primitives

const main = () => {
  const obj = sphere({ radius: 5, segments: 8 })
  return expand({ delta: 5 }, obj)
}

module.exports = { main }
```

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
