### PR TITLE
fix(cli): corrected CLI usage message

### DIFF
--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -3,23 +3,23 @@
 
 // NOTE: this will only run on Node > 6 or needs to be transpiled
 
-// == OpenJSCAD.org CLI interface, written by Rene K. Mueller <spiritdude@gmail.com>, Licensed under MIT License
+// == JSCAD CLI interface, written by Rene K. Mueller <spiritdude@gmail.com>, Licensed under MIT License
 //
 // Description:
-//   openjscad <file> [-of <format>] [-o <output>]
+//   jscad <file> [-of <format>] [-o <output>]
 // e.g.
-//   openjscad test.jscad
-//   openjscad test.jscad -o test.stl
-//   openjscad test.jscad -o test.amf
-//   openjscad test.jscad -o test.dxf
-//   openjscad test.scad -o testFromSCAD.jscad
-//   openjscad test.scad -o test.stl
-//   openjscad test.stl -o test2.stl      # reprocessed: stl -> jscad -> stl
-//   openjscad test.amf -o test2.jscad
-//   openjscad test.jscad -of amf
-//   openjscad test.jscad -of dxf
-//   openjscad test.jscad -of stl
-//   openjscad name_plate.jscad --name "Just Me" --title "CEO" -o amf test.amf
+//   jscad test.jscad
+//   jscad test.jscad -o test.stl
+//   jscad test.jscad -o test.amf
+//   jscad test.jscad -o test.dxf
+//   jscad test.scad -o testFromSCAD.jscad
+//   jscad test.scad -o test.stl
+//   jscad test.stl -o test2.stl      # reprocessed: stl -> jscad -> stl
+//   jscad test.amf -o test2.jscad
+//   jscad test.jscad -of amf
+//   jscad test.jscad -of dxf
+//   jscad test.jscad -of stl
+//   jscad name_plate.jscad --name "Just Me" --title "CEO" -o amf test.amf
 //
 const fs = require('fs')
 

--- a/packages/cli/src/env.js
+++ b/packages/cli/src/env.js
@@ -1,7 +1,7 @@
 const version = require('../package.json').version
 
 const env = () => {
-  let env = 'OpenJSCAD ' + version
+  let env = 'JSCAD ' + version
   if (typeof document !== 'undefined') {
     const w = document.defaultView
     env = env + ' [' + w.navigator.userAgent + ']'

--- a/packages/cli/src/parseArgs.js
+++ b/packages/cli/src/parseArgs.js
@@ -13,7 +13,7 @@ const parseArgs = (args) => {
   // hint: https://github.com/substack/node-optimist
   //       https://github.com/visionmedia/commander.js
   if (args.length < 1) {
-    console.log('USAGE:\n\nopenjscad [-v] <file> [-of <format>] [-o <output>]')
+    console.log('USAGE:\n\njscad [-v] <file> [-of <format>] [-o <output>]')
     console.log(`\t<file>  :\tinput (Supported types: folder, .${inputExtensions.join(', .')})`)
     console.log(`\t<output>:\toutput (Supported types: folder, .${outputExtensions.join(', .')})`)
     console.log(`\t<format>:\t${outputFormats.join(', ')}`)


### PR DESCRIPTION
I noticed that the CLI prints out the wrong usage help information. To see, just do `npm i -g @jscad/cli` and then run `jscad`. Note that the executable is called `jscad` not `openjscad`.


### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
