### PR TITLE
fix 1135 svg start == end point throw unecessary error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ objects/
 
 # project ignores
 packages/web/examples/
+.history

--- a/packages/io/svg-deserializer/src/shapesMapGeometry.js
+++ b/packages/io/svg-deserializer/src/shapesMapGeometry.js
@@ -428,7 +428,6 @@ const expandPath = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups
 
     if (pc !== true && paths[pathName] && paths[pathName].isClosed) {
       let coNext = obj.commands[j + 1]
-
       if (!coNext || !isCloseCmd(coNext.c)) {
         if (pathSelfClosed === 'trim') {
           while (coNext && !isCloseCmd(coNext.c)) {
@@ -437,7 +436,7 @@ const expandPath = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups
           }
         } else if (pathSelfClosed === 'split') {
           newPath()
-        } else {
+        } else if(coNext){ // allow self close in the last command #1135
           throw new Error(`Malformed svg path at ${obj.position[0]}:${co.pos}. Path closed itself with command #${j} ${co.c}${pts.join(' ')}`)
         }
       }

--- a/packages/io/svg-deserializer/src/shapesMapGeometry.js
+++ b/packages/io/svg-deserializer/src/shapesMapGeometry.js
@@ -428,7 +428,9 @@ const expandPath = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups
 
     if (pc !== true && paths[pathName] && paths[pathName].isClosed) {
       let coNext = obj.commands[j + 1]
-      if (!coNext || !isCloseCmd(coNext.c)) {
+      // allow self close in the last command #1135 (coNext is null or undefined)
+      // if do have a next command use pathSelfClosed to decide how to react to closing in the middle of a path 
+      if (coNext && !isCloseCmd(coNext.c)) {
         if (pathSelfClosed === 'trim') {
           while (coNext && !isCloseCmd(coNext.c)) {
             j++
@@ -436,7 +438,7 @@ const expandPath = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups
           }
         } else if (pathSelfClosed === 'split') {
           newPath()
-        } else if(coNext){ // allow self close in the last command #1135
+        }else{ 
           throw new Error(`Malformed svg path at ${obj.position[0]}:${co.pos}. Path closed itself with command #${j} ${co.c}${pts.join(' ')}`)
         }
       }

--- a/packages/io/svg-deserializer/tests/issue.1135.test.js
+++ b/packages/io/svg-deserializer/tests/issue.1135.test.js
@@ -1,0 +1,10 @@
+const test = require('ava')
+
+const deserializer = require('../src/index.js')
+
+test('deserialize issue 885 do not fail on close at the end', (t) => {
+  const svg = `<svg><g><path d="M0 0 L10 10L10 0L0 0" id="path4544" /></g></svg>`
+
+  shapes = deserializer.deserialize({ output: 'geometry', pathSelfClosed: 'error' }, svg)
+  t.is(shapes.length, 1)
+})


### PR DESCRIPTION
fix for #1135

there is no need to throw error when last point is same as first point in svg.

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?

