### PR TITLE
fix(modeling): fix assignHoles function when there are nested holes

### DIFF
--- a/packages/modeling/src/operations/extrusions/earcut/assignHoles.js
+++ b/packages/modeling/src/operations/extrusions/earcut/assignHoles.js
@@ -31,6 +31,7 @@ const assignHoles = (geometry) => {
       solids.push(i)
     }
   })
+
   // for each hole, determine what solids it is inside of
   const children = [] // child holes of solid[i]
   const parents = [] // parent solids of hole[i]
@@ -47,19 +48,22 @@ const assignHoles = (geometry) => {
       }
     })
   })
+
   // check if holes have multiple parents and choose one with fewest children
   holes.forEach((h, j) => {
     // ensure at least one parent exists
     if (parents[j] && parents[j].length > 1) {
-      const parent = minIndex(parents[j], (p) => p.length)
+      // the solid directly containing this hole
+      const directParent = minIndex(parents[j], (p) => children[p].length)
       parents[j].forEach((p, i) => {
-        if (i !== parent) {
+        if (i !== directParent) {
           // Remove hole from skip level parents
-          children[p] = children[p].filter((c) => c !== j)
+          children[p] = children[p].filter((c) => c !== h)
         }
       })
     }
   })
+
   // map indices back to points
   return children.map((holes, i) => ({
     solid: outlines[solids[i]],

--- a/packages/modeling/src/operations/extrusions/earcut/assignHoles.test.js
+++ b/packages/modeling/src/operations/extrusions/earcut/assignHoles.test.js
@@ -1,7 +1,7 @@
 const test = require('ava')
 
-const { subtract } = require('../../../operations/booleans')
-const rectangle = require('../../../primitives/rectangle')
+const { subtract, union } = require('../../../operations/booleans')
+const square = require('../../../primitives/square')
 const assignHoles = require('./assignHoles')
 
 test('slice: assignHoles() should return a polygon hierarchy', (t) => {
@@ -20,9 +20,55 @@ test('slice: assignHoles() should return a polygon hierarchy', (t) => {
     ]]
   }]
   const geometry = subtract(
-    rectangle({ size: [6, 6] }),
-    rectangle({ size: [4, 4] })
+    square({ size: 6 }),
+    square({ size: 4 })
   )
   const obs1 = assignHoles(geometry)
+  t.deepEqual(obs1, exp1)
+})
+
+test('slice: assignHoles() should handle nested holes', (t) => {
+  const geometry = union(
+    subtract(
+      square({ size: 6 }),
+      square({ size: 4 })
+    ),
+    subtract(
+      square({ size: 10 }),
+      square({ size: 8 })
+    )
+  )
+  const obs1 = assignHoles(geometry)
+
+  const exp1 = [
+    {
+      solid: [
+        [-3.0000006060444444, -3.0000006060444444],
+        [3.0000006060444444, -3.0000006060444444],
+        [3.0000006060444444, 3.0000006060444444],
+        [-3.0000006060444444, 3.0000006060444444]
+      ],
+      holes: [[
+        [-2.0000248485333336, 2.0000248485333336],
+        [2.0000248485333336, 2.0000248485333336],
+        [2.0000248485333336, -2.0000248485333336],
+        [-2.0000248485333336, -2.0000248485333336]
+      ]]
+    },
+    {
+      solid: [
+        [-5.000025454577778, -5.000025454577778],
+        [5.000025454577778, -5.000025454577778],
+        [5.000025454577778, 5.000025454577778],
+        [-5.000025454577778, 5.000025454577778]
+      ],
+      holes: [[
+        [-3.9999763635555556, 3.9999763635555556],
+        [3.9999763635555556, 3.9999763635555556],
+        [3.9999763635555556, -3.9999763635555556],
+        [-3.9999763635555556, -3.9999763635555556]
+      ]]
+    }
+  ]
   t.deepEqual(obs1, exp1)
 })

--- a/packages/modeling/src/operations/extrusions/extrudeRectangular.test.js
+++ b/packages/modeling/src/operations/extrusions/extrudeRectangular.test.js
@@ -65,6 +65,6 @@ test('extrudeRectangular (holes)', (t) => {
 
   const obs = extrudeRectangular({ size: 2, height: 15, segments: 16, corners: 'round' }, geometry2)
   const pts = geom3.toPoints(obs)
-  t.notThrows.skip(() => geom3.validate(obs))
+  t.notThrows(() => geom3.validate(obs))
   t.is(pts.length, 192)
 })


### PR DESCRIPTION
When your validation PR reveals a bug in your own previous earcut PR.
![spidermen](https://user-images.githubusercontent.com/1766297/159625427-e6111778-910a-4174-94ab-1faa5b387ba7.jpg)

I was investigating the "skipped" validation tests, specifically the test on `extrudeRectangular.test.js:68` and realized that it was producing invalid geometry because of a bug in my earcut code. In the case where there were polygons with a hole nested inside another polygon hole, there was a bug. The test should have rendered as:
![holes2](https://user-images.githubusercontent.com/1766297/159625806-43dc7a35-21dc-4461-9810-2024c9727093.png)

But it actually looked like this:
![holes1](https://user-images.githubusercontent.com/1766297/159625780-6d8536ef-9def-4e86-a1c5-f6feccb6f59e.png)

I traced the bug to the `assignHoles` function I wrote. I wrote a test for this case, and fixed the bug. I think it should be good now. One less bug, and one more valid geometry. :-)

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
