### PR TITLE
perf(modeling): cache poly3.measureBoundingSphere for BSP performance

### DIFF
--- a/packages/modeling/src/geometries/poly3/measureBoundingSphere.d.ts
+++ b/packages/modeling/src/geometries/poly3/measureBoundingSphere.d.ts
@@ -1,6 +1,6 @@
 import Poly3 from './type'
-import Vec3 from '../../maths/vec3/type'
+import Vec4 from '../../maths/vec4/type'
 
 export default measureBoundingSphere
 
-declare function measureBoundingSphere(polygon: Poly3): [Vec3, Vec3]
+declare function measureBoundingSphere(polygon: Poly3): Vec4

--- a/packages/modeling/src/geometries/poly3/measureBoundingSphere.js
+++ b/packages/modeling/src/geometries/poly3/measureBoundingSphere.js
@@ -1,6 +1,8 @@
 const vec3 = require('../../maths/vec3')
 const measureBoundingBox = require('./measureBoundingBox')
 
+const cache = new WeakMap()
+
 /**
  * Measure the bounding sphere of the given polygon.
  * @param {poly3} polygon - the polygon to measure
@@ -8,12 +10,19 @@ const measureBoundingBox = require('./measureBoundingBox')
  * @alias module:modeling/geometries/poly3.measureBoundingSphere
  */
 const measureBoundingSphere = (polygon) => {
+  let boundingBox = cache.get(polygon)
+  if (boundingBox) return boundingBox
+
   const box = measureBoundingBox(polygon)
-  const center = box[0]
+  const center = vec3.create()
   vec3.add(center, box[0], box[1])
   vec3.scale(center, center, 0.5)
   const radius = vec3.distance(center, box[1])
-  return [center, radius]
+
+  boundingSphere = [center, radius]
+  cache.set(polygon, boundingSphere)
+
+  return boundingSphere
 }
 
 module.exports = measureBoundingSphere

--- a/packages/modeling/src/geometries/poly3/measureBoundingSphere.js
+++ b/packages/modeling/src/geometries/poly3/measureBoundingSphere.js
@@ -1,11 +1,12 @@
 const vec3 = require('../../maths/vec3')
