### PR TITLE
refactor(modeling): refactor geometry types

### DIFF
--- a/packages/modeling/src/colors/colorize.d.ts
+++ b/packages/modeling/src/colors/colorize.d.ts
@@ -5,9 +5,10 @@ import { RGB, RGBA } from './types'
 
 export default colorize
 
-declare function colorize<T extends Geometry>(color: RGB | RGBA, object: T): T
-declare function colorize<T>(color: RGB | RGBA, object: T): T & Colored
+// Single Geom3 returns Colored Geom3
+declare function colorize<T extends Geometry>(color: RGB | RGBA, object: T): T & Colored
 
-declare function colorize<T extends Geometry>(color: RGB | RGBA, ...objects: RecursiveArray<T>): Array<T>
-declare function colorize<T>(color: RGB | RGBA, ...objects: RecursiveArray<T>): Array<T & Colored>
-declare function colorize(color: RGB | RGBA, ...objects: RecursiveArray<any>): Array<any & Colored>
+// List of Geom3 returns list of Colored Geom3
+declare function colorize<T extends Geometry>(color: RGB | RGBA, ...objects: RecursiveArray<T>): Array<T & Colored>
+// List of mixed geometries returns list of colored geometries
+declare function colorize(color: RGB | RGBA, ...objects: RecursiveArray<Geometry>): Array<Geometry & Colored>

--- a/packages/modeling/src/geometries/geom2/type.d.ts
+++ b/packages/modeling/src/geometries/geom2/type.d.ts
@@ -1,10 +1,11 @@
 import Vec2 from '../../maths/vec2/type'
 import Mat4 from '../../maths/mat4/type'
-import { Colored } from '../types'
+import { Color } from '../types'
 
 export default Geom2
 
-declare interface Geom2 extends Colored {
+declare interface Geom2 {
   sides: Array<[Vec2, Vec2]>
   transforms: Mat4
+  color?: Color
 }

--- a/packages/modeling/src/geometries/geom3/type.d.ts
+++ b/packages/modeling/src/geometries/geom3/type.d.ts
@@ -1,10 +1,11 @@
 import Poly3 from '../poly3/type'
 import Mat4 from '../../maths/mat4/type'
-import { Colored } from '../types'
+import { Color } from '../types'
 
 export default Geom3
 
-declare interface Geom3 extends Colored {
+declare interface Geom3 {
   polygons: Array<Poly3>
   transforms: Mat4
+  color?: Color
 }

--- a/packages/modeling/src/geometries/path2/type.d.ts
+++ b/packages/modeling/src/geometries/path2/type.d.ts
@@ -1,11 +1,12 @@
 import Vec2 from '../../maths/vec2/type'
 import Mat4 from '../../maths/mat4/type'
-import { Colored } from '../types'
+import { Color } from '../types'
 
 export default Path2
 
-declare interface Path2 extends Colored {
+declare interface Path2 {
   points: Array<Vec2>
   isClosed: boolean
   transforms: Mat4
+  color?: Color
 }

--- a/packages/modeling/src/geometries/poly3/type.d.ts
+++ b/packages/modeling/src/geometries/poly3/type.d.ts
@@ -1,8 +1,9 @@
 import Vec3 from '../../maths/vec3/type'
-import { Colored } from '../types'
+import { Color } from '../types'
 
 export default Poly3
 
-declare interface Poly3 extends Colored {
+declare interface Poly3 {
   vertices: Array<Vec3>
+  color?: Color
 }

--- a/packages/modeling/src/geometries/types.d.ts
+++ b/packages/modeling/src/geometries/types.d.ts
@@ -8,8 +8,10 @@ import { RGB, RGBA } from '../colors'
 // see https://github.com/jscad/OpenJSCAD.org/pull/726#issuecomment-724575265
 export type Geometry = Geom2 | Geom3 | Poly3 | Path2
 
-export type Colored = {
-  color?: RGB | RGBA
+export type Color = RGB | RGBA
+
+export interface Colored {
+  color: Color
 }
 
 export { default as Geom2 } from './geom2/type'


### PR DESCRIPTION
This is an attempt to improve the JSCAD geometry type definitions. See discussion from #1086

I made a few proposed changes:

- Changed geometries to not "extend" type `Colored`
- But all geometries have an _optional_ `color` field
- Changed `Colored` to _require_ that a color be present.
- Changed `Colored` from a type to an interface
- Defined a new `type Color = RGA | RGBA` to simplify the type definitions, and make it easier to change color types in the future

A concrete advantage is that a geometry is now only definitively colored after a call to `colorize` and this can be checked by typescript automatically. So for example this gives a type warning:

```ts
function example(geom: Geom3) {
  console.log(geom.color[0])
}
```

But this considered valid (correctly):

```ts
function example(geom: Geom3) {
  const colored = colorize([0,0,0], geom)
  console.log(colored.color[0])
}
```

I think that's pretty neat.

Feedback welcome though.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
