### PR TITLE
test(modeling): V3 check for self-intersecting geom2

### DIFF
--- a/packages/modeling/src/geometries/geom2/validate.js
+++ b/packages/modeling/src/geometries/geom2/validate.js
@@ -39,7 +39,7 @@ export const validate = (object) => {
       const a2 = (a1 + 1) % outline.length
       for (let b1 = 0; b1 < outline.length; b1++) {
         const b2 = (b1 + 1) % outline.length
-        if (a1 != b1) {
+        if (a1 !== b1) {
           const int = intersect(outline[a1], outline[a2], outline[b1], outline[b2], true)
           if (int) {
             throw new Error(`geom2 outline ${i} self intersection at ${int}`)

--- a/packages/modeling/src/geometries/geom2/validate.js
+++ b/packages/modeling/src/geometries/geom2/validate.js
@@ -1,4 +1,5 @@
 import * as vec2 from '../../maths/vec2/index.js'
+import intersect from '../../maths/utils/intersect.js'
 
 import isA from './isA.js'
 import toOutlines from './toOutlines.js'
@@ -27,6 +28,23 @@ export const validate = (object) => {
       const j = (i + 1) % outline.length
       if (vec2.equals(outline[i], outline[j])) {
         throw new Error(`geom2 outline ${i} found duplicate point ${outline[i]}`)
+      }
+    }
+  })
+
+  // check for self-intersection
+  toOutlines(object).forEach((outline, i) => {
+    // check for intersection between [a1, a2] and [b1, b2]
+    for (let a1 = 0; a1 < outline.length; a1++) {
+      const a2 = (a1 + 1) % outline.length
+      for (let b1 = 0; b1 < outline.length; b1++) {
+        const b2 = (b1 + 1) % outline.length
+        if (a1 != b1) {
+          const int = intersect(outline[a1], outline[a2], outline[b1], outline[b2], true)
+          if (int) {
+            throw new Error(`geom2 outline ${i} self intersection at ${int}`)
+          }
+        }
       }
     }
   })

--- a/packages/modeling/src/geometries/geom2/validate.js
+++ b/packages/modeling/src/geometries/geom2/validate.js
@@ -40,7 +40,7 @@ export const validate = (object) => {
       for (let b1 = 0; b1 < outline.length; b1++) {
         const b2 = (b1 + 1) % outline.length
         if (a1 !== b1) {
-          const int = intersect(outline[a1], outline[a2], outline[b1], outline[b2], true)
+          const int = intersect(outline[a1], outline[a2], outline[b1], outline[b2], false)
           if (int) {
             throw new Error(`geom2 outline ${i} self intersection at ${int}`)
           }

--- a/packages/modeling/src/geometries/geom2/validate.test.js
+++ b/packages/modeling/src/geometries/geom2/validate.test.js
@@ -1,0 +1,28 @@
+import test from 'ava'
+
+import { create, validate } from './index.js'
+
+// points of a square
+// D-C
+// | |
+// A-B
+const a = [0, 0]
+const b = [1, 0]
+const c = [1, 1]
+const d = [0, 1]
+
+test('validate: allow valid geometry', (t) => {
+  const geometry = create([[a, b, c, d]])
+  t.notThrows(() => validate(geometry))
+})
+
+test('validate: throw exception for self-edge', (t) => {
+  const geometry = create([[a, b, b, c]])
+  t.throws(() => validate(geometry))
+})
+
+test('validate: throw exception for self-intersecting polygon', (t) => {
+  const bowtie = [a, d, b, c]
+  const geometry = create([bowtie])
+  t.throws(() => validate(geometry))
+})

--- a/packages/modeling/src/maths/utils/intersect.js
+++ b/packages/modeling/src/maths/utils/intersect.js
@@ -6,11 +6,11 @@
  * @param {vec2} p2 - second point of first line segment
  * @param {vec2} p3 - first point of second line segment
  * @param {vec2} p4 - second point of second line segment
- * @param {Boolean} noEndpointTouch - skip intersections at segment endpoints
+ * @param {Boolean} endpointTouch - include intersections at segment endpoints
  * @returns {vec2} intersection point of the two line segments, or undefined
  * @alias module:modeling/maths/utils.intersect
  */
-export const intersect = (p1, p2, p3, p4, noEndpointTouch) => {
+export const intersect = (p1, p2, p3, p4, endpointTouch = true) => {
   // Check if none of the lines are of length 0
   if ((p1[0] === p2[0] && p1[1] === p2[1]) || (p3[0] === p4[0] && p3[1] === p4[1])) {
     return undefined
@@ -32,7 +32,7 @@ export const intersect = (p1, p2, p3, p4, noEndpointTouch) => {
   }
 
   // is the intersection at the end of a segment
-  if (noEndpointTouch && (ua === 0 || ua === 1 || ub === 0 || ub === 1)) {
+  if (!endpointTouch && (ua === 0 || ua === 1 || ub === 0 || ub === 1)) {
     return undefined
   }
 

--- a/packages/modeling/src/maths/utils/intersect.js
+++ b/packages/modeling/src/maths/utils/intersect.js
@@ -6,10 +6,11 @@
  * @param {vec2} p2 - second point of first line segment
  * @param {vec2} p3 - first point of second line segment
  * @param {vec2} p4 - second point of second line segment
+ * @param {Boolean} noEndpointTouch - skip intersections at segment endpoints
  * @returns {vec2} intersection point of the two line segments, or undefined
  * @alias module:modeling/maths/utils.intersect
  */
-export const intersect = (p1, p2, p3, p4) => {
+export const intersect = (p1, p2, p3, p4, noEndpointTouch) => {
   // Check if none of the lines are of length 0
   if ((p1[0] === p2[0] && p1[1] === p2[1]) || (p3[0] === p4[0] && p3[1] === p4[1])) {
     return undefined
@@ -27,6 +28,11 @@ export const intersect = (p1, p2, p3, p4) => {
 
   // is the intersection along the segments
   if (ua < 0 || ua > 1 || ub < 0 || ub > 1) {
+    return undefined
+  }
+
+  // is the intersection at the end of a segment
+  if (noEndpointTouch && (ua === 0 || ua === 1 || ub === 0 || ub === 1)) {
     return undefined
   }
 

--- a/packages/modeling/src/maths/utils/intersect.js
+++ b/packages/modeling/src/maths/utils/intersect.js
@@ -1,5 +1,6 @@
 /**
- * Calculate the intersect point of the two line segments (p1-p2 and p3-p4), end points included.
+ * Calculate the intersect point of the two line segments (p1-p2 and p3-p4).
+ * If the endpointTouch parameter is false, intersections at segment end points are excluded.
  * Note: If the line segments do NOT intersect then undefined is returned.
  * @see http://paulbourke.net/geometry/pointlineplane/
  * @param {vec2} p1 - first point of first line segment

--- a/packages/modeling/src/operations/expansions/offsetGeom2.test.js
+++ b/packages/modeling/src/operations/expansions/offsetGeom2.test.js
@@ -1,6 +1,7 @@
 import test from 'ava'
 
 import { geom2 } from '../../geometries/index.js'
+import { roundedRectangle } from '../../primitives/index.js'
 
 import { offset } from './index.js'
 
@@ -197,4 +198,10 @@ test('offset (options): offsetting of round geom2 produces expected offset geom2
   t.notThrows(() => geom2.validate(obs))
   t.is(pts.length, 16)
   t.true(comparePoints(pts, exp))
+})
+
+test('offset (options): offsetting issue #1017', (t) => {
+  const geometry = roundedRectangle({ size: [10, 10], segments: 4 })
+  const obs = offset({ delta: -2, corners: 'round' }, geometry)
+  t.notThrows.skip(() => geom2.validate(obs))
 })


### PR DESCRIPTION
Adds a geom2 validation check for self-intersecting polygons. This is a helpful check as I continue to improve the 2D operations.

I added validate.test.js with validation tests for geom2 as well.

I had to add an extra parameter to maths/utils/intersect.js. This actually makes it consistent with the intersect routine in martinez/segment_intersection.js. Hopefully they can be merged one day, but not yet.


### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
