### PR TITLE
quality of life change for demo.html

### DIFF
--- a/packages/utils/regl-renderer/demo.html
+++ b/packages/utils/regl-renderer/demo.html
@@ -201,13 +201,11 @@ const downHandler = (ev) => {
   lastX = ev.pageX
   lastY = ev.pageY
   containerElement.setPointerCapture(ev.pointerId)
-  ev.preventDefault()
 }
 
 const upHandler = (ev) => {
   pointerDown = false
   containerElement.releasePointerCapture(ev.pointerId)
-  ev.preventDefault()
 }
 
 const wheelHandler = (ev) => {


### PR DESCRIPTION
This is very small quality of life change for the demo.html

I have removed `preventDefault` from mouseup and mousedown as it is note required for proper function of orbit controls.

I had to do this in new prototype to be able to have a functioning popup-menu. Without this, opening the menu and then clicking on the 3d view (canvas) the popup menu would not hide.

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?

