### PR TITLE
fix path2

### DIFF
--- a/packages/modeling/src/geometries/path2/appendPoints.js
+++ b/packages/modeling/src/geometries/path2/appendPoints.js
@@ -1,5 +1,5 @@
-const fromPoints = require('./fromPoints')
-const toPoints = require('./toPoints')
+const concat = require('./concat')
+const create = require('./create')
 
 /**
  * Append the given list of points to the end of the given geometry.
@@ -10,15 +10,6 @@ const toPoints = require('./toPoints')
  * @example
  * let newpath = appendPoints([[3, 4], [4, 5]], oldpath)
  */
-const appendPoints = (points, geometry) => {
-  if (geometry.isClosed) {
-    throw new Error('cannot append points to a closed path')
-  }
-
-  let newpoints = toPoints(geometry)
-  newpoints = newpoints.concat(points)
-
-  return fromPoints({}, newpoints)
-}
+const appendPoints = (points, geometry) => concat(geometry, create(points))
 
 module.exports = appendPoints

--- a/packages/modeling/src/geometries/path2/appendPoints.test.js
+++ b/packages/modeling/src/geometries/path2/appendPoints.test.js
@@ -17,3 +17,19 @@ test('appendPoints: appending to a path produces a new path with expected points
   t.not(p1, obs)
   t.is(pts.length, 4)
 })
+
+test('appendPoints: appending empty points to a path produces a new path with expected points', (t) => {
+  const p1 = fromPoints({}, [[1, 1], [2, 2]])
+  const obs = appendPoints([], p1)
+  const pts = toPoints(obs)
+  t.not(p1, obs)
+  t.is(pts.length, 2)
+})
+
+test('appendPoints: appending same points to a path produces a new path with expected points', (t) => {
+  const p1 = fromPoints({}, [[1, 1], [2, 2]])
+  const obs = appendPoints([[2, 2], [3, 3]], p1)
+  const pts = toPoints(obs)
+  t.not(p1, obs)
+  t.is(pts.length, 3)
+})

--- a/packages/modeling/src/geometries/path2/concat.js
+++ b/packages/modeling/src/geometries/path2/concat.js
@@ -1,8 +1,11 @@
 const fromPoints = require('./fromPoints')
 const toPoints = require('./toPoints')
+
 const { equals } = require('../../maths/vec2')
+
 /**
  * Concatenate the given paths.
+ *
  * If both contain the same point at the junction, merge it into one.
  * A concatenation of zero paths is an empty, open path.
  * A concatenation of one closed path to a series of open paths produces a closed path.
@@ -17,16 +20,14 @@ const { equals } = require('../../maths/vec2')
 const concat = (...paths) => {
   // Only the last path can be closed, producing a closed path.
   let isClosed = false
-  for (const path of paths) {
-    if (isClosed) {
-      throw new Error('Cannot concatenate to a closed path')
+  let newpoints = []
+  paths.forEach((path, i) => {
+    const tmp = toPoints(path).slice()
+    if (newpoints.length > 0 && tmp.length > 0 && equals(tmp[0], newpoints[newpoints.length - 1])) tmp.shift()
+    if (tmp.length > 0 && isClosed) {
+      throw new Error(`Cannot concatenate to a closed path; check the ${i}th path`)
     }
     isClosed = path.isClosed
-  }
-  let newpoints = []
-  paths.forEach((path) => {
-    const tmp = toPoints(path)
-    if (newpoints.length > 0 && tmp.length > 0 && equals(tmp[0], newpoints[newpoints.length - 1])) tmp.shift()
     newpoints = newpoints.concat(tmp)
   })
   return fromPoints({ closed: isClosed }, newpoints)

--- a/packages/modeling/src/geometries/path2/concat.test.js
+++ b/packages/modeling/src/geometries/path2/concat.test.js
@@ -10,10 +10,16 @@ test('concat: empty paths produces an empty open path', (t) => {
   t.true(equals(concat(fromPoints({}, []), fromPoints({}, [])), fromPoints({ closed: false }, [])))
 })
 
-test('concat: Two open paths produces a open path', (t) => {
-  t.true(equals(concat(fromPoints({ closed: false }, [[0, 0]]),
-    fromPoints({ closed: false }, [[1, 1]])),
-  fromPoints({ closed: false }, [[0, 0], [1, 1]])))
+test('concat: many open paths produces a open path', (t) => {
+  const p1 = fromPoints({ closed: false }, [[0, 0]])
+  const p2 = fromPoints({ closed: false }, [[1, 1]])
+  const p3 = fromPoints({ closed: false }, [[1, 1], [3, 3]])
+
+  const result = concat(p1, p2, p3)
+  t.true(equals(result, fromPoints({}, [[0, 0], [1, 1], [3, 3]])))
+  t.is(p1.points.length, 1)
+  t.is(p2.points.length, 1)
+  t.is(p3.points.length, 2)
 })
 
 test('concat: An open path and a closed path produces a closed path', (t) => {
@@ -23,7 +29,7 @@ test('concat: An open path and a closed path produces a closed path', (t) => {
 })
 
 test('concat: A closed path and an open path throws an error', (t) => {
-  t.throws(() => concat(fromPoints({ closed: true }, [[0, 0]]),
-    fromPoints({ closed: false }, [[1, 1]])),
-  { message: 'Cannot concatenate to a closed path' })
+  const p1 = fromPoints({ closed: true }, [[0, 0]])
+  const p2 = fromPoints({ closed: false }, [[1, 1]])
+  t.throws(() => concat(p1, p2), { message: 'Cannot concatenate to a closed path; check the 1th path' })
 })


### PR DESCRIPTION
While working on some issues with the SVG deserializer, I found some issues with path2. These changes fix some issues, and enhance concat() to allow empty paths.

Summary
- appendPoints() has been changes to use concat()
- concat() has been fixed to prevent modifying the original paths
- concat() has been enhanced to ignore empty paths

The last enhancement to concat() allows the appending of the same point to the end of a path, which is very common in SVG path definitions from Inkscape.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Does your submission pass tests?