### PR TITLE
uniform segments for involute gear example

### DIFF
--- a/packages/examples/parameters/gear.js
+++ b/packages/examples/parameters/gear.js
@@ -50,7 +50,7 @@ const createSingleToothPolygon = (maxAngle, baseRadius, angularToothWidthAtBase)
   const points = [[0, 0]]
   for (let i = 0; i <= toothCurveResolution; i++) {
     // first side of the tooth:
-    const angle = maxAngle * i / toothCurveResolution
+    const angle = maxAngle * Math.pow(i / toothCurveResolution, 2 / 3)
     const tanLength = angle * baseRadius
     let radiantVector = vec2.fromAngleRadians(vec2.create(), angle)
     let tangentVector = vec2.scale(vec2.create(), vec2.normal(vec2.create(), radiantVector), -tanLength)


### PR DESCRIPTION
Very small change.

I was looking at the one of the originator repos of jscad, and found a pull request that changed the Involute Gear example which still exists in JSCAD.

From the pull request by @LunsTee [Update gears.jscad #93](https://github.com/joostn/OpenJsCad/pull/93):

> Existing code picks points on involute curve with uniform angle steps. This gives small steps on the curve close to the base circle, and larger steps away, with larger steps deviating more from the involute curve.
> 
> Deviation goes with angle*(angle step)^2. Taking the angle proportional to (i/resolution)^2/3 keeps deviation uniform, making the most out of the steps available.

OLD:
![gear-old](https://user-images.githubusercontent.com/1766297/169905737-8dae713d-99d2-433c-b105-ce31ad28ec34.png)

NEW:
![gear-new](https://user-images.githubusercontent.com/1766297/169905746-a85be66a-49fe-4381-8787-285c7557b32f.png)


### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
