### PR TITLE
fix(core): update json5 dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,7 @@
     "@jscad/io": "2.4.4",
     "@jscad/io-utils": "2.0.23",
     "@jscad/modeling": "2.11.0",
-    "json5": "2.2.0",
+    "json5": "2.2.3",
     "strip-bom": "4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The core package has a dependency on `json5`. There is a recent CVE vulnerability on version < 2.2.2. I was alerted by dependabot.

[CVE-2022-46175](https://nvd.nist.gov/vuln/detail/CVE-2022-46175)

This PR updates to `json5` version 2.2.3 which is not vulnerable to the parsing vulnerability.


### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