+const vec4 = require('../../maths/vec4')
 
 const cache = new WeakMap()
 
 /**
  * Measure the bounding sphere of the given polygon.
  * @param {poly3} polygon - the polygon to measure
- * @returns {Array} the computed bounding sphere; center point (3D) and radius
+ * @returns {vec4} the computed bounding sphere; center point (3D) and radius
  * @alias module:modeling/geometries/poly3.measureBoundingSphere
  */
 const measureBoundingSphere = (polygon) => {
@@ -13,13 +14,14 @@ const measureBoundingSphere = (polygon) => {
   if (boundingSphere) return boundingSphere
 
   const vertices = polygon.vertices
-  const center = vec3.create()
+  const out = vec4.create()
 
   if (vertices.length === 0) {
-    center[0] = 0
-    center[1] = 0
-    center[2] = 0
-    return [center, 0]
+    out[0] = 0
+    out[1] = 0
+    out[2] = 0
+    out[3] = 0
+    return out
   }
 
   // keep a list of min/max vertices by axis
@@ -39,15 +41,14 @@ const measureBoundingSphere = (polygon) => {
     if (maxz[2] < v[2]) maxz = v
   })
 
-  center[0] = (minx[0] + maxx[0]) * 0.5 // center of sphere
-  center[1] = (miny[1] + maxy[1]) * 0.5
-  center[2] = (minz[2] + maxz[2]) * 0.5
-  const x = center[0] - maxx[0]
-  const y = center[1] - maxy[1]
-  const z = center[2] - maxz[2]
-  const radius = Math.sqrt(x * x + y * y + z * z) // radius of sphere
+  out[0] = (minx[0] + maxx[0]) * 0.5 // center of sphere
+  out[1] = (miny[1] + maxy[1]) * 0.5
+  out[2] = (minz[2] + maxz[2]) * 0.5
+  const x = out[0] - maxx[0]
+  const y = out[1] - maxy[1]
+  const z = out[2] - maxz[2]
+  out[3] = Math.sqrt(x * x + y * y + z * z) // radius of sphere
 
-  const out = [center, radius]
   cache.set(polygon, out)
 
   return out

--- a/packages/modeling/src/geometries/poly3/measureBoundingSphere.test.js
+++ b/packages/modeling/src/geometries/poly3/measureBoundingSphere.test.js
@@ -3,28 +3,23 @@ const { measureBoundingSphere, create, fromPoints, transform } = require('./inde
 
 const mat4 = require('../../maths/mat4')
 
-const { compareVectors, nearlyEqual } = require('../../../test/helpers/index')
-
 test('poly3: measureBoundingSphere() should return correct values', (t) => {
   let ply1 = create()
-  let exp1 = [[0, 0, 0], 0]
+  let exp1 = [0, 0, 0, 0]
   let ret1 = measureBoundingSphere(ply1)
-  t.true(compareVectors(ret1[0], exp1[0]))
-  nearlyEqual(t, ret1[1], exp1[1], Number.EPSILON)
+  t.deepEqual(ret1, exp1)
 
   // simple triangle
   let ply2 = fromPoints([[0, 0, 0], [0, 10, 0], [0, 10, 10]])
-  let exp2 = [[0, 5, 5], 7.0710678118654755]
+  let exp2 = [0, 5, 5, 7.0710678118654755]
   let ret2 = measureBoundingSphere(ply2)
-  t.true(compareVectors(ret2[0], exp2[0]))
-  nearlyEqual(t, ret2[1], exp2[1], Number.EPSILON)
+  t.deepEqual(ret2, exp2)
 
   // simple square
   let ply3 = fromPoints([[0, 0, 0], [0, 10, 0], [0, 10, 10], [0, 0, 10]])
-  let exp3 = [[0, 5, 5], 7.0710678118654755]
+  let exp3 = [0, 5, 5, 7.0710678118654755]
   let ret3 = measureBoundingSphere(ply3)
-  t.true(compareVectors(ret3[0], exp3[0]))
-  nearlyEqual(t, ret3[1], exp3[1], Number.EPSILON)
+  t.deepEqual(ret3, exp3)
 
   // V-shape
   const points = [
@@ -40,10 +35,9 @@ test('poly3: measureBoundingSphere() should return correct values', (t) => {
     [0, 3, 3]
   ]
   let ply4 = fromPoints(points)
-  let exp4 = [[0, 4.5, 3], 4.6097722286464435]
+  let exp4 = [0, 4.5, 3, 4.6097722286464435]
   let ret4 = measureBoundingSphere(ply4)
-  t.true(compareVectors(ret4[0], exp4[0]))
-  nearlyEqual(t, ret4[1], exp4[1], Number.EPSILON)
+  t.deepEqual(ret4, exp4)
 
   // rotated to various angles
   const rotation = mat4.fromZRotation(mat4.create(), (45 * 0.017453292519943295))
@@ -55,16 +49,12 @@ test('poly3: measureBoundingSphere() should return correct values', (t) => {
   ret2 = measureBoundingSphere(ply2)
   ret3 = measureBoundingSphere(ply3)
   ret4 = measureBoundingSphere(ply4)
-  exp1 = [[0, 0, 0], 0]
-  t.true(compareVectors(ret1[0], exp1[0]))
-  nearlyEqual(t, ret1[1], exp1[1], Number.EPSILON)
-  exp2 = [[-3.5355339059327373, 3.5355339059327378, 5], 7.0710678118654755]
-  t.true(compareVectors(ret2[0], exp2[0]))
-  nearlyEqual(t, ret2[1], exp2[1], Number.EPSILON)
-  exp3 = [[-3.5355339059327373, 3.5355339059327378, 5], 7.0710678118654755]
-  t.true(compareVectors(ret3[0], exp3[0]))
-  nearlyEqual(t, ret3[1], exp3[1], Number.EPSILON)
-  exp4 = [[-3.181980515339464, 3.1819805153394642, 3], 4.6097722286464435]
-  t.true(compareVectors(ret4[0], exp4[0]))
-  nearlyEqual(t, ret4[1], exp4[1], Number.EPSILON)
+  exp1 = [0, 0, 0, 0]
+  t.deepEqual(ret1, exp1)
+  exp2 = [-3.5355339059327373, 3.5355339059327378, 5, 7.0710678118654755]
+  t.deepEqual(ret2, exp2)
+  exp3 = [-3.5355339059327373, 3.5355339059327378, 5, 7.0710678118654755]
+  t.deepEqual(ret3, exp3)
+  exp4 = [-3.181980515339464, 3.1819805153394642, 3, 4.6097722286464435]
+  t.deepEqual(ret4, exp4)
 })

--- a/packages/modeling/src/operations/booleans/trees/PolygonTreeNode.js
+++ b/packages/modeling/src/operations/booleans/trees/PolygonTreeNode.js
@@ -132,8 +132,8 @@ class PolygonTreeNode {
     const polygon = this.polygon
     if (polygon) {
       const bound = poly3.measureBoundingSphere(polygon)
-      const sphereradius = bound[1] + EPS // ensure radius is LARGER then polygon
-      const spherecenter = bound[0]
+      const sphereradius = bound[3] + EPS // ensure radius is LARGER then polygon
+      const spherecenter = bound
       const d = vec3.dot(splane, spherecenter) - splane[3]
       if (d > sphereradius) {
         frontnodes.push(this)


### PR DESCRIPTION
A number of performance issues were pointed out by @briansturgill. One of them was caching of `measureBoundingSphere` in the BSP boolean operations (#1094). BSP operations use measureBoundingSphere to determine if objects overlap.

By adding caching to `poly3.measureBoundingSphere`, we can get a significant speed up in BSP operations. This uses the same caching code as in the `measurements` package, but applied to the `poly3` package.

For unioning two overlapping spheres with 100 segments, we get **49,366** cache misses (measurements), and **97,030,301** cache hits saved! That's a 99.95% cache hit rate. :grimacing: 

This results in major performance improvements as measured in BSP union operations. Comparing the last release 2.5.10, master (with no-hypot #1099), and measureBoundingSphere caching:

|  | 2.5.10 | master | caching |
| --- | --- | --- | --- |
| disjoint (x=4) | 480ms | 480ms | 480ms |
| touching (x=2) | 8500ms | 5800ms | 3800ms |
| overlap (x=1) | 8900ms | 5850ms | 4000ms |
| same (x=0) | 7300ms | 4800ms | 3700ms |
| inside (x=0) | 4850ms | 3300ms | 2500ms |

So roughly speaking, removing `hypot` gave a ~30% improvement, and caching gives ANOTHER ~30% performance improvement. This gives a total speedup in BSP operations of 48-55% this month! :sunglasses: 


### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
