### PR TITLE
fix (modeling): ensure color is preserved in boolean operations

### DIFF
--- a/packages/modeling/src/geometries/poly3/invert.js
+++ b/packages/modeling/src/geometries/poly3/invert.js
@@ -15,7 +15,9 @@ const invert = (polygon) => {
     // Flip existing plane to save recompute
     inverted.plane = plane.flip(plane.create(), polygon.plane)
   }
-  inverted.color = polygon.color;
+  if(polygon.color) {
+    inverted.color = polygon.color;
+  }
   return inverted
 }
 

--- a/packages/modeling/src/geometries/poly3/invert.js
+++ b/packages/modeling/src/geometries/poly3/invert.js
@@ -15,6 +15,7 @@ const invert = (polygon) => {
     // Flip existing plane to save recompute
     inverted.plane = plane.flip(plane.create(), polygon.plane)
   }
+  inverted.color = polygon.color;
   return inverted
 }
 

--- a/packages/modeling/src/operations/booleans/trees/splitPolygonByPlane.js
+++ b/packages/modeling/src/operations/booleans/trees/splitPolygonByPlane.js
@@ -109,9 +109,15 @@ const splitPolygonByPlane = (splane, polygon) => {
       }
       if (frontvertices.length >= 3) {
         result.front = poly3.fromPointsAndPlane(frontvertices, pplane)
+        if(polygon.color){
+          result.front.color = polygon.color
+        }
       }
       if (backvertices.length >= 3) {
         result.back = poly3.fromPointsAndPlane(backvertices, pplane)
+        if(polygon.color){
+          result.front.color = polygon.color
+        }
       }
     }
   }

--- a/packages/modeling/src/operations/modifiers/reTesselateCoplanarPolygons.js
+++ b/packages/modeling/src/operations/modifiers/reTesselateCoplanarPolygons.js
@@ -20,6 +20,7 @@ const reTesselateCoplanarPolygons = (sourcepolygons) => {
   const destpolygons = []
   const numpolygons = sourcepolygons.length
   const plane = poly3.plane(sourcepolygons[0])
+  const color = sourcepolygons[0].color
   const orthobasis = new OrthoNormalBasis(plane)
   const polygonvertices2d = [] // array of array of Vector2D
   const polygontopvertexindexes = [] // array of indexes of topmost vertex per polygon
@@ -307,6 +308,7 @@ const reTesselateCoplanarPolygons = (sourcepolygons) => {
           const points2d = prevpolygon.outpolygon.rightpoints.concat(prevpolygon.outpolygon.leftpoints)
           const vertices3d = points2d.map((point2d) => orthobasis.to3D(point2d))
           const polygon = poly3.fromPointsAndPlane(vertices3d, plane) // TODO support shared
+          polygon.color = color
 
           // if we let empty polygon out, next retesselate will crash
           if (polygon.vertices.length) destpolygons.push(polygon)

--- a/packages/modeling/src/operations/modifiers/reTesselateCoplanarPolygons.js
+++ b/packages/modeling/src/operations/modifiers/reTesselateCoplanarPolygons.js
@@ -308,7 +308,9 @@ const reTesselateCoplanarPolygons = (sourcepolygons) => {
           const points2d = prevpolygon.outpolygon.rightpoints.concat(prevpolygon.outpolygon.leftpoints)
           const vertices3d = points2d.map((point2d) => orthobasis.to3D(point2d))
           const polygon = poly3.fromPointsAndPlane(vertices3d, plane) // TODO support shared
-          polygon.color = color
+          if(color) {
+            polygon.color = color
+          }
 
           // if we let empty polygon out, next retesselate will crash
           if (polygon.vertices.length) destpolygons.push(polygon)


### PR DESCRIPTION
Hello,

I am currently adding jscad to [polygonjs](https://github.com/polygonjs/polygonjs), so that it would be possible to create csg operations via a node-based interface.
One problem I've hit is that some operations, like the boolean ones, do not preserve the poly3 color of the input geometries. This PR should fix this.

See screenshots for an illustration of the problem:

the boolean inputs geom3:
![jscad_boolean_objectA](https://user-images.githubusercontent.com/59701/167273411-27b65d7c-60b1-4765-88a2-c17e8e1d641a.jpg)
![jscad_boolean_objectB](https://user-images.githubusercontent.com/59701/167273415-70aeb78b-2750-4a7a-9dd8-9b6204ce3289.jpg)

the result (without this PR) looses the color:
![jscad_boolean_result_no_color](https://user-images.githubusercontent.com/59701/167273428-81e5b010-0704-4687-aad3-fa873b319185.jpg)

or with the PR, the color is preserved:
![jscad_boolean_result_with_color](https://user-images.githubusercontent.com/59701/167273451-5b375b81-6263-4358-b857-dce1492e9bf8.jpg)

Let me know if you'd like me to adjust anything in this PR, or anything that makes it easier on your end.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?


> Note: please do NOT include build files (those generate by the build-xxx commands) with your PR,

Thank you for your help in advance, much appreciated !





