### PR TITLE
refactor(modeling)!: V3 convert poly2 vertices to points

### DIFF
--- a/packages/modeling/src/geometries/poly2/arePointsInside.js
+++ b/packages/modeling/src/geometries/poly2/arePointsInside.js
@@ -12,14 +12,13 @@ import reverse from './reverse.js'
 export const arePointsInside = (points, polygon) => {
   if (points.length === 0) return 0 // nothing to check
 
-  const vertices = polygon.vertices
-  if (vertices.length < 3) return 0 // nothing can be inside an empty polygon
+  if (polygon.points.length < 3) return 0 // nothing can be inside an empty polygon
 
   if (measureArea(polygon) < 0) {
     polygon = reverse(polygon) // CCW is required
   }
 
-  const sum = points.reduce((acc, point) => acc + isPointInside(point, vertices), 0)
+  const sum = points.reduce((acc, point) => acc + isPointInside(point, polygon.points), 0)
   return sum === points.length ? 1 : 0
 }
 
@@ -72,7 +71,7 @@ const isPointInside = (point, polygon) => {
         }
       }
     }
-    /* move to next pair of vertices, retaining info as possible */
+    /* move to next pair of points, retaining info as possible */
     yflag0 = yflag1
     vtx0 = vtx1
     vtx1 = polygon[++i]

--- a/packages/modeling/src/geometries/poly2/clone.test.js
+++ b/packages/modeling/src/geometries/poly2/clone.test.js
@@ -2,16 +2,16 @@ import test from 'ava'
 
 import { create, clone } from './index.js'
 
-import { comparePolygons } from '../../../test/helpers/index.js'
+import { comparePoints } from '../../../test/helpers/index.js'
 
 test('poly2: clone() should return a new poly2 with same values', (t) => {
   const org1 = create()
   const ret1 = clone(org1)
-  t.true(comparePolygons(ret1, org1))
+  t.true(comparePoints(ret1.points, org1.points))
   t.not(ret1, org1)
 
   const org2 = create([[1, 1], [-1, 1], [-1, -1], [1, -1]])
   const ret2 = clone(org2)
-  t.true(comparePolygons(ret2, org2))
+  t.true(comparePoints(ret2.points, org2.points))
   t.not(ret2, org2)
 })

--- a/packages/modeling/src/geometries/poly2/create.d.ts
+++ b/packages/modeling/src/geometries/poly2/create.d.ts
@@ -3,4 +3,4 @@ import Vec2 from '../../maths/vec2/type'
 
 export default create
 
-declare function create(vertices?: Array<Vec2>): Poly2
+declare function create(points?: Array<Vec2>): Poly2

--- a/packages/modeling/src/geometries/poly2/create.js
+++ b/packages/modeling/src/geometries/poly2/create.js
@@ -1,26 +1,26 @@
 /**
- * Represents a 2D polygon consisting of a list of ordered vertices
- * which is closed between start and end vertices.
+ * Represents a 2D polygon consisting of a list of ordered points
+ * which is closed between start and end points.
  * @see https://en.wikipedia.org/wiki/Polygon
  * @typedef {Object} poly2
- * @property {Array} vertices - list of ordered vertices (2D)
+ * @property {Array} points - list of ordered points (2D)
  */
 
 /**
  * Creates a new polygon with initial values.
  *
- * @param {Array} [vertices] - list of vertices (2D)
+ * @param {Array} [points] - list of points (2D)
  * @returns {poly2} a new polygon
  * @alias module:modeling/geometries/poly2.create
  *
  * @example
  * let polygon = create()
  */
