### PR TITLE
Improve error handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: node_js
-node_js:
-  - "16"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "16"

--- a/packages/core/src/code-evaluation/rebuildGeometry.js
+++ b/packages/core/src/code-evaluation/rebuildGeometry.js
@@ -72,8 +72,8 @@ const rebuildSolids = (data, callback) => {
   } catch (error) {
     callback({
       type: 'errors',
-      name: error.name,
-      message: error.message,
+      name: error.name ? error.name : 'Error',
+      message: error.message ? error.message : error.toString(),
       description: error.description ? error.description : '',
       number: error.number ? error.number : '',
       fileName: error.fileName ? error.fileName : '',

--- a/packages/core/src/code-evaluation/rebuildGeometry.js
+++ b/packages/core/src/code-evaluation/rebuildGeometry.js
@@ -17,9 +17,12 @@ const applyParameterDefinitions = require('../parameters/applyParameterDefinitio
  * @param {Object} [data.parameterValues] - over-rides of parameter values (optional)
  * @param {Function} callback - function to process parameters and solids
  * @return NONE
+ *
  * This function extracts the parameters first, and then generates the solids.
  * The parsed parameters (definitions and values) are passed back to the given callback function.
  * The generated solids are also passed back to the given callback function.
+ * Also, all errors are caught and passed back to the given callback function.
+ *
  * Everything is together in a single function, because this is usually run in the context of a web worker
  * And transfering data back & forth is both complex (see transferables) and costly (time)
  **/
@@ -34,37 +37,51 @@ const rebuildSolids = (data, callback) => {
   }
   let { mainPath, apiMainPath, serialize, lookup, lookupCounts, parameterValues } = Object.assign({}, defaults, data)
 
-  const filesAndFolders = data.filesAndFolders
+  try {
+    const filesAndFolders = data.filesAndFolders
 
-  // let start = new Date()
-  const designData = loadDesign(mainPath, apiMainPath, filesAndFolders, parameterValues)
-  // send back parameter definitions & values
-  // in a worker this would be a postmessage, this is sent back early so that uis can update
-  // the parameters editor before the solids are displayed (which takes longer)
-  callback(null, {
-    type: 'params',
-    parameterDefaults: designData.parameterValues,
-    parameterDefinitions: designData.parameterDefinitions
-  })
-  // make sure parameters are correct by applying parameter definitions
-  // this might be redundant with ui-side logic, but it makes sure this core piece works regardless of ui
-  parameterValues = applyParameterDefinitions(parameterValues, designData.parameterDefinitions)
-  parameterValues = Object.assign({}, designData.parameterValues, parameterValues)
-  // start = new Date()
-  const options = {
-    lookup,
-    lookupCounts,
-    serialize
+    // let start = new Date()
+    const designData = loadDesign(mainPath, apiMainPath, filesAndFolders, parameterValues)
+    // send back parameter definitions & values
+    // in a worker this would be a postmessage, this is sent back early so that uis can update
+    // the parameters editor before the solids are displayed (which takes longer)
+    callback(null, {
+      type: 'params',
+      parameterDefaults: designData.parameterValues,
+      parameterDefinitions: designData.parameterDefinitions
+    })
+    // make sure parameters are correct by applying parameter definitions
+    // this might be redundant with ui-side logic, but it makes sure this core piece works regardless of ui
+    parameterValues = applyParameterDefinitions(parameterValues, designData.parameterDefinitions)
+    parameterValues = Object.assign({}, designData.parameterValues, parameterValues)
+    // start = new Date()
+    const options = {
+      lookup,
+      lookupCounts,
+      serialize
+    }
+    const solidsData = instanciateDesign(designData.rootModule, parameterValues, options)
+
+    // send back solids & any other metadata
+    callback(null, {
+      type: 'solids',
+      solids: solidsData.solids,
+      lookup: solidsData.lookup,
+      lookupCounts: solidsData.lookupCounts
+    })
+  } catch (error) {
+    callback({
+      type: 'errors',
+      name: error.name,
+      message: error.message,
+      description: error.description ? error.description : '',
+      number: error.number ? error.number : '',
+      fileName: error.fileName ? error.fileName : '',
+      lineNumber: error.lineNumber ? error.lineNumber : '',
+      columnNumber: error.columnNumber ? error.columnNumber : '',
+      stack: error.stack ? error.stack : ''
+    }, null)
   }
-  const solidsData = instanciateDesign(designData.rootModule, parameterValues, options)
-
-  // send back solids & any other metadata
-  callback(null, {
-    type: 'solids',
-    solids: solidsData.solids,
-    lookup: solidsData.lookup,
-    lookupCounts: solidsData.lookupCounts
-  })
 }
 
 module.exports = rebuildSolids

--- a/packages/core/src/code-evaluation/rebuildGeometryWorker.js
+++ b/packages/core/src/code-evaluation/rebuildGeometryWorker.js
@@ -13,7 +13,10 @@ const rebuildGeometryWorker = (self) => {
     if (event.data instanceof Object) {
       const { data } = event
       if (data.cmd === 'generate') {
-        rebuildGeometry(data, (err, message) => self.postMessage(message))
+        rebuildGeometry(data, (error, message) => {
+          if (message) self.postMessage(message)
+          if (error) self.postMessage(error)
+        })
       }
     }
   }

--- a/packages/web/css/demo.css
+++ b/packages/web/css/demo.css
@@ -193,9 +193,13 @@ span#paramsControls {
   color: red;
   top: 60px;
   left: 0;
-  width: 33%;
   padding:  20px;
   z-index: 1;
+}
+
+#stacktrace ul{
+  padding: 0px 0px 0px 15px;
+  margin: 0px;
 }
 
 #container{

--- a/packages/web/src/ui/flow/design.js
+++ b/packages/web/src/ui/flow/design.js
@@ -575,6 +575,17 @@ const actions = ({ sources }) => {
     .multicast()
     .delay(10) // needed , why ?
 
+  // errors retrieved from worker
+  const errorsFromWorker$ = sources.solidWorker
+    .filter((event) => event.data instanceof Object && event.data.type === 'errors')
+    .map(({ data }) => ({ error: data, origin: 'worker' }))
+
+  const reportErrorsFromWorker$ = most.mergeArray([
+    errorsFromWorker$
+  ])
+    .skipRepeatsWith(jsonCompare)
+    .tap((x) => console.log('errors', x))
+
   // ui/toggles
   const toggleAutoReload$ = most.mergeArray([
     sources.dom.select('#toggleAutoReload').events('click')
@@ -614,6 +625,8 @@ const actions = ({ sources }) => {
     setDesignSolids$,
     setDesignParameterDefinitions$,
     setDesignParameterValues$,
+
+    reportErrorsFromWorker$,
 
     requestGeometryRecompute$,
     timeoutGeometryRecompute$,

--- a/packages/web/src/ui/views/parameterControls.js
+++ b/packages/web/src/ui/views/parameterControls.js
@@ -263,19 +263,19 @@ const createInputControl = (definition, prevValue) => {
 
   // check for required parameters
   if (!('type' in definition)) {
-    throw new Error('Parameter definition (' + definition + ") must include a 'type' parameter")
+    throw new Error(`Parameter definition (${definition.name}) must include a 'type' parameter`)
   }
   let typeData = controlList.filter((x) => definition.type === x.type)
   typeData = (typeData && typeData.length > 0) ? typeData[0] : undefined
   if (!typeData) {
-    throw new Error('Parameter definition (' + definition + ') is not known')
+    throw new Error(`Parameter definition (${definition.name}), invalid type "${definition.type}"`)
   }
 
   // validate fields
   const definitionFields = Object.keys(definition)
   typeData.required.forEach((requiredField) => {
     if (!definitionFields.includes(requiredField)) {
-      throw new Error(`Parameter definition for "${definition.name}" must include a "${requiredField}" parameter`)
+      throw new Error(`Parameter definition of type "${definition.type}" must include a "${requiredField}" parameter`)
     }
   })
 

--- a/packages/web/src/ui/views/status.js
+++ b/packages/web/src/ui/views/status.js
@@ -3,29 +3,36 @@ const html = require('nanohtml')
 // status display
 const status = (state, paramsCallbacktoStream) => {
   const status = state.status
-  const errorMessage = status.error !== undefined && status.error.message ? `${status.error.message}` : ''
-  const errorLine = status.error !== undefined && status.error.lineno ? `Line: ${status.error.lineno}` : ''
-  const errorStack = status.error !== undefined && status.error.stack ? `Stack: ${status.error.stack}` : ''
+  let errorWhere = ''
+  let errorMessage = ''
+  let errorStack = ''
+  if (status.error) {
+    if (status.error.fileName && !status.error.fileName.startsWith('blob')) {
+      // syntax errors provide file name, line, and column number
+      errorWhere = `${status.error.fileName}:${status.error.lineNumber}:${status.error.columnNumber}`
+    }
+    errorMessage = `${status.error.name}: ${status.error.message}`
+    if (status.error.stack) {
+      errorStack = status.error.stack.trim().split('\n').map((s) => html`<ul>${s}</ul>`)
+    }
+  }
 
   const statusMessage = status.error !== undefined
     ? html`<span>
-    <div>
-      ERROR: 
+    <div id='errormessage'>
+      <p>
+        ${errorWhere}
+      </p>
+      <p>
+        ${errorMessage}
+      </p>
     </div>
-    <div>
-      ${errorMessage}
-    </div>
-    <div>
-      ${errorLine}
-    </div>
-    <div>
+    <div id='stacktrace'>
       ${errorStack}
     </div>
   </span>`
     : ''
 
-  // ? `Error: ${status.error.message} line: ${status.error.lineno}, filename:${status.error.filename} stack:  ${status.error.stack}` : ''
-  // ${statusMessage}
   const busy = status.busy
   return html`
       <span id='status'>


### PR DESCRIPTION
A little background on these changes.

The current error handing is kind of broken (See the first set of screen shots.) There are many reasons for the really poor messages, but basically errors are propagating from web-worker thread to main thread via a DOM event called [ErrorEvent](https://developer.mozilla.org/en-US/docs/Web/API/ErrorEvent). The information propagated is incomplete or irrelevant. And of course, important information about the real error is lost immediately.

These changes do several things.

First, the core library was enhanced (not really API breaking changes) to catch all errors (both evaluation and runtime errors), and correctly report the error back via the callback. This is NEW functionality, and may break applications that are catching the DOM ErrorEvent.

Second, the webRequire function was enhanced to catch evaluation errors (see the Function call), enhance the error with file name, and create a specific stack message with context. It actually works!

Third, the WEB UI was enhanced to handle the error message properly in the design state. As well as display the error message in a beautiful new format. :)

Forth, there were a few little bug fixes to the WEB UI to report parameter definition errors properly.

**NOTE: This still isn't perfect, but improved in many ways.**

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?