### PR TITLE
add extrudeHelical

### DIFF
--- a/packages/modeling/src/operations/extrusions/extrudeHelical.d.ts
+++ b/packages/modeling/src/operations/extrusions/extrudeHelical.d.ts
@@ -4,8 +4,10 @@ export default extrudeHelical
 
 export interface ExtrudeHelicalOptions {
   angle?: number
+  startAngle?: number
   pitch?: number
-  endRadiusOffset?: number
+  height?: number
+  endOffset?: number
   segments?: number
 }
 

--- a/packages/modeling/src/operations/extrusions/extrudeHelical.d.ts
+++ b/packages/modeling/src/operations/extrusions/extrudeHelical.d.ts
@@ -8,7 +8,7 @@ export interface ExtrudeHelicalOptions {
   pitch?: number
   height?: number
   endOffset?: number
-  segments?: number
+  segmentsPerRotation?: number
 }
 
 declare function extrudeHelical(options: ExtrudeHelicalOptions, geometry: Geom2): Geom3

--- a/packages/modeling/src/operations/extrusions/extrudeHelical.d.ts
+++ b/packages/modeling/src/operations/extrusions/extrudeHelical.d.ts
@@ -1,0 +1,12 @@
+import { Geom2, Geom3 } from '../../geometries/types'
+
+export default extrudeHelical
+
+export interface ExtrudeHelicalOptions {
+  angle?: number
+  pitch?: number
+  endRadiusOffset?: number
+  segments?: number
+}
+
+declare function extrudeHelical(options: ExtrudeHelicalOptions, geometry: Geom2): Geom3

