### PR TITLE
Update Usage instructions for stl-deserializer

### DIFF
--- a/packages/io/stl-deserializer/README.md
+++ b/packages/io/stl-deserializer/README.md
@@ -40,7 +40,7 @@ npm install @jscad/stl-deserializer
 const stlDeserializer = require('@jscad/stl-deserializer')
 
 const rawData = fs.readFileSync('PATH/TO/file.stl')
-const geometry = stlDeserializer.deserialize(rawData, 'file.stl', {output: 'geometry'})
+const geometry = stlDeserializer.deserialize({output: 'geometry', filename: 'file.stl'}, rawData)
 
 ```
 


### PR DESCRIPTION
The instructions in the README no longer work with the current codebase, as they don't match the `deserialize()` function signature.