-export const create = (vertices) => {
-  if (vertices === undefined || vertices.length < 3) {
-    vertices = [] // empty contents
+export const create = (points) => {
+  if (points === undefined || points.length < 3) {
+    points = [] // empty contents
   }
-  return { vertices }
+  return { points }
 }
 
 export default create

--- a/packages/modeling/src/geometries/poly2/create.test.js
+++ b/packages/modeling/src/geometries/poly2/create.test.js
@@ -4,10 +4,10 @@ import { create } from './index.js'
 
 test('poly2: create() should return a poly2 with initial values', (t) => {
   let obs = create()
-  let exp = { vertices: [] }
+  let exp = { points: [] }
   t.deepEqual(obs, exp)
 
   obs = create([[1, 1], [2, 2], [3, 3]])
-  exp = { vertices: [[1, 1], [2, 2], [3, 3]] }
+  exp = { points: [[1, 1], [2, 2], [3, 3]] }
   t.deepEqual(obs, exp)
 })

--- a/packages/modeling/src/geometries/poly2/index.js
+++ b/packages/modeling/src/geometries/poly2/index.js
@@ -1,5 +1,5 @@
 /**
- * Represents a 2D polygon consisting of a list of ordered vertices.
+ * Represents a 2D polygon consisting of a list of ordered points.
  * @see {@link poly2} for data structure information.
  * @module modeling/geometries/poly2
  *

--- a/packages/modeling/src/geometries/poly2/isA.js
+++ b/packages/modeling/src/geometries/poly2/isA.js
@@ -6,8 +6,8 @@
  */
 export const isA = (object) => {
   if (object && typeof object === 'object') {
-    if ('vertices' in object) {
-      if (Array.isArray(object.vertices)) {
+    if ('points' in object) {
+      if (Array.isArray(object.points)) {
         return true
       }
     }

--- a/packages/modeling/src/geometries/poly2/isA.test.js
+++ b/packages/modeling/src/geometries/poly2/isA.test.js
@@ -1,5 +1,8 @@
 import test from 'ava'
 
+import * as geom2 from '../geom2/index.js'
+import * as geom3 from '../geom3/index.js'
+import * as poly3 from '../poly3/index.js'
 import { isA, create } from './index.js'
 
 test('isA: identifies created poly2', (t) => {
@@ -12,8 +15,16 @@ test('isA: identifies created poly2', (t) => {
 test('isA: identifies non poly2', (t) => {
   const p1 = null
   const p2 = {}
-  const p3 = { vertices: 1 }
+  const p3 = { points: 1 }
+  const p4 = { vertices: 1 }
+  const p5 = geom2.create()
+  const p6 = geom3.create()
+  const p7 = poly3.create()
   t.false(isA(p1))
   t.false(isA(p2))
   t.false(isA(p3))
+  t.false(isA(p4))
+  t.false(isA(p5))
+  t.false(isA(p6))
+  t.false(isA(p7))
 })

--- a/packages/modeling/src/geometries/poly2/isConvex.js
+++ b/packages/modeling/src/geometries/poly2/isConvex.js
@@ -5,13 +5,13 @@
  * @alias module:modeling/geometries/poly2.isConvex
  */
 export const isConvex = (polygon) => {
-  const numvertices = polygon.vertices.length
-  if (numvertices > 2) {
-    const vertices = polygon.vertices
+  const numPoints = polygon.points.length
+  if (numPoints > 2) {
+    const points = polygon.points
     let prev = 0
     let curr = 0
-    for (let i = 0; i < numvertices; i++) {
-      curr = crossBetweenSegments(vertices[i], vertices[(i + 1) % numvertices], vertices[(i + 2) % numvertices])
+    for (let i = 0; i < numPoints; i++) {
+      curr = crossBetweenSegments(points[i], points[(i + 1) % numPoints], points[(i + 2) % numPoints])
       if (curr !== 0) {
         // sum angle of crosses, looking for a change in direction
         if (curr * prev < 0) {

--- a/packages/modeling/src/geometries/poly2/isSimple.js
+++ b/packages/modeling/src/geometries/poly2/isSimple.js
@@ -8,27 +8,27 @@ import intersect from '../../maths/utils/intersect.js'
  * @alias module:modeling/geometries/poly2.isSimple
  */
 export const isSimple = (polygon) => {
-  const numVertices = polygon.vertices.length
-  if (numVertices < 3) return false // only polygons with an areas are simple
+  const numPoints = polygon.points.length
+  if (numPoints < 3) return false // only polygons with an areas are simple
 
-  if (numVertices === 3) return true // triangles are simple
+  if (numPoints === 3) return true // triangles are simple
 
-  const vertices = polygon.vertices
+  const points = polygon.points
 
-  // proof one: there are N unique vertices
+  // proof one: there are N unique points
   const found = new Set()
-  vertices.forEach((v) => found.add(v.toString()))
-  if (found.size !== numVertices) return false
+  points.forEach((v) => found.add(v.toString()))
+  if (found.size !== numPoints) return false
 
   // proof two: line segments do not cross
-  for (let i = 0; i < numVertices; i++) {
-    for (let j = i + 2; j < numVertices; j++) {
-      const k = (j + 1) % numVertices
+  for (let i = 0; i < numPoints; i++) {
+    for (let j = i + 2; j < numPoints; j++) {
+      const k = (j + 1) % numPoints
       if (i !== k) {
-        const s0 = vertices[i]
-        const s1 = vertices[(i + 1) % numVertices]
-        const z0 = vertices[j]
-        const z1 = vertices[k]
+        const s0 = points[i]
+        const s1 = points[(i + 1) % numPoints]
+        const z0 = points[j]
+        const z1 = points[k]
         const ip = intersect(s0, s1, z0, z1)
         if (ip) return false
       }

--- a/packages/modeling/src/geometries/poly2/measureArea.js
+++ b/packages/modeling/src/geometries/poly2/measureArea.js
@@ -7,6 +7,6 @@
  */
 import area from '../../maths/utils/area.js'
 
-export const measureArea = (polygon) => area(polygon.vertices)
+export const measureArea = (polygon) => area(polygon.points)
 
 export default measureArea

--- a/packages/modeling/src/geometries/poly2/measureBoundingBox.js
+++ b/packages/modeling/src/geometries/poly2/measureBoundingBox.js
@@ -6,13 +6,13 @@ import * as vec2 from '../../maths/vec2/index.js'
  * @alias module:modeling/geometries/poly2.measureBoundingBox
  */
 export const measureBoundingBox = (polygon) => {
-  const vertices = polygon.vertices
-  const numVertices = vertices.length
-  const min = numVertices === 0 ? vec2.create() : vec2.clone(vertices[0])
+  const points = polygon.points
+  const numPoints = points.length
+  const min = numPoints === 0 ? vec2.create() : vec2.clone(points[0])
   const max = vec2.clone(min)
-  for (let i = 1; i < numVertices; i++) {
-    vec2.min(min, min, vertices[i])
-    vec2.max(max, max, vertices[i])
+  for (let i = 1; i < numPoints; i++) {
+    vec2.min(min, min, points[i])
+    vec2.max(max, max, points[i])
   }
   return [min, max]
 }

--- a/packages/modeling/src/geometries/poly2/reverse.js
+++ b/packages/modeling/src/geometries/poly2/reverse.js
@@ -1,15 +1,15 @@
 import create from './create.js'
 
 /**
- * Reverse the direction of vertices in the given polygon, rotating the opposite direction.
+ * Reverse the direction of points in the given polygon, rotating the opposite direction.
  *
  * @param {poly2} polygon - the polygon to reverse
  * @returns {poly2} a new polygon
  * @alias module:modeling/geometries/poly2.reverse
  */
 export const reverse = (polygon) => {
-  const vertices = polygon.vertices.slice().reverse()
-  return create(vertices)
+  const points = polygon.points.slice().reverse()
+  return create(points)
 }
 
 export default reverse

--- a/packages/modeling/src/geometries/poly2/reverse.test.js
+++ b/packages/modeling/src/geometries/poly2/reverse.test.js
@@ -1,0 +1,27 @@
+import test from 'ava'
+
+import { create, reverse, toPoints } from './index.js'
+
+import { comparePoints } from '../../../test/helpers/index.js'
+
+test('reverse: reverses a populated poly2', (t) => {
+  const points = [[0, 0], [1, 0], [0, 1]]
+  const expected = { points: [[0, 1], [1, 0], [0, 0]] }
+  const geometry = create(points)
+  const another = reverse(geometry)
+  t.not(geometry, another)
+  t.true(comparePoints(another.points, expected.points))
+})
+
+test('reverse: does not modify input poly2', (t) => {
+  const points = [[0, 0], [1, 0], [0, 1]]
+  // expected:
+  const forward = [[0, 0], [1, 0], [0, 1]]
+  const backward = [[0, 1], [1, 0], [0, 0]]
+
+  const geometry = create(points)
+  const another = reverse(geometry)
+  t.not(geometry, another)
+  t.true(comparePoints(toPoints(geometry), forward))
+  t.true(comparePoints(toPoints(another), backward))
+})

--- a/packages/modeling/src/geometries/poly2/toPoints.js
+++ b/packages/modeling/src/geometries/poly2/toPoints.js
@@ -5,6 +5,6 @@
  * @return {Array} list of points (2D)
  * @alias module:modeling/geometries/poly2.toPoints
  */
-export const toPoints = (polygon) => polygon.vertices
+export const toPoints = (polygon) => polygon.points
 
 export default toPoints

--- a/packages/modeling/src/geometries/poly2/toPoints.test.js
+++ b/packages/modeling/src/geometries/poly2/toPoints.test.js
@@ -1,0 +1,18 @@
+import test from 'ava'
+
+import { create, toPoints } from './index.js'
+
+import { comparePoints } from '../../../test/helpers/index.js'
+
+test('toPoints: creates an empty array of points from an empty poly2', (t) => {
+  const geometry = create()
+  const points = toPoints(geometry)
+  t.deepEqual(points, [])
+})
+
+test('toPoints: creates an array of points from a populated poly2', (t) => {
+  const geometry = create([[0, 0], [1, 0], [0, 1]])
+  const expected = [[0, 0], [1, 0], [0, 1]]
+  const points = toPoints(geometry)
+  t.true(comparePoints(points, expected))
+})

--- a/packages/modeling/src/geometries/poly2/toString.js
+++ b/packages/modeling/src/geometries/poly2/toString.js
@@ -7,9 +7,9 @@ import * as vec2 from '../../maths/vec2/index.js'
  * @alias module:modeling/geometries/poly2.toString
  */
 export const toString = (polygon) => {
-  let result = 'poly2: vertices: ['
-  polygon.vertices.forEach((vertex) => {
-    result += `${vec2.toString(vertex)}, `
+  let result = 'poly2: points: ['
+  polygon.points.forEach((point) => {
+    result += `${vec2.toString(point)}, `
   })
   result += ']'
   return result

--- a/packages/modeling/src/geometries/poly2/transform.js
+++ b/packages/modeling/src/geometries/poly2/transform.js
@@ -11,12 +11,12 @@ import create from './create.js'
  * @alias module:modeling/geometries/poly2.transform
  */
 export const transform = (matrix, polygon) => {
-  const vertices = polygon.vertices.map((vertex) => vec2.transform(vec2.create(), vertex, matrix))
+  const points = polygon.points.map((point) => vec2.transform(vec2.create(), point, matrix))
   if (mat4.isMirroring(matrix)) {
     // reverse the order to preserve the orientation
-    vertices.reverse()
+    points.reverse()
   }
-  return create(vertices)
+  return create(points)
 }
 
 export default transform

--- a/packages/modeling/src/geometries/poly2/transform.test.js
+++ b/packages/modeling/src/geometries/poly2/transform.test.js
@@ -2,7 +2,7 @@ import test from 'ava'
 
 import { transform, create } from './index.js'
 
-import { comparePolygons } from '../../../test/helpers/index.js'
+import { comparePoints } from '../../../test/helpers/index.js'
 
 test('poly2: transform() should return a new poly2 with correct values', (t) => {
   const identityMatrix = [
@@ -12,10 +12,10 @@ test('poly2: transform() should return a new poly2 with correct values', (t) => 
     0, 0, 0, 1
   ]
 
-  const exp1 = { vertices: [[0, 0], [1, 0], [1, 1]] }
+  const exp1 = { points: [[0, 0], [1, 0], [1, 1]] }
   const org1 = create([[0, 0], [1, 0], [1, 1]])
   const ret1 = transform(identityMatrix, org1)
-  t.true(comparePolygons(ret1, exp1))
+  t.true(comparePoints(ret1.points, exp1.points))
   t.not(org1, ret1)
 
   const x = 1
@@ -28,10 +28,10 @@ test('poly2: transform() should return a new poly2 with correct values', (t) => 
     x, y, z, 1
   ]
 
-  const exp2 = { vertices: [[1, 5], [2, 5], [2, 6]] }
+  const exp2 = { points: [[1, 5], [2, 5], [2, 6]] }
   const org2 = create([[0, 0], [1, 0], [1, 1]])
   const ret2 = transform(translationMatrix, org2)
-  t.true(comparePolygons(ret2, exp2))
+  t.true(comparePoints(ret2.points, exp2.points))
   t.not(org2, ret2)
 
   const r = (90 * 0.017453292519943295)
@@ -42,10 +42,10 @@ test('poly2: transform() should return a new poly2 with correct values', (t) => 
     0, 0, 0, 1
   ]
 
-  const exp3 = { vertices: [[0, 0], [0, -1], [1, -1]] }
+  const exp3 = { points: [[0, 0], [0, -1], [1, -1]] }
   const org3 = create([[0, 0], [1, 0], [1, 1]])
   const ret3 = transform(rotateZMatrix, org3)
-  t.true(comparePolygons(ret3, exp3))
+  t.true(comparePoints(ret3.points, exp3.points))
   t.not(org3, ret3)
 
   const mirrorMatrix = [
@@ -54,9 +54,9 @@ test('poly2: transform() should return a new poly2 with correct values', (t) => 
     0, 0, 1, 0,
     0, 0, 0, 1
   ]
-  const exp4 = { vertices: [[-1, 1], [-1, 0], [0, 0]] }
+  const exp4 = { points: [[-1, 1], [-1, 0], [0, 0]] }
   const org4 = create([[0, 0], [1, 0], [1, 1]])
   const ret4 = transform(mirrorMatrix, org4)
-  t.true(comparePolygons(ret4, exp4))
+  t.true(comparePoints(ret4.points, exp4.points))
   t.not(org4, ret4)
 })

--- a/packages/modeling/src/geometries/poly2/type.d.ts
+++ b/packages/modeling/src/geometries/poly2/type.d.ts
@@ -3,5 +3,5 @@ import Vec2 from '../../maths/vec2/type'
 export default Poly2
 
 declare interface Poly2 {
-  vertices: Array<Vec2>
+  points: Array<Vec2>
 }

--- a/packages/modeling/src/geometries/poly2/validate.js
+++ b/packages/modeling/src/geometries/poly2/validate.js
@@ -19,8 +19,8 @@ export const validate = (object) => {
   }
 
   // check for empty polygon
-  if (object.vertices.length < 3) {
-    throw new Error(`poly2 not enough vertices ${object.vertices.length}`)
+  if (object.points.length < 3) {
+    throw new Error(`poly2 not enough points ${object.points.length}`)
   }
   // check area
   if (measureArea(object) <= 0) {
@@ -28,19 +28,19 @@ export const validate = (object) => {
   }
 
   // check for duplicate points
-  for (let i = 0; i < object.vertices.length; i++) {
-    if (vec2.equals(object.vertices[i], object.vertices[(i + 1) % object.vertices.length])) {
-      throw new Error(`poly2 duplicate vertex at ${i}: [${object.vertices[i]}]`)
+  for (let i = 0; i < object.points.length; i++) {
+    if (vec2.equals(object.points[i], object.points[(i + 1) % object.points.length])) {
+      throw new Error(`poly2 duplicate point at ${i}: [${object.points[i]}]`)
     }
   }
 
   // check for infinity, nan
-  object.vertices.forEach((vertex) => {
-    if (vertex.length != 2) {
-      throw new Error(`poly2 invalid vertex ${vertex}`)
+  object.points.forEach((point) => {
+    if (point.length != 2) {
+      throw new Error(`poly2 invalid point ${point}`)
     }
-    if (!vertex.every(Number.isFinite)) {
-      throw new Error(`poly2 invalid vertex ${vertex}`)
+    if (!point.every(Number.isFinite)) {
+      throw new Error(`poly2 invalid point ${point}`)
     }
   })
 }

--- a/packages/modeling/src/geometries/poly2/validate.test.js
+++ b/packages/modeling/src/geometries/poly2/validate.test.js
@@ -4,7 +4,7 @@ import { validate, create, toString } from './index.js'
 
 test('validate: identifies polygons', (t) => {
   const ply1 = create()
-  t.throws(() => validate(ply1), { message: 'poly2 not enough vertices 0' })
+  t.throws(() => validate(ply1), { message: 'poly2 not enough points 0' })
 
   const ply2 = create([[0, 0], [1, 0], [1, 1]])
   t.notThrows(() => validate(ply2))
@@ -29,5 +29,5 @@ test('validate: identifies polygons', (t) => {
 
   // Counter Clockwise with duplicate points
   const ply7 = create([[5, 5], [-5, 5], [-5, 5], [-5, -5], [5, -5]])
-  t.throws(() => validate(ply7), { message: 'poly2 duplicate vertex at 1: [-5,5]' })
+  t.throws(() => validate(ply7), { message: 'poly2 duplicate point at 1: [-5,5]' })
 })

--- a/packages/modeling/src/operations/extrusions/earcut/assignHoles.js
+++ b/packages/modeling/src/operations/extrusions/earcut/assignHoles.js
@@ -1,6 +1,6 @@
 import area from '../../../maths/utils/area.js'
-import toOutlines from '../../../geometries/geom2/toOutlines.js'
-import arePointsInside from '../../../geometries/poly2/arePointsInside.js'
+import { toOutlines } from '../../../geometries/geom2/index.js'
+import * as poly2 from '../../../geometries/poly2/index.js'
 
 /*
  * Constructs a polygon hierarchy of solids and holes.
@@ -41,7 +41,7 @@ export const assignHoles = (geometry) => {
     holes.forEach((h, j) => {
       const hole = outlines[h]
       // check if a point of hole j is inside solid i
-      if (arePointsInside([hole[0]], { vertices: solid })) {
+      if (poly2.arePointsInside([hole[0]], poly2.create(solid))) {
         children[i].push(h)
         if (!parents[j]) parents[j] = []
         parents[j].push(i)


### PR DESCRIPTION
This PR changes `poly2.vertices` to `poly2.points`.

The problems is that otherwise there is no difference between the structure of poly2 and poly3. So you would have the following weirdness:

```js
poly2.isA( poly3.create() ) == true
poly3.isA( poly2.create() ) == true
```

By using `points` instead of `vertices` we can tell the difference between a poly2 and a poly3.

More generally, I like the idea of using "points" to refer to 2D points, and "vertices" to refer to 3D points. I think it could help make JSCAD code easier to understand if we are consistent about that.

I also added tests for `poly2.reverse` and `poly2.toPoints` since I noticed that they were not covered by existing tests.


### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