--- a/packages/modeling/src/operations/extrusions/extrudeHelical.js
+++ b/packages/modeling/src/operations/extrusions/extrudeHelical.js
@@ -76,7 +76,7 @@ const extrudeHelical = (options, geometry) => {
     mat4.multiply(
       step1,
       // then apply offsets
-      mat4.fromTranslation(mat4.create(), [xOffset, 0, zOffset]),
+      mat4.fromTranslation(mat4.create(), [xOffset, 0, zOffset * Math.sign(angle)]),
       // first rotate "flat" 2D shape from XY to XZ plane
       mat4.fromXRotation(mat4.create(), -TAU / 4 * Math.sign(angle)) // rotate the slice correctly to not create inside-out polygon
     )

--- a/packages/modeling/src/operations/extrusions/extrudeHelical.js
+++ b/packages/modeling/src/operations/extrusions/extrudeHelical.js
@@ -13,7 +13,7 @@ const geom2 = require('../../geometries/geom2')
  * @param {Number} [options.pitch=10] - elevation gain for each turn
  * @param {Number} [options.height] - total height of the helix path. Ignored if pitch is set.
  * @param {Number} [options.endOffset=0] - offset the final radius of the extrusion, allowing for tapered helix, and or spiral
- * @param {Number} [options.segmentsPerRotation=32] - number of segments of the extrusion
+ * @param {Number} [options.segmentsPerRotation=32] - number of segments per full rotation of the extrusion
  * @param {geom2} geometry - the geometry to extrude
  * @returns {geom3} the extruded geometry
  * @alias module:modeling/extrusions.extrudeHelical

--- a/packages/modeling/src/operations/extrusions/extrudeHelical.js
+++ b/packages/modeling/src/operations/extrusions/extrudeHelical.js
@@ -27,55 +27,55 @@ const geom2 = require('../../geometries/geom2')
  * )
  */
 const extrudeHelical = (options, geometry) => {
-    const defaults = {
-        angle: TAU,
-        pitch: 10,
-        endRadiusOffset: 0,
-        segments: 32
-    }
-    const { angle, pitch, endRadiusOffset, segments } = Object.assign({}, defaults, options)
+  const defaults = {
+    angle: TAU,
+    pitch: 10,
+    endRadiusOffset: 0,
+    segments: 32
+  }
+  const { angle, pitch, endRadiusOffset, segments } = Object.assign({}, defaults, options)
 
-    const baseSlice = slice.fromSides(geom2.toSides(geometry))
+  const baseSlice = slice.fromSides(geom2.toSides(geometry))
 
-    const sliceCallback = (progress, index, base) => {
-        const zRotation = angle / segments * index
-        const xOffset = endRadiusOffset / segments * index
-        const zOffset = zRotation / TAU * pitch
+  const sliceCallback = (progress, index, base) => {
+    const zRotation = angle / segments * index
+    const xOffset = endRadiusOffset / segments * index
+    const zOffset = zRotation / TAU * pitch
 
-        // TODO: check for valid geometry after translations
-        // ie all the points have to be either x > -xOffset or x < -xOffset
-        // this would have to be checked for every transform, and handled
-        //
-        // not implementing, as this currently doesn't break anything,
-        // only creates inside-out polygons
+    // TODO: check for valid geometry after translations
+    // ie all the points have to be either x > -xOffset or x < -xOffset
+    // this would have to be checked for every transform, and handled
+    //
+    // not implementing, as this currently doesn't break anything,
+    // only creates inside-out polygons
 
-        // create transformation matrix
-        const step1 = mat4.create()
-        mat4.multiply(
-            step1,
-            // then apply offsets
-            mat4.fromTranslation(mat4.create(), [xOffset, 0, zOffset]),
-            // first rotate "flat" 2D shape from XY to XZ plane
-            mat4.fromXRotation(mat4.create(), -TAU / 4) // putting TAU/4 here creates inside-out polygon
-        )
-        
-        const matrix = mat4.create()
-        mat4.multiply(
-            matrix,
-            // finally rotate around Z axis
-            mat4.fromZRotation(mat4.create(), zRotation),
-            step1
-        )
-        return slice.transform(matrix, base)
-    }
-
-    return extrudeFromSlices(
-        {
-            numberOfSlices: segments,
-            callback: sliceCallback
-        },
-        baseSlice
+    // create transformation matrix
+    const step1 = mat4.create()
+    mat4.multiply(
+      step1,
+      // then apply offsets
+      mat4.fromTranslation(mat4.create(), [xOffset, 0, zOffset]),
+      // first rotate "flat" 2D shape from XY to XZ plane
+      mat4.fromXRotation(mat4.create(), -TAU / 4) // putting TAU/4 here creates inside-out polygon
     )
+
+    const matrix = mat4.create()
+    mat4.multiply(
+      matrix,
+      // finally rotate around Z axis
+      mat4.fromZRotation(mat4.create(), zRotation),
+      step1
+    )
+    return slice.transform(matrix, base)
+  }
+
+  return extrudeFromSlices(
+    {
+      numberOfSlices: segments,
+      callback: sliceCallback
+    },
+    baseSlice
+  )
 }
 
 module.exports = extrudeHelical

--- a/packages/modeling/src/operations/extrusions/extrudeHelical.js
+++ b/packages/modeling/src/operations/extrusions/extrudeHelical.js
@@ -11,6 +11,7 @@ const geom2 = require('../../geometries/geom2')
  * @param {Number} [options.angle=TAU] - angle of the extrusion (RADIANS) positive for right-hand rotation, negative for left-hand
  * @param {Number} [options.startAngle=0] - start angle of the extrusion (RADIANS)
  * @param {Number} [options.pitch=10] - elevation gain for each turn
+ * @param {Number} [options.height] - total height of the helix path. Ignored if pitch is set.
  * @param {Number} [options.endRadiusOffset=0] - offset the final radius of the extrusion, allowing for tapered helix, and or spiral
  * @param {Number} [options.segments=32] - number of segments of the extrusion
  * @param {geom2} geometry - the geometry to extrude
@@ -35,7 +36,15 @@ const extrudeHelical = (options, geometry) => {
     endRadiusOffset: 0,
     segments: 32
   }
-  const { angle, pitch, endRadiusOffset, segments } = Object.assign({}, defaults, options)
+  const { angle, endRadiusOffset, segments, startAngle } = Object.assign({}, defaults, options)
+
+  let pitch
+  // ignore height if pitch is set
+  if(!options.pitch && options.height) {
+    pitch = options.height / (angle / TAU)
+  } else {
+    pitch = options.pitch ? options.pitch : defaults.pitch
+  }
 
   if (segments < 2) throw new Error('segments must be greater than 1')
 

--- a/packages/modeling/src/operations/extrusions/extrudeHelical.js
+++ b/packages/modeling/src/operations/extrusions/extrudeHelical.js
@@ -9,6 +9,7 @@ const geom2 = require('../../geometries/geom2')
  *
  * @param {Object} options - options for extrusion
  * @param {Number} [options.angle=TAU] - angle of the extrusion (RADIANS) positive for right-hand rotation, negative for left-hand
+ * @param {Number} [options.startAngle=0] - start angle of the extrusion (RADIANS)
  * @param {Number} [options.pitch=10] - elevation gain for each turn
  * @param {Number} [options.endRadiusOffset=0] - offset the final radius of the extrusion, allowing for tapered helix, and or spiral
  * @param {Number} [options.segments=32] - number of segments of the extrusion
@@ -29,6 +30,7 @@ const geom2 = require('../../geometries/geom2')
 const extrudeHelical = (options, geometry) => {
   const defaults = {
     angle: TAU,
+    startAngle: 0,
     pitch: 10,
     endRadiusOffset: 0,
     segments: 32
@@ -40,9 +42,9 @@ const extrudeHelical = (options, geometry) => {
   const baseSlice = slice.fromSides(geom2.toSides(geometry))
 
   const sliceCallback = (progress, index, base) => {
-    const zRotation = angle / segments * index
+    const zRotation = startAngle + angle / segments * index
     const xOffset = endRadiusOffset / segments * index
-    const zOffset = zRotation / TAU * pitch
+    const zOffset = (zRotation - startAngle) / TAU * pitch
 
     // TODO: check for valid geometry after translations
     // ie all the points have to be either x > -xOffset or x < -xOffset

--- a/packages/modeling/src/operations/extrusions/extrudeHelical.js
+++ b/packages/modeling/src/operations/extrusions/extrudeHelical.js
@@ -47,10 +47,11 @@ const extrudeHelical = (options, geometry) => {
   }
 
   // needs at least 3 segments for each revolution
-  const minNumberOfSegments = Math.ceil(angle / TAU) * 3
+  const minNumberOfSegments = Math.ceil(Math.abs(angle) / TAU) * 3
 
   if (segments < minNumberOfSegments)
-    throw new Error(`For a rotation of ${angle - startAngle} radians there need to be at least ${minNumberOfSegments} segments.`)
+    throw new Error(`For a rotation of ${angle - startAngle} radians there need to be at least ${minNumberOfSegments} segments.
+  Only ${segments} segments were specified.`)
 
   const baseSlice = slice.fromSides(geom2.toSides(geometry))
 

--- a/packages/modeling/src/operations/extrusions/extrudeHelical.js
+++ b/packages/modeling/src/operations/extrusions/extrudeHelical.js
@@ -78,7 +78,7 @@ const extrudeHelical = (options, geometry) => {
       // then apply offsets
       mat4.fromTranslation(mat4.create(), [xOffset, 0, zOffset]),
       // first rotate "flat" 2D shape from XY to XZ plane
-      mat4.fromXRotation(mat4.create(), -TAU / 4) // putting TAU/4 here creates inside-out polygon
+      mat4.fromXRotation(mat4.create(), -TAU / 4 * Math.sign(angle)) // rotate the slice correctly to not create inside-out polygon
     )
 
     matrix = mat4.create()

--- a/packages/modeling/src/operations/extrusions/extrudeHelical.js
+++ b/packages/modeling/src/operations/extrusions/extrudeHelical.js
@@ -50,6 +50,10 @@ const extrudeHelical = (options, geometry) => {
 
   const baseSlice = slice.fromSides(geom2.toSides(geometry))
 
+
+  // define transform matrix variables for performance increase
+  let step1
+  let matrix
   const sliceCallback = (progress, index, base) => {
     const zRotation = startAngle + angle / segments * index
     const xOffset = endOffset / segments * index
@@ -63,7 +67,7 @@ const extrudeHelical = (options, geometry) => {
     // only creates inside-out polygons
 
     // create transformation matrix
-    const step1 = mat4.create()
+    step1 = mat4.create()
     mat4.multiply(
       step1,
       // then apply offsets
@@ -72,7 +76,7 @@ const extrudeHelical = (options, geometry) => {
       mat4.fromXRotation(mat4.create(), -TAU / 4) // putting TAU/4 here creates inside-out polygon
     )
 
-    const matrix = mat4.create()
+    matrix = mat4.create()
     mat4.multiply(
       matrix,
       // finally rotate around Z axis

--- a/packages/modeling/src/operations/extrusions/extrudeHelical.js
+++ b/packages/modeling/src/operations/extrusions/extrudeHelical.js
@@ -12,7 +12,7 @@ const geom2 = require('../../geometries/geom2')
  * @param {Number} [options.startAngle=0] - start angle of the extrusion (RADIANS)
  * @param {Number} [options.pitch=10] - elevation gain for each turn
  * @param {Number} [options.height] - total height of the helix path. Ignored if pitch is set.
- * @param {Number} [options.endRadiusOffset=0] - offset the final radius of the extrusion, allowing for tapered helix, and or spiral
+ * @param {Number} [options.endOffset=0] - offset the final radius of the extrusion, allowing for tapered helix, and or spiral
  * @param {Number} [options.segments=32] - number of segments of the extrusion
  * @param {geom2} geometry - the geometry to extrude
  * @returns {geom3} the extruded geometry
@@ -33,10 +33,10 @@ const extrudeHelical = (options, geometry) => {
     angle: TAU,
     startAngle: 0,
     pitch: 10,
-    endRadiusOffset: 0,
+    endOffset: 0,
     segments: 32
   }
-  const { angle, endRadiusOffset, segments, startAngle } = Object.assign({}, defaults, options)
+  const { angle, endOffset, segments, startAngle } = Object.assign({}, defaults, options)
 
   let pitch
   // ignore height if pitch is set
@@ -52,7 +52,7 @@ const extrudeHelical = (options, geometry) => {
 
   const sliceCallback = (progress, index, base) => {
     const zRotation = startAngle + angle / segments * index
-    const xOffset = endRadiusOffset / segments * index
+    const xOffset = endOffset / segments * index
     const zOffset = (zRotation - startAngle) / TAU * pitch
 
     // TODO: check for valid geometry after translations

--- a/packages/modeling/src/operations/extrusions/extrudeHelical.js
+++ b/packages/modeling/src/operations/extrusions/extrudeHelical.js
@@ -71,7 +71,8 @@ const extrudeHelical = (options, geometry) => {
 
   return extrudeFromSlices(
     {
-      numberOfSlices: segments,
+      // "base" slice is counted as segment, so add one for complete final rotation
+      numberOfSlices: segments + 1,
       callback: sliceCallback
     },
     baseSlice

--- a/packages/modeling/src/operations/extrusions/extrudeHelical.js
+++ b/packages/modeling/src/operations/extrusions/extrudeHelical.js
@@ -13,7 +13,7 @@ const geom2 = require('../../geometries/geom2')
  * @param {Number} [options.pitch=10] - elevation gain for each turn
  * @param {Number} [options.height] - total height of the helix path. Ignored if pitch is set.
  * @param {Number} [options.endOffset=0] - offset the final radius of the extrusion, allowing for tapered helix, and or spiral
- * @param {Number} [options.segments=32] - number of segments of the extrusion
+ * @param {Number} [options.segmentsPerRotation=32] - number of segments of the extrusion
  * @param {geom2} geometry - the geometry to extrude
  * @returns {geom3} the extruded geometry
  * @alias module:modeling/extrusions.extrudeHelical
@@ -34,9 +34,9 @@ const extrudeHelical = (options, geometry) => {
     startAngle: 0,
     pitch: 10,
     endOffset: 0,
-    segments: 32
+    segmentsPerRotation: 32
   }
-  const { angle, endOffset, segments, startAngle } = Object.assign({}, defaults, options)
+  const { angle, endOffset, segmentsPerRotation, startAngle } = Object.assign({}, defaults, options)
 
   let pitch
   // ignore height if pitch is set
@@ -47,11 +47,10 @@ const extrudeHelical = (options, geometry) => {
   }
 
   // needs at least 3 segments for each revolution
-  const minNumberOfSegments = Math.ceil(Math.abs(angle) / TAU) * 3
+  const minNumberOfSegments = 3
 
-  if (segments < minNumberOfSegments)
-    throw new Error(`For a rotation of ${angle - startAngle} radians there need to be at least ${minNumberOfSegments} segments.
-  Only ${segments} segments were specified.`)
+  if (segmentsPerRotation < minNumberOfSegments)
+    throw new Error(`The number of segments per rotation needs to be at least 3.`)
 
   let shapeSides = geom2.toSides(geometry)
   if (shapeSides.length === 0) throw new Error('the given geometry cannot be empty')
@@ -66,6 +65,8 @@ const extrudeHelical = (options, geometry) => {
     baseSlice = slice.reverse(baseSlice)
   }
 
+  const calculatedSegments = Math.round(segmentsPerRotation / TAU * Math.abs(angle))
+  const segments = calculatedSegments >= 2 ? calculatedSegments : 2
   // define transform matrix variables for performance increase
   let step1
   let matrix

--- a/packages/modeling/src/operations/extrusions/extrudeHelical.js
+++ b/packages/modeling/src/operations/extrusions/extrudeHelical.js
@@ -23,7 +23,7 @@ const geom2 = require('../../geometries/geom2')
  *  {
  *      angle: Math.PI * 4,
  *      pitch: 10,
- *      segments: 64
+ *      segmentsPerRotation: 64
  *  },
  *  circle({size: 3, center: [10, 0]})
  * )

--- a/packages/modeling/src/operations/extrusions/extrudeHelical.js
+++ b/packages/modeling/src/operations/extrusions/extrudeHelical.js
@@ -35,6 +35,8 @@ const extrudeHelical = (options, geometry) => {
   }
   const { angle, pitch, endRadiusOffset, segments } = Object.assign({}, defaults, options)
 
+  if (segments < 2) throw new Error('segments must be greater than 1')
+
   const baseSlice = slice.fromSides(geom2.toSides(geometry))
 
   const sliceCallback = (progress, index, base) => {

--- a/packages/modeling/src/operations/extrusions/extrudeHelical.js
+++ b/packages/modeling/src/operations/extrusions/extrudeHelical.js
@@ -10,7 +10,7 @@ const geom2 = require('../../geometries/geom2')
  * @param {Object} options - options for extrusion
  * @param {Number} [options.angle=TAU] - angle of the extrusion (RADIANS) positive for right-hand rotation, negative for left-hand
  * @param {Number} [options.pitch=10] - elevation gain for each turn
- * @param {Number} [options.endRadiusOffset=0] - number of segments of the extrusion
+ * @param {Number} [options.endRadiusOffset=0] - offset the final radius of the extrusion, allowing for tapered helix, and or spiral
  * @param {Number} [options.segments=32] - number of segments of the extrusion
  * @param {geom2} geometry - the geometry to extrude
  * @returns {geom3} the extruded geometry

--- a/packages/modeling/src/operations/extrusions/extrudeHelical.js
+++ b/packages/modeling/src/operations/extrusions/extrudeHelical.js
@@ -46,7 +46,11 @@ const extrudeHelical = (options, geometry) => {
     pitch = options.pitch ? options.pitch : defaults.pitch
   }
 
-  if (segments < 2) throw new Error('segments must be greater than 1')
+  // needs at least 3 segments for each revolution
+  const minNumberOfSegments = Math.ceil(angle / TAU) * 3
+
+  if (segments < minNumberOfSegments)
+    throw new Error(`For a rotation of ${angle - startAngle} radians there need to be at least ${minNumberOfSegments} segments.`)
 
   const baseSlice = slice.fromSides(geom2.toSides(geometry))
 

--- a/packages/modeling/src/operations/extrusions/extrudeHelical.js
+++ b/packages/modeling/src/operations/extrusions/extrudeHelical.js
@@ -53,8 +53,18 @@ const extrudeHelical = (options, geometry) => {
     throw new Error(`For a rotation of ${angle - startAngle} radians there need to be at least ${minNumberOfSegments} segments.
   Only ${segments} segments were specified.`)
 
-  const baseSlice = slice.fromSides(geom2.toSides(geometry))
+  let shapeSides = geom2.toSides(geometry)
+  if (shapeSides.length === 0) throw new Error('the given geometry cannot be empty')
 
+  // const pointsWithNegativeX = shapeSides.filter((s) => (s[0][0] < 0))
+  const pointsWithPositiveX = shapeSides.filter((s) => (s[0][0] >= 0))
+  
+  let baseSlice = slice.fromSides(shapeSides)
+  
+  if(pointsWithPositiveX.length === 0) {
+    // only points in negative x plane, reverse
+    baseSlice = slice.reverse(baseSlice)
+  }
 
   // define transform matrix variables for performance increase
   let step1

--- a/packages/modeling/src/operations/extrusions/extrudeHelical.js
+++ b/packages/modeling/src/operations/extrusions/extrudeHelical.js
@@ -68,7 +68,7 @@ const extrudeHelical = (options, geometry) => {
   const calculatedSegments = Math.round(segmentsPerRotation / TAU * Math.abs(angle))
   const segments = calculatedSegments >= 2 ? calculatedSegments : 2
   // define transform matrix variables for performance increase
-  let step1
+  const step1 = mat4.create()
   let matrix
   const sliceCallback = (progress, index, base) => {
     const zRotation = startAngle + angle / segments * index
@@ -83,7 +83,6 @@ const extrudeHelical = (options, geometry) => {
     // only creates inside-out polygons
 
     // create transformation matrix
-    step1 = mat4.create()
     mat4.multiply(
       step1,
       // then apply offsets

--- a/packages/modeling/src/operations/extrusions/extrudeHelical.js
+++ b/packages/modeling/src/operations/extrusions/extrudeHelical.js
@@ -1,0 +1,81 @@
+const { TAU } = require('../../maths/constants')
+const slice = require('./slice')
+const mat4 = require('../../maths/mat4')
+const extrudeFromSlices = require('./extrudeFromSlices')
+const geom2 = require('../../geometries/geom2')
+
+/**
+ * Perform a helical extrude of the geometry, using the given options.
+ *
+ * @param {Object} options - options for extrusion
+ * @param {Number} [options.angle=TAU] - angle of the extrusion (RADIANS) positive for right-hand rotation, negative for left-hand
+ * @param {Number} [options.pitch=10] - elevation gain for each turn
+ * @param {Number} [options.endRadiusOffset=0] - number of segments of the extrusion
+ * @param {Number} [options.segments=32] - number of segments of the extrusion
+ * @param {geom2} geometry - the geometry to extrude
+ * @returns {geom3} the extruded geometry
+ * @alias module:modeling/extrusions.extrudeHelical
+ *
+ * @example
+ * const myshape = extrudeHelical(
+ *  {
+ *      angle: Math.PI * 4,
+ *      pitch: 10,
+ *      segments: 64
+ *  },
+ *  circle({size: 3, center: [10, 0]})
+ * )
+ */
+const extrudeHelical = (options, geometry) => {
+    const defaults = {
+        angle: TAU,
+        pitch: 10,
+        endRadiusOffset: 0,
+        segments: 32
+    }
+    const { angle, pitch, endRadiusOffset, segments } = Object.assign({}, defaults, options)
+
+    const baseSlice = slice.fromSides(geom2.toSides(geometry))
+
+    const sliceCallback = (progress, index, base) => {
+        const zRotation = angle / segments * index
+        const xOffset = endRadiusOffset / segments * index
+        const zOffset = zRotation / TAU * pitch
+
+        // TODO: check for valid geometry after translations
+        // ie all the points have to be either x > -xOffset or x < -xOffset
+        // this would have to be checked for every transform, and handled
+        //
+        // not implementing, as this currently doesn't break anything,
+        // only creates inside-out polygons
+
+        // create transformation matrix
+        const step1 = mat4.create()
+        mat4.multiply(
+            step1,
+            // then apply offsets
+            mat4.fromTranslation(mat4.create(), [xOffset, 0, zOffset]),
+            // first rotate "flat" 2D shape from XY to XZ plane
+            mat4.fromXRotation(mat4.create(), -TAU / 4) // putting TAU/4 here creates inside-out polygon
+        )
+        
+        const matrix = mat4.create()
+        mat4.multiply(
+            matrix,
+            // finally rotate around Z axis
+            mat4.fromZRotation(mat4.create(), zRotation),
+            step1
+        )
+        return slice.transform(matrix, base)
+    }
+
+    return extrudeFromSlices(
+        {
+            numberOfSlices: segments,
+            callback: sliceCallback
+        },
+        baseSlice
+    )
+}
+
+module.exports = extrudeHelical

--- a/packages/modeling/src/operations/extrusions/extrudeHelical.test.js
+++ b/packages/modeling/src/operations/extrusions/extrudeHelical.test.js
@@ -52,7 +52,7 @@ test('extrudeHelical: (endRadiusOffset) extruding of a circle produces an expect
 })
 
 test('extrudeHelical: (segments) extruding of a circle produces an expected geom3', (t) => {
-    const startSegments = 2
+    const startSegments = 3
     const geometry2 = circle({ size: 3, center: [10, 0] })
     for (const index of [...Array(30).keys()]) {
         // also test negative pitches

--- a/packages/modeling/src/operations/extrusions/extrudeHelical.test.js
+++ b/packages/modeling/src/operations/extrusions/extrudeHelical.test.js
@@ -12,7 +12,6 @@ test('extrudeHelical: (defaults) extruding of a geom2 produces an expected geom3
     const geometry3 = extrudeHelical({}, geometry2)
     const pts = geom3.toPoints(geometry3)
     t.notThrows(() => geom3.validate(geometry3))
-    t.is(pts.length, 252)
 })
 
 test('extrudeHelical: (defaults) extruding of a circle produces an expected geom3', (t) => {

--- a/packages/modeling/src/operations/extrusions/extrudeHelical.test.js
+++ b/packages/modeling/src/operations/extrusions/extrudeHelical.test.js
@@ -1,0 +1,63 @@
+const test = require('ava')
+const { comparePoints, comparePolygonsAsPoints } = require('../../../test/helpers')
+const { TAU } = require('../../maths/constants')
+const { geom2, geom3 } = require('../../geometries')
+const { circle } = require('../../primitives')
+
+const { extrudeHelical } = require('./index')
+
+test('extrudeHelical: (defaults) extruding of a geom2 produces an expected geom3', (t) => {
+    const geometry2 = geom2.fromPoints([[10, 8], [10, -8], [26, -8], [26, 8]])
+
+    const geometry3 = extrudeHelical({}, geometry2)
+    const pts = geom3.toPoints(geometry3)
+    t.notThrows(() => geom3.validate(geometry3))
+    t.is(pts.length, 252)
+})
+
+test('extrudeHelical: (defaults) extruding of a circle produces an expected geom3', (t) => {
+    const geometry2 = circle({ size: 3, center: [10, 0] })
+
+    const geometry3 = extrudeHelical({}, geometry2)
+    t.notThrows(() => geom3.validate(geometry3))
+})
+
+test('extrudeHelical: (angle) extruding of a circle produces an expected geom3', (t) => {
+    const maxRevolutions = 10
+    const geometry2 = circle({ size: 3, center: [10, 0] })
+    for (const index of [...Array(maxRevolutions).keys()]) {
+        // also test negative angles
+        const geometry3 = extrudeHelical({angle: TAU * (index - maxRevolutions / 2)}, geometry2)
+        t.notThrows(() => geom3.validate(geometry3))
+    }
+})
+
+test('extrudeHelical: (pitch) extruding of a circle produces an expected geom3', (t) => {
+    const startPitch = -10
+    const geometry2 = circle({ size: 3, center: [10, 0] })
+    for (const index of [...Array(20).keys()]) {
+        // also test negative pitches
+        const geometry3 = extrudeHelical({pitch: startPitch + index}, geometry2)
+        t.notThrows(() => geom3.validate(geometry3))
+    }
+})
+
+test('extrudeHelical: (endRadiusOffset) extruding of a circle produces an expected geom3', (t) => {
+    const startOffset = -5
+    const geometry2 = circle({ size: 3, center: [10, 0] })
+    for (const index of [...Array(10).keys()]) {
+        // also test negative pitches
+        const geometry3 = extrudeHelical({endRadiusOffset: startOffset + index}, geometry2)
+        t.notThrows(() => geom3.validate(geometry3))
+    }
+})
+
+test('extrudeHelical: (segments) extruding of a circle produces an expected geom3', (t) => {
+    const startSegments = 2
+    const geometry2 = circle({ size: 3, center: [10, 0] })
+    for (const index of [...Array(30).keys()]) {
+        // also test negative pitches
+        const geometry3 = extrudeHelical({segments: startSegments + index}, geometry2)
+        t.notThrows(() => geom3.validate(geometry3))
+    }
+})

--- a/packages/modeling/src/operations/extrusions/index.js
+++ b/packages/modeling/src/operations/extrusions/index.js
@@ -10,6 +10,7 @@ module.exports = {
   extrudeLinear: require('./extrudeLinear'),
   extrudeRectangular: require('./extrudeRectangular'),
   extrudeRotate: require('./extrudeRotate'),
+  extrudeHelical: require('./extrudeHelical'),
   project: require('./project'),
   slice: require('./slice')
 }


### PR DESCRIPTION
Adds the `extrudeHelical` functionality as discussed in #1162

This supposes that the `geom2` that is to be extruded is laying fully in the positive x plane. Otherwise you get issues with inside-out polygons, as discussed in #1012

It allows for the generating of a helix, tapered helix (`endRadiusOffset !== 0`) and spiral (`pitch === 0, endRadiusOffset !== 0`)

Simple example:
```js
const jscad = require("@jscad/modeling")
const { circle } = jscad.primitives
const { extrudeHelical } = jscad.extrusions

const main = () => {
    return extrudeHelical(
            {
                angle: Math.PI * 4,
                pitch: 10,
                endRadiusOffset: -5,
                segments: 64
            },
            circle({ size: 3, center: [10, 0] })
        )
}

module.exports = { main }
```

Resulting in a tapered helix:
![image](https://user-images.githubusercontent.com/66420755/200585281-bd7a4999-ac15-44cf-9a81-a62256fc95b2.png)

I will need some extra guidance with adding the documentation, as I could not immediately find where I should add such documentation. For example, there's the [docs](https://openjscad.xyz/docs/) website, and the [user guide](https://openjscad.xyz/dokuwiki/doku.php). I'm not sure which one is supposed to be edited, and how I do that. Thanks for the help.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
