### PR TITLE
perf(modeling): use Map instead of {} for repairSlice

### DIFF
--- a/packages/modeling/src/operations/extrusions/extrudeFromSlices.js
+++ b/packages/modeling/src/operations/extrusions/extrudeFromSlices.js
@@ -5,7 +5,7 @@ const geom3 = require('../../geometries/geom3')
 const poly3 = require('../../geometries/poly3')
 
 const slice = require('./slice')
-const repairSlice = require('./slice/repairSlice')
+const repairSlice = require('./slice/repair')
 
 const extrudeWalls = require('./extrudeWalls')
 
@@ -59,7 +59,7 @@ const extrudeFromSlices = (options, base) => {
 
   // Repair gaps in the base slice
   if (repair) {
-    // note: base must be a slice, if base is geom2 this fails to repair
+    // note: base must be a slice, if base is geom2 this doesn't repair
     base = repairSlice(base)
   }
 

--- a/packages/modeling/src/operations/extrusions/extrudeFromSlices.js
+++ b/packages/modeling/src/operations/extrusions/extrudeFromSlices.js
@@ -59,7 +59,8 @@ const extrudeFromSlices = (options, base) => {
 
   // Repair gaps in the base slice
   if (repair) {
-    repairSlice(base)
+    // note: base must be a slice, if base is geom2 this fails to repair
+    base = repairSlice(base)
   }
 
   const sMax = numberOfSlices - 1

--- a/packages/modeling/src/operations/extrusions/slice/repair.js
+++ b/packages/modeling/src/operations/extrusions/slice/repair.js
@@ -4,7 +4,7 @@ const create = require('./create')
 /*
  * Mend gaps in a 2D slice to make it a closed polygon
  */
-const repairSlice = (slice) => {
+const repair = (slice) => {
   if (!slice.edges) return slice
   let edges = slice.edges
   const vertexMap = new Map() // string key to vertex map
@@ -46,7 +46,7 @@ const repairSlice = (slice) => {
         bestReplacement = v2
       }
     })
-    console.warn(`repairSlice: repairing vertex gap ${v1} to ${bestReplacement} distance ${bestDistance}`)
+    console.warn(`slice.repair: repairing vertex gap ${v1} to ${bestReplacement} distance ${bestDistance}`)
 
     // merge broken vertices
     edges = edges.map((edge) => {
@@ -59,4 +59,4 @@ const repairSlice = (slice) => {
   return create(edges)
 }
 
-module.exports = repairSlice
+module.exports = repair

--- a/packages/modeling/src/operations/extrusions/slice/repairSlice.js
+++ b/packages/modeling/src/operations/extrusions/slice/repairSlice.js
@@ -5,27 +5,36 @@ const vec3 = require('../../../maths/vec3')
  */
 const repairSlice = (slice) => {
   if (!slice.edges) return slice
-  const vertexMap = {} // string key to vertex map
-  const edgeCount = {} // count of (in - out) edges
+  const vertexMap = new Map() // string key to vertex map
+  const edgeCount = new Map() // count of (in - out) edges
+
+  // build vertex and edge count maps
   slice.edges.forEach((edge) => {
     const inKey = edge[0].toString()
     const outKey = edge[1].toString()
-    vertexMap[inKey] = edge[0]
-    vertexMap[outKey] = edge[1]
-    edgeCount[inKey] = (edgeCount[inKey] || 0) + 1 // in
-    edgeCount[outKey] = (edgeCount[outKey] || 0) - 1 // out
+    vertexMap.set(inKey, edge[0])
+    vertexMap.set(outKey, edge[1])
+    edgeCount.set(inKey, (edgeCount.get(inKey) || 0) + 1) // in
+    edgeCount.set(outKey, (edgeCount.get(outKey) || 0) - 1) // out
   })
+
   // find vertices which are missing in or out edges
-  const missingIn = Object.keys(edgeCount).filter((e) => edgeCount[e] < 0)
-  const missingOut = Object.keys(edgeCount).filter((e) => edgeCount[e] > 0)
+  const missingIn = []
+  const missingOut = []
+  edgeCount.forEach((count, vertex) => {
+    if (count < 0) missingIn.push(vertex)
+    if (count > 0) missingOut.push(vertex)
+  })
+
   // pairwise distance of bad vertices
   missingIn.forEach((key1) => {
-    const v1 = vertexMap[key1]
+    const v1 = vertexMap.get(key1)
+
     // find the closest vertex that is missing an out edge
     let bestDistance = Infinity
     let bestReplacement
     missingOut.forEach((key2) => {
-      const v2 = vertexMap[key2]
+      const v2 = vertexMap.get(key2)
       const distance = Math.hypot(v1[0] - v2[0], v1[1] - v2[1])
       if (distance < bestDistance) {
         bestDistance = distance
@@ -33,14 +42,17 @@ const repairSlice = (slice) => {
       }
     })
     console.warn(`repairSlice: repairing vertex gap ${v1} to ${bestReplacement} distance ${bestDistance}`)
+
     // merge broken vertices
     slice.edges.forEach((edge) => {
       if (edge[0].toString() === key1) edge[0] = bestReplacement
       if (edge[1].toString() === key1) edge[1] = bestReplacement
     })
   })
+
   // Remove self-edges
   slice.edges = slice.edges.filter((e) => !vec3.equals(e[0], e[1]))
+
   return slice
 }
 

--- a/packages/modeling/src/operations/extrusions/slice/repairSlice.js
+++ b/packages/modeling/src/operations/extrusions/slice/repairSlice.js
@@ -1,15 +1,20 @@
 const vec3 = require('../../../maths/vec3')
+const create = require('./create')
 
 /*
  * Mend gaps in a 2D slice to make it a closed polygon
  */
 const repairSlice = (slice) => {
   if (!slice.edges) return slice
+  let edges = slice.edges
   const vertexMap = new Map() // string key to vertex map
   const edgeCount = new Map() // count of (in - out) edges
 
+  // Remove self-edges
+  edges = edges.filter((e) => !vec3.equals(e[0], e[1]))
+
   // build vertex and edge count maps
-  slice.edges.forEach((edge) => {
+  edges.forEach((edge) => {
     const inKey = edge[0].toString()
     const outKey = edge[1].toString()
     vertexMap.set(inKey, edge[0])
@@ -44,16 +49,14 @@ const repairSlice = (slice) => {
     console.warn(`repairSlice: repairing vertex gap ${v1} to ${bestReplacement} distance ${bestDistance}`)
 
     // merge broken vertices
-    slice.edges.forEach((edge) => {
-      if (edge[0].toString() === key1) edge[0] = bestReplacement
-      if (edge[1].toString() === key1) edge[1] = bestReplacement
+    edges = edges.map((edge) => {
+      if (edge[0].toString() === key1) return [bestReplacement, edge[1]]
+      if (edge[1].toString() === key1) return [edge[0], bestReplacement]
+      return edge
     })
   })
 
-  // Remove self-edges
-  slice.edges = slice.edges.filter((e) => !vec3.equals(e[0], e[1]))
-
-  return slice
+  return create(edges)
 }
 
 module.exports = repairSlice


### PR DESCRIPTION
Faster performance in `repairSlice` function by using a `Map` instead of an object `{}`.

This gives a ~18% performance improvement on 50k segment geometries inside the `repairSlice` (105ms -> 85ms).


### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
