### PR TITLE
add render hotkey message in editor

### DIFF
--- a/packages/web/css/demo.css
+++ b/packages/web/css/demo.css
@@ -444,3 +444,11 @@ input.error::placeholder { /* Chrome, Firefox, Opera, Safari 10.1+ */
   width: 16px;
   height: 16px;
 }
+
+.renderHotkeyHelp {
+  position: absolute;
+  top: 0rem;
+  right: 1rem;
+  color: gray;
+  user-select: none;
+}

--- a/packages/web/src/ui/views/editor.js
+++ b/packages/web/src/ui/views/editor.js
@@ -34,7 +34,11 @@ const createWrapper = (state, callbackToStream) => {
   if (!wrapper) {
     wrapper = html`
     <section class='popup-menu' id='editor' key='editor' style='visibility:${state.activeTool === 'editor' ? 'visible' : 'hidden'}'>
-      <textarea></textarea>
+    <textarea>
+    </textarea>
+    <p style='position:absolute;top:0rem;right:1rem;color:gray;user-select:none'>
+      Press 'shift + enter' to render!
+    </p>
     </section>
     `
     wrapper.onkeydown = (e) => e.stopPropagation()


### PR DESCRIPTION
Fixes #1174, by adding a subtle message in the editor on how to render the code.

Currently looks like this:
![image](https://user-images.githubusercontent.com/66420755/204542985-4f07d8d9-cf44-462d-9f63-3cf90ec66ba5.png)
