### PR TITLE
feat(modeling): allow zero size in primitives

### DIFF
--- a/packages/modeling/src/primitives/circle.js
+++ b/packages/modeling/src/primitives/circle.js
@@ -2,7 +2,7 @@ const { TAU } = require('../maths/constants')
 
 const ellipse = require('./ellipse')
 
-const { isGT } = require('./commonChecks')
+const { isGTE } = require('./commonChecks')
 
 /**
  * Construct a circle in two dimensional space where all points are at the same distance from the center.
@@ -28,7 +28,7 @@ const circle = (options) => {
   }
   let { center, radius, startAngle, endAngle, segments } = Object.assign({}, defaults, options)
 
-  if (!isGT(radius, 0)) throw new Error('radius must be greater than zero')
+  if (!isGTE(radius, 0)) throw new Error('radius must be positive')
 
   radius = [radius, radius]
 

--- a/packages/modeling/src/primitives/circle.test.js
+++ b/packages/modeling/src/primitives/circle.test.js
@@ -146,3 +146,10 @@ test('circle (options)', (t) => {
   t.deepEqual(pts.length, 5)
   t.true(comparePoints(pts, exp))
 })
+
+test('circle (radius zero)', (t) => {
+  const geometry = circle({ radius: 0 })
+  const pts = geom2.toPoints(geometry)
+  t.notThrows(() => geom2.validate(geometry))
+  t.is(pts.length, 0)
+})

--- a/packages/modeling/src/primitives/cube.js
+++ b/packages/modeling/src/primitives/cube.js
@@ -1,6 +1,6 @@
 const cuboid = require('./cuboid')
 
-const { isGT } = require('./commonChecks')
+const { isGTE } = require('./commonChecks')
 
 /**
  * Construct an axis-aligned solid cube in three dimensional space with six square faces.
@@ -20,7 +20,7 @@ const cube = (options) => {
   }
   let { center, size } = Object.assign({}, defaults, options)
 
-  if (!isGT(size, 0)) throw new Error('size must be greater than zero')
+  if (!isGTE(size, 0)) throw new Error('size must be positive')
 
   size = [size, size, size]
 

--- a/packages/modeling/src/primitives/cube.test.js
+++ b/packages/modeling/src/primitives/cube.test.js
@@ -46,3 +46,10 @@ test('cube (options)', (t) => {
   t.is(pts.length, 6)
   t.true(comparePolygonsAsPoints(pts, exp))
 })
+
+test('cube (zero size)', (t) => {
+  const obs = cube({ size: 0 })
+  const pts = geom3.toPoints(obs)
+  t.notThrows(() => geom3.validate(obs))
+  t.is(pts.length, 0)
+})

--- a/packages/modeling/src/primitives/cuboid.js
+++ b/packages/modeling/src/primitives/cuboid.js
@@ -23,7 +23,10 @@ const cuboid = (options) => {
 
   if (!isNumberArray(center, 3)) throw new Error('center must be an array of X, Y and Z values')
   if (!isNumberArray(size, 3)) throw new Error('size must be an array of width, depth and height values')
-  if (!size.every((n) => n > 0)) throw new Error('size values must be greater than zero')
+  if (!size.every((n) => n >= 0)) throw new Error('size values must be positive')
+
+  // if any size is zero return empty geometry
+  if (size[0] === 0 || size[1] === 0 || size[2] === 0) return geom3.create()
 
   const result = geom3.create(
     // adjust a basic shape to size

--- a/packages/modeling/src/primitives/cuboid.test.js
+++ b/packages/modeling/src/primitives/cuboid.test.js
@@ -55,3 +55,10 @@ test('cuboid (options)', (t) => {
   t.is(pts.length, 6)
   t.true(comparePolygonsAsPoints(pts, exp))
 })
+
+test('cuboid (zero size)', (t) => {
+  const obs = cuboid({ size: [1, 1, 0] })
+  const pts = geom3.toPoints(obs)
+  t.notThrows(() => geom3.validate(obs))
+  t.is(pts.length, 0)
+})

--- a/packages/modeling/src/primitives/cylinder.js
+++ b/packages/modeling/src/primitives/cylinder.js
@@ -1,6 +1,8 @@
+const geom3 = require('../geometries/geom3')
+
 const cylinderElliptic = require('./cylinderElliptic')
 
-const { isGT } = require('./commonChecks')
+const { isGTE } = require('./commonChecks')
 
 /**
  * Construct a Z axis-aligned cylinder in three dimensional space.
@@ -25,7 +27,10 @@ const cylinder = (options) => {
   }
   const { center, height, radius, segments } = Object.assign({}, defaults, options)
 
-  if (!isGT(radius, 0)) throw new Error('radius must be greater than zero')
+  if (!isGTE(radius, 0)) throw new Error('radius must be positive')
+
+  // if radius is zero return empty geometry
+  if (radius === 0) return geom3.create()
 
   const newoptions = {
     center,

--- a/packages/modeling/src/primitives/cylinder.js
+++ b/packages/modeling/src/primitives/cylinder.js
@@ -29,8 +29,8 @@ const cylinder = (options) => {
 
   if (!isGTE(radius, 0)) throw new Error('radius must be positive')
 
-  // if radius is zero return empty geometry
-  if (radius === 0) return geom3.create()
+  // if size is zero return empty geometry
+  if (height === 0 || radius === 0) return geom3.create()
 
   const newoptions = {
     center,

--- a/packages/modeling/src/primitives/cylinder.test.js
+++ b/packages/modeling/src/primitives/cylinder.test.js
@@ -74,3 +74,10 @@ test('cylinder (options)', (t) => {
   t.is(pts.length, 15)
   t.true(comparePolygonsAsPoints(pts, exp))
 })
+
+test('cylinder (zero radius)', (t) => {
+  const obs = cylinder({ radius: 0 })
+  const pts = geom3.toPoints(obs)
+  t.notThrows(() => geom3.validate(obs))
+  t.is(pts.length, 0)
+})

--- a/packages/modeling/src/primitives/cylinder.test.js
+++ b/packages/modeling/src/primitives/cylinder.test.js
@@ -14,6 +14,20 @@ test('cylinder (defaults)', (t) => {
   t.is(pts.length, 96)
 })
 
+test('cylinder (zero height)', (t) => {
+  const obs = cylinder({ height: 0 })
+  const pts = geom3.toPoints(obs)
+  t.notThrows(() => geom3.validate(obs))
+  t.is(pts.length, 0)
+})
+
+test('cylinder (zero radius)', (t) => {
+  const obs = cylinder({ radius: 0 })
+  const pts = geom3.toPoints(obs)
+  t.notThrows(() => geom3.validate(obs))
+  t.is(pts.length, 0)
+})
+
 test('cylinder (options)', (t) => {
   let obs = cylinder({ height: 10, radius: 4, segments: 5 })
   let pts = geom3.toPoints(obs)
@@ -73,11 +87,4 @@ test('cylinder (options)', (t) => {
   t.notThrows(() => geom3.validate(obs))
   t.is(pts.length, 15)
   t.true(comparePolygonsAsPoints(pts, exp))
-})
-
-test('cylinder (zero radius)', (t) => {
-  const obs = cylinder({ radius: 0 })
-  const pts = geom3.toPoints(obs)
-  t.notThrows(() => geom3.validate(obs))
-  t.is(pts.length, 0)
 })

--- a/packages/modeling/src/primitives/ellipse.js
+++ b/packages/modeling/src/primitives/ellipse.js
@@ -34,10 +34,13 @@ const ellipse = (options) => {
 
   if (!isNumberArray(center, 2)) throw new Error('center must be an array of X and Y values')
   if (!isNumberArray(radius, 2)) throw new Error('radius must be an array of X and Y values')
-  if (!radius.every((n) => n > 0)) throw new Error('radius values must be greater than zero')
+  if (!radius.every((n) => n >= 0)) throw new Error('radius values must be positive')
   if (!isGTE(startAngle, 0)) throw new Error('startAngle must be positive')
   if (!isGTE(endAngle, 0)) throw new Error('endAngle must be positive')
   if (!isGTE(segments, 3)) throw new Error('segments must be three or more')
+
+  // if any radius is zero return empty geometry
+  if (radius[0] === 0 || radius[1] === 0) return geom2.create()
 
   startAngle = startAngle % TAU
   endAngle = endAngle % TAU

--- a/packages/modeling/src/primitives/ellipse.test.js
+++ b/packages/modeling/src/primitives/ellipse.test.js
@@ -137,3 +137,10 @@ test('ellipse (options)', (t) => {
   t.notThrows(() => geom2.validate(geometry))
   t.deepEqual(obs.length, 72)
 })
+
+test('ellipse (zero radius)', (t) => {
+  const geometry = ellipse({ radius: [1, 0] })
+  const obs = geom2.toPoints(geometry)
+  t.notThrows(() => geom2.validate(geometry))
+  t.is(obs.length, 0)
+})

--- a/packages/modeling/src/primitives/ellipsoid.js
+++ b/packages/modeling/src/primitives/ellipsoid.js
@@ -32,8 +32,11 @@ const ellipsoid = (options) => {
 
   if (!isNumberArray(center, 3)) throw new Error('center must be an array of X, Y and Z values')
   if (!isNumberArray(radius, 3)) throw new Error('radius must be an array of X, Y and Z values')
-  if (!radius.every((n) => n > 0)) throw new Error('radius values must be greater than zero')
+  if (!radius.every((n) => n >= 0)) throw new Error('radius values must be positive')
   if (!isGTE(segments, 4)) throw new Error('segments must be four or more')
+
+  // if any radius is zero return empty geometry
+  if (radius[0] === 0 || radius[1] === 0 || radius[2] === 0) return geom3.create()
 
   const xvector = vec3.scale(vec3.create(), vec3.normalize(vec3.create(), axes[0]), radius[0])
   const yvector = vec3.scale(vec3.create(), vec3.normalize(vec3.create(), axes[1]), radius[1])

--- a/packages/modeling/src/primitives/ellipsoid.test.js
+++ b/packages/modeling/src/primitives/ellipsoid.test.js
@@ -207,3 +207,10 @@ test('ellipsoid (options)', (t) => {
   t.is(pts.length, 32)
   t.true(comparePolygonsAsPoints(pts, exp))
 })
+
+test('ellipsoid (zero radius)', (t) => {
+  const obs = ellipsoid({ radius: [1, 1, 0] })
+  const pts = geom3.toPoints(obs)
+  t.notThrows(() => geom3.validate(obs))
+  t.is(pts.length, 0)
+})

--- a/packages/modeling/src/primitives/geodesicSphere.js
+++ b/packages/modeling/src/primitives/geodesicSphere.js
@@ -25,8 +25,11 @@ const geodesicSphere = (options) => {
   }
   let { radius, frequency } = Object.assign({}, defaults, options)
 
-  if (!isGT(radius, 0)) throw new Error('radius must be greater than zero')
+  if (!isGTE(radius, 0)) throw new Error('radius must be positive')
   if (!isGTE(frequency, 6)) throw new Error('frequency must be six or more')
+
+  // if radius is zero return empty geometry
+  if (radius === 0) return geom3.create()
 
   // adjust the frequency to base 6
   frequency = Math.floor(frequency / 6)

--- a/packages/modeling/src/primitives/geodesicSphere.test.js
+++ b/packages/modeling/src/primitives/geodesicSphere.test.js
@@ -51,3 +51,10 @@ test('geodesicSphere (options)', (t) => {
   t.notThrows.skip(() => geom3.validate(obs))
   t.is(pts.length, 180)
 })
+
+test('geodesicSphere (zero radius)', (t) => {
+  const obs = geodesicSphere({ radius: 0 })
+  const pts = geom3.toPoints(obs)
+  t.notThrows(() => geom3.validate(obs))
+  t.is(pts.length, 0)
+})

--- a/packages/modeling/src/primitives/rectangle.js
+++ b/packages/modeling/src/primitives/rectangle.js
@@ -24,7 +24,10 @@ const rectangle = (options) => {
 
   if (!isNumberArray(center, 2)) throw new Error('center must be an array of X and Y values')
   if (!isNumberArray(size, 2)) throw new Error('size must be an array of X and Y values')
-  if (!size.every((n) => n > 0)) throw new Error('size values must be greater than zero')
+  if (!size.every((n) => n >= 0)) throw new Error('size values must be positive')
+
+  // if any size is zero return empty geometry
+  if (size[0] === 0 || size[1] === 0) return geom2.create()
 
   const point = [size[0] / 2, size[1] / 2]
   const pswap = [point[0], -point[1]]

--- a/packages/modeling/src/primitives/rectangle.test.js
+++ b/packages/modeling/src/primitives/rectangle.test.js
@@ -50,3 +50,10 @@ test('rectangle (options)', (t) => {
   t.deepEqual(obs.length, 4)
   t.true(comparePoints(obs, exp))
 })
+
+test('rectangle (zero size)', (t) => {
+  const geometry = rectangle({ size: [1, 0] })
+  const obs = geom2.toPoints(geometry)
+  t.notThrows(() => geom2.validate(geometry))
+  t.is(obs.length, 0)
+})

--- a/packages/modeling/src/primitives/roundedCuboid.js
+++ b/packages/modeling/src/primitives/roundedCuboid.js
@@ -8,7 +8,8 @@ const poly3 = require('../geometries/poly3')
 
 const { sin, cos } = require('../maths/utils/trigonometry')
 
-const { isGT, isGTE, isNumberArray } = require('./commonChecks')
+const { isGTE, isNumberArray } = require('./commonChecks')
+const cuboid = require('./cuboid')
 
 const createCorners = (center, size, radius, segments, slice, positive) => {
   const pitch = (TAU / 4) * slice / segments
@@ -135,9 +136,15 @@ const roundedCuboid = (options) => {
 
   if (!isNumberArray(center, 3)) throw new Error('center must be an array of X, Y and Z values')
   if (!isNumberArray(size, 3)) throw new Error('size must be an array of X, Y and Z values')
-  if (!size.every((n) => n > 0)) throw new Error('size values must be greater than zero')
-  if (!isGT(roundRadius, 0)) throw new Error('roundRadius must be greater than zero')
+  if (!size.every((n) => n >= 0)) throw new Error('size values must be positive')
+  if (!isGTE(roundRadius, 0)) throw new Error('roundRadius must be positive')
   if (!isGTE(segments, 4)) throw new Error('segments must be four or more')
+
+  // if any size is zero return empty geometry
+  if (size[0] === 0 || size[1] === 0 || size[2] === 0) return geom3.create()
+
+  // if roundRadius is zero, return cuboid
+  if (roundRadius === 0) return cuboid({ center, size })
 
   size = size.map((v) => v / 2) // convert to radius
 

--- a/packages/modeling/src/primitives/roundedCuboid.test.js
+++ b/packages/modeling/src/primitives/roundedCuboid.test.js
@@ -14,6 +14,20 @@ test('roundedCuboid (defaults)', (t) => {
   t.deepEqual(pts.length, 614)
 })
 
+test('roundedCuboid (zero size)', (t) => {
+  const obs = roundedCuboid({ size: [1, 1, 0] })
+  const pts = geom3.toPoints(obs)
+  t.notThrows(() => geom3.validate(obs))
+  t.is(pts.length, 0)
+})
+
+test('roundedCuboid (zero radius)', (t) => {
+  const obs = roundedCuboid({ roundRadius: 0 })
+  const pts = geom3.toPoints(obs)
+  t.notThrows(() => geom3.validate(obs))
+  t.deepEqual(pts.length, 6)
+})
+
 test('roundedCuboid (options)', (t) => {
   // test segments
   let obs = roundedCuboid({ segments: 8 })

--- a/packages/modeling/src/primitives/roundedCylinder.js
+++ b/packages/modeling/src/primitives/roundedCylinder.js
@@ -7,7 +7,8 @@ const poly3 = require('../geometries/poly3')
 
 const { sin, cos } = require('../maths/utils/trigonometry')
 
-const { isGT, isGTE, isNumberArray } = require('./commonChecks')
+const { isGTE, isNumberArray } = require('./commonChecks')
+const cylinder = require('./cylinder')
 
 /**
  * Construct a Z axis-aligned solid cylinder in three dimensional space with rounded ends.
@@ -34,11 +35,17 @@ const roundedCylinder = (options) => {
   const { center, height, radius, roundRadius, segments } = Object.assign({}, defaults, options)
 
   if (!isNumberArray(center, 3)) throw new Error('center must be an array of X, Y and Z values')
-  if (!isGT(height, 0)) throw new Error('height must be greater then zero')
-  if (!isGT(radius, 0)) throw new Error('radius must be greater then zero')
-  if (!isGT(roundRadius, 0)) throw new Error('roundRadius must be greater then zero')
-  if (roundRadius > (radius - EPS)) throw new Error('roundRadius must be smaller then the radius')
+  if (!isGTE(height, 0)) throw new Error('height must be positive')
+  if (!isGTE(radius, 0)) throw new Error('radius must be positive')
+  if (!isGTE(roundRadius, 0)) throw new Error('roundRadius must be positive')
+  if (roundRadius > radius) throw new Error('roundRadius must be smaller then the radius')
   if (!isGTE(segments, 4)) throw new Error('segments must be four or more')
+
+  // if size is zero return empty geometry
+  if (height === 0 || radius === 0) return geom3.create()
+
+  // if roundRadius is zero, return cylinder
+  if (roundRadius === 0) return cylinder({ center, height, radius })
 
   const start = [0, 0, -(height / 2)]
   const end = [0, 0, height / 2]

--- a/packages/modeling/src/primitives/roundedCylinder.test.js
+++ b/packages/modeling/src/primitives/roundedCylinder.test.js
@@ -14,6 +14,27 @@ test('roundedCylinder (defaults)', (t) => {
   t.is(pts.length, 544)
 })
 
+test('roundedCylinder (zero height)', (t) => {
+  const obs = roundedCylinder({ height: 0 })
+  const pts = geom3.toPoints(obs)
+  t.notThrows(() => geom3.validate(obs))
+  t.is(pts.length, 0)
+})
+
+test('roundedCylinder (zero radius)', (t) => {
+  const obs = roundedCylinder({ radius: 0, roundRadius: 0 })
+  const pts = geom3.toPoints(obs)
+  t.notThrows(() => geom3.validate(obs))
+  t.is(pts.length, 0)
+})
+
+test('roundedCylinder (zero roundRadius)', (t) => {
+  const obs = roundedCylinder({ roundRadius: 0 })
+  const pts = geom3.toPoints(obs)
+  t.notThrows(() => geom3.validate(obs))
+  t.is(pts.length, 96)
+})
+
 test('roundedCylinder (options)', (t) => {
   // test segments
   let obs = roundedCylinder({ segments: 5 })

--- a/packages/modeling/src/primitives/roundedRectangle.js
+++ b/packages/modeling/src/primitives/roundedRectangle.js
@@ -4,7 +4,8 @@ const vec2 = require('../maths/vec2')
 
 const geom2 = require('../geometries/geom2')
 
-const { isGT, isGTE, isNumberArray } = require('./commonChecks')
+const { isGTE, isNumberArray } = require('./commonChecks')
+const rectangle = require('./rectangle')
 
 /**
  * Construct an axis-aligned rectangle in two dimensional space with rounded corners.
@@ -30,9 +31,15 @@ const roundedRectangle = (options) => {
 
   if (!isNumberArray(center, 2)) throw new Error('center must be an array of X and Y values')
   if (!isNumberArray(size, 2)) throw new Error('size must be an array of X and Y values')
-  if (!size.every((n) => n > 0)) throw new Error('size values must be greater than zero')
-  if (!isGT(roundRadius, 0)) throw new Error('roundRadius must be greater than zero')
+  if (!size.every((n) => n >= 0)) throw new Error('size values must be positive')
+  if (!isGTE(roundRadius, 0)) throw new Error('roundRadius must be positive')
   if (!isGTE(segments, 4)) throw new Error('segments must be four or more')
+
+  // if any size is zero return empty geometry
+  if (size[0] === 0 || size[1] === 0) return geom2.create()
+
+  // if roundRadius is zero, return rectangle
+  if (roundRadius === 0) return rectangle({ center, size })
 
   size = size.map((v) => v / 2) // convert to radius
 

--- a/packages/modeling/src/primitives/roundedRectangle.test.js
+++ b/packages/modeling/src/primitives/roundedRectangle.test.js
@@ -14,6 +14,20 @@ test('roundedRectangle (defaults)', (t) => {
   t.deepEqual(obs.length, 36)
 })
 
+test('roundedRectangle (zero size)', (t) => {
+  const obs = roundedRectangle({ size: [1, 0] })
+  const pts = geom2.toPoints(obs)
+  t.notThrows(() => geom2.validate(obs))
+  t.is(pts.length, 0)
+})
+
+test('roundedRectangle (zero radius)', (t) => {
+  const obs = roundedRectangle({ roundRadius: 0 })
+  const pts = geom2.toPoints(obs)
+  t.notThrows(() => geom2.validate(obs))
+  t.deepEqual(pts.length, 4)
+})
+
 test('roundedRectangle (options)', (t) => {
   // test center
   let geometry = roundedRectangle({ center: [4, 5], segments: 16 })

--- a/packages/modeling/src/primitives/sphere.js
+++ b/packages/modeling/src/primitives/sphere.js
@@ -1,6 +1,6 @@
 const ellipsoid = require('./ellipsoid')
 
-const { isGT } = require('./commonChecks')
+const { isGTE } = require('./commonChecks')
 
 /**
  * Construct a sphere in three dimensional space where all points are at the same distance from the center.
@@ -25,7 +25,7 @@ const sphere = (options) => {
   }
   let { center, radius, segments, axes } = Object.assign({}, defaults, options)
 
-  if (!isGT(radius, 0)) throw new Error('radius must be greater than zero')
+  if (!isGTE(radius, 0)) throw new Error('radius must be positive')
 
   radius = [radius, radius, radius]
 

--- a/packages/modeling/src/primitives/sphere.test.js
+++ b/packages/modeling/src/primitives/sphere.test.js
@@ -163,3 +163,10 @@ test('sphere (options)', (t) => {
   t.is(pts.length, 32)
   t.true(comparePolygonsAsPoints(pts, exp))
 })
+
+test('sphere (zero radius)', (t) => {
+  const obs = sphere({ radius: 0 })
+  const pts = geom3.toPoints(obs)
+  t.notThrows(() => geom3.validate(obs))
+  t.is(pts.length, 0)
+})

--- a/packages/modeling/src/primitives/square.js
+++ b/packages/modeling/src/primitives/square.js
@@ -1,6 +1,6 @@
 const rectangle = require('./rectangle')
 
-const { isGT } = require('./commonChecks')
+const { isGTE } = require('./commonChecks')
 
 /**
  * Construct an axis-aligned square in two dimensional space with four equal sides at right angles.
@@ -21,7 +21,7 @@ const square = (options) => {
   }
   let { center, size } = Object.assign({}, defaults, options)
 
-  if (!isGT(size, 0)) throw new Error('size must be greater than zero')
+  if (!isGTE(size, 0)) throw new Error('size must be positive')
 
   size = [size, size]
 

--- a/packages/modeling/src/primitives/square.test.js
+++ b/packages/modeling/src/primitives/square.test.js
@@ -42,3 +42,10 @@ test('square (options)', (t) => {
   t.is(pts.length, 4)
   t.true(comparePoints(pts, exp))
 })
+
+test('square (zero size)', (t) => {
+  const geometry = square({ size: 0 })
+  const obs = geom2.toPoints(geometry)
+  t.notThrows(() => geom2.validate(geometry))
+  t.is(obs.length, 0)
+})


### PR DESCRIPTION
This PR allows primitives to "scale to zero" in size. Specifically, for rectangles and cuboids allow size equal to zero. And for ellipses and cylinders allow radius equal to zero.

Previously these primitives would throw an exception if the size was zero. This leads to a bad user experience in cases where you have a parametric design that has a parameter that might scale to zero and disappear. Right now, you need awkward special cases in your code to handle that (a user raised this issue on discord recently).

Another example where this is helpful: Using a slider parameter, today if you slide it to zero you get an exception and the design does not update on the screen. After this PR, you can scale these to zero, and it works fine:

```js
const { circle, cube, cylinder, square } = require('@jscad/modeling').primitives

const getParameterDefinitions = () => ([
  { name: "size", type: "slider", initial: 1, min: 0, max: 10 }
])

const main = ({ size }) => {
  return [
    circle({ radius: size, center: [0, 0, 0] }),
    cylinder({ radius: size, center: [5, 0, 0] }),
    cube({ size, center: [10, 0, 0] }),
    square({ size, center: [15, 0, 0] })
  ]
}

module.exports = { main, getParameterDefinitions }
```


### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
