### PR TITLE
test(modeling): tests for area and volume of operations

### DIFF
--- a/packages/modeling/src/operations/booleans/intersectGeom2.test.js
+++ b/packages/modeling/src/operations/booleans/intersectGeom2.test.js
@@ -4,6 +4,8 @@ import { comparePoints } from '../../../test/helpers/index.js'
 
 import { geom2 } from '../../geometries/index.js'
 
+import { measureArea } from '../../measurements/index.js'
+
 import { circle, rectangle } from '../../primitives/index.js'
 
 import { intersect } from './index.js'
@@ -27,6 +29,7 @@ test('intersect: intersect of one or more geom2 objects produces expected geomet
     [1.4142135623730947, -1.4142135623730954]
   ]
   t.notThrows(() => geom2.validate(result1))
+  t.is(measureArea(result1), 11.31370849898476)
   t.is(obs.length, 8)
   t.true(comparePoints(obs, exp))
 
@@ -36,6 +39,7 @@ test('intersect: intersect of one or more geom2 objects produces expected geomet
   const result2 = intersect(geometry1, geometry2)
   obs = geom2.toPoints(result2)
   t.notThrows(() => geom2.validate(result2))
+  t.is(measureArea(result2), 0)
   t.is(obs.length, 0)
 
   // intersect of two partially overlapping objects
@@ -47,6 +51,7 @@ test('intersect: intersect of one or more geom2 objects produces expected geomet
     [8, 8], [9, 8], [9, 9], [8, 9]
   ]
   t.notThrows(() => geom2.validate(result3))
+  t.is(measureArea(result3), 1)
   t.is(obs.length, 4)
   t.true(comparePoints(obs, exp))
 
@@ -64,6 +69,7 @@ test('intersect: intersect of one or more geom2 objects produces expected geomet
     [-1.414213562373095, 1.4142135623730951]
   ]
   t.notThrows(() => geom2.validate(result4))
+  t.is(measureArea(result4), 11.31370849898476)
   t.is(obs.length, 8)
   t.true(comparePoints(obs, exp))
 })

--- a/packages/modeling/src/operations/booleans/intersectGeom3.test.js
+++ b/packages/modeling/src/operations/booleans/intersectGeom3.test.js
@@ -4,6 +4,8 @@ import { comparePolygonsAsPoints } from '../../../test/helpers/index.js'
 
 import { geom3 } from '../../geometries/index.js'
 
+import { measureVolume } from '../../measurements/index.js'
+
 import { sphere, cuboid } from '../../primitives/index.js'
 
 import { intersect } from './index.js'
@@ -67,6 +69,7 @@ test('intersect: intersect of one or more geom3 objects produces expected geomet
     [[8.65956056235493e-17, 8.659560562354935e-17, 2], [1.4142135623730951, 3.4638242249419736e-16, 1.414213562373095], [0.9999999999999998, 1.0000000000000002, 1.414213562373095]]
   ]
   t.notThrows.skip(() => geom3.validate(result1))
+  t.is(measureVolume(result1), 25.751611331979678)
   t.is(obs.length, 32)
   t.true(comparePolygonsAsPoints(obs, exp))
 
@@ -76,6 +79,7 @@ test('intersect: intersect of one or more geom3 objects produces expected geomet
   const result2 = intersect(geometry1, geometry2)
   obs = geom3.toPoints(result2)
   t.notThrows(() => geom3.validate(result2))
+  t.is(measureVolume(result2), 0)
   t.is(obs.length, 0)
 
   // intersect of two partially overlapping objects
@@ -85,16 +89,6 @@ test('intersect: intersect of one or more geom3 objects produces expected geomet
   obs = geom3.toPoints(result3)
 
   // the order changes based on the bestplane chosen in Node.js
-  /*
-  exp = [
-    [[9, 9, 8], [9, 9, 9], [9, 8, 9], [9, 8, 8]],
-    [[8, 9, 9], [9, 9, 9], [9, 9, 8], [8, 9, 8]],
-    [[9, 8, 9], [9, 9, 9], [8, 9, 9], [8, 8, 9]],
-    [[8, 9, 9], [8, 9, 8], [8, 8, 8], [8, 8, 9]],
-    [[8, 8, 9], [8, 8, 8], [9, 8, 8], [9, 8, 9]],
-    [[9, 9, 8], [9, 8, 8], [8, 8, 8], [8, 9, 8]]
-  ]
-*/
   exp = [
     [[9, 9, 8], [9, 9, 9], [9, 8, 9], [9, 8, 8]],
     [[8, 9, 9], [9, 9, 9], [9, 9, 8], [8, 9, 8]],
@@ -105,6 +99,7 @@ test('intersect: intersect of one or more geom3 objects produces expected geomet
   ]
 
   t.notThrows(() => geom3.validate(result3))
+  t.is(measureVolume(result3), 1.0000000000000009)
   t.is(obs.length, 6)
   t.true(comparePolygonsAsPoints(obs, exp))
 
@@ -112,5 +107,6 @@ test('intersect: intersect of one or more geom3 objects produces expected geomet
   const result4 = intersect(geometry1, geometry3)
   obs = geom3.toPoints(result4)
   t.notThrows.skip(() => geom3.validate(result4))
+  t.is(measureVolume(result4), 25.751611331979678)
   t.is(obs.length, 32)
 })

--- a/packages/modeling/src/operations/booleans/subtractGeom2.test.js
+++ b/packages/modeling/src/operations/booleans/subtractGeom2.test.js
@@ -4,6 +4,8 @@ import { comparePoints } from '../../../test/helpers/index.js'
 
 import { geom2 } from '../../geometries/index.js'
 
+import { measureArea } from '../../measurements/index.js'
+
 import { circle, rectangle } from '../../primitives/index.js'
 
 import { center } from '../transforms/center.js'
@@ -27,6 +29,7 @@ test('subtract: subtract of one or more geom2 objects produces expected geometry
     [1.4142135623730947, -1.4142135623730954]
   ]
   t.notThrows(() => geom2.validate(result1))
+  t.is(measureArea(result1), 11.31370849898476)
   t.is(obs.length, 8)
   t.true(comparePoints(obs, exp))
 
@@ -46,6 +49,7 @@ test('subtract: subtract of one or more geom2 objects produces expected geometry
     [1.4142135623730947, -1.4142135623730954]
   ]
   t.notThrows(() => geom2.validate(result2))
+  t.is(measureArea(result2), 11.31370849898476)
   t.is(obs.length, 8)
   t.true(comparePoints(obs, exp))
 
@@ -58,15 +62,16 @@ test('subtract: subtract of one or more geom2 objects produces expected geometry
     [8, 9], [9, 9], [9, 8], [12, 8], [12, 12], [8, 12]
   ]
   t.notThrows(() => geom2.validate(result3))
+  t.is(measureArea(result3), 15)
   t.is(obs.length, 6)
   t.true(comparePoints(obs, exp))
 
   // subtract of two completely overlapping objects
   const result4 = subtract(geometry1, geometry3)
   obs = geom2.toPoints(result4)
-  exp = [
-  ]
+  exp = []
   t.notThrows(() => geom2.validate(result4))
+  t.is(measureArea(result4), 0)
   t.is(obs.length, 0)
   t.deepEqual(obs, exp)
 })

--- a/packages/modeling/src/operations/booleans/subtractGeom3.test.js
+++ b/packages/modeling/src/operations/booleans/subtractGeom3.test.js
@@ -4,6 +4,8 @@ import { comparePolygonsAsPoints } from '../../../test/helpers/index.js'
 
 import { geom3 } from '../../geometries/index.js'
 
+import { measureVolume } from '../../measurements/index.js'
+
 import { sphere, cuboid } from '../../primitives/index.js'
 
 import { subtract } from './index.js'
@@ -67,6 +69,7 @@ test('subtract: subtract of one or more geom3 objects produces expected geometry
     [[8.65956056235493e-17, 8.659560562354935e-17, 2], [1.4142135623730951, 3.4638242249419736e-16, 1.414213562373095], [0.9999999999999998, 1.0000000000000002, 1.414213562373095]]
   ]
   t.notThrows.skip(() => geom3.validate(result1))
+  t.is(measureVolume(result1), 25.751611331979678)
   t.is(obs.length, 32)
   t.true(comparePolygonsAsPoints(obs, exp))
 
@@ -76,6 +79,7 @@ test('subtract: subtract of one or more geom3 objects produces expected geometry
   const result2 = subtract(geometry1, geometry2)
   obs = geom3.toPoints(result2)
   t.notThrows.skip(() => geom3.validate(result2))
+  t.is(measureVolume(result2), 25.751611331979678)
   t.is(obs.length, 32)
 
   // subtract of two partially overlapping objects
@@ -98,6 +102,7 @@ test('subtract: subtract of one or more geom3 objects produces expected geometry
     [[12, 9, 8], [12, 8, 8], [9, 8, 8], [9, 9, 8]]
   ]
   t.notThrows.skip(() => geom3.validate(result3))
+  t.is(measureVolume(result3), 63)
   t.is(obs.length, 12)
   t.true(comparePolygonsAsPoints(obs, exp))
 
@@ -105,5 +110,6 @@ test('subtract: subtract of one or more geom3 objects produces expected geometry
   const result4 = subtract(geometry1, geometry3)
   obs = geom3.toPoints(result4)
   t.notThrows(() => geom3.validate(result4))
+  t.is(measureVolume(result4), 0)
   t.is(obs.length, 0)
 })

--- a/packages/modeling/src/operations/booleans/unionGeom2.test.js
+++ b/packages/modeling/src/operations/booleans/unionGeom2.test.js
@@ -4,6 +4,8 @@ import { comparePoints } from '../../../test/helpers/index.js'
 
 import { geom2 } from '../../geometries/index.js'
 
+import { measureArea } from '../../measurements/index.js'
+
 import { circle, rectangle } from '../../primitives/index.js'
 
 import { center, translate } from '../transforms/index.js'
@@ -27,6 +29,8 @@ test('union of one or more geom2 objects produces expected geometry', (t) => {
     [1.4142135623730947, -1.4142135623730954]
   ]
   t.notThrows(() => geom2.validate(result1))
+  t.is(measureArea(result1), 11.31370849898476)
+  t.is(obs.length, 8)
   t.true(comparePoints(obs, exp))
 
   // union of two non-overlapping objects
@@ -49,6 +53,7 @@ test('union of one or more geom2 objects produces expected geometry', (t) => {
     [8, 12]
   ]
   t.notThrows(() => geom2.validate(result2))
+  t.is(measureArea(result2), 27.31370849898476)
   t.is(obs.length, 12)
   t.true(comparePoints(obs, exp))
 
@@ -68,6 +73,8 @@ test('union of one or more geom2 objects produces expected geometry', (t) => {
     [-9, 9]
   ]
   t.notThrows(() => geom2.validate(result3))
+  t.is(measureArea(result3), 339)
+  t.is(obs.length, 8)
   t.true(comparePoints(obs, exp))
 
   // union of two completely overlapping objects
@@ -80,6 +87,8 @@ test('union of one or more geom2 objects produces expected geometry', (t) => {
     [-9, 9]
   ]
   t.notThrows(() => geom2.validate(result4))
+  t.is(measureArea(result4), 324)
+  t.is(obs.length, 4)
   t.true(comparePoints(obs, exp))
 
   // union of unions of non-overlapping objects (BSP gap from #907)
@@ -96,6 +105,7 @@ test('union of one or more geom2 objects produces expected geometry', (t) => {
   )
   obs = geom2.toPoints(result5)
   t.notThrows(() => geom2.validate(result5))
+  t.is(measureArea(result5), 9.36433545677411)
   t.is(obs.length, 96)
 })
 
@@ -141,8 +151,8 @@ test('union of geom2 with closing issues #15', (t) => {
     ]
   ])
 
-  const obs = union(c, d)
-  const pts = geom2.toPoints(obs)
+  const result = union(c, d)
+  const pts = geom2.toPoints(result)
   const exp = [
     [-68.40089829889257, -2.9818050203707855],
     [-68.31614651314507, -3.1079037395143487],
@@ -165,7 +175,8 @@ test('union of geom2 with closing issues #15', (t) => {
     [-49.057272912186846, -15.486616385421712],
     [-49.10586702080816, -15.276041773521108]
   ]
-  t.notThrows(() => geom2.validate(obs))
+  t.notThrows(() => geom2.validate(result))
+  t.is(measureArea(result), 17.56120670215806)
   t.is(pts.length, 20) // number of sides in union
   t.true(comparePoints(pts, exp))
 })
@@ -194,6 +205,7 @@ test('union of geom2 with colinear edge (martinez issue #155)', (t) => {
   const result = union(g1, g2)
   const pts = geom2.toPoints(result)
   t.notThrows(() => geom2.validate(result))
+  t.is(measureArea(result), 1.9906657858562764)
   t.is(pts.length, 5)
   t.true(comparePoints(pts, exp))
 })

--- a/packages/modeling/src/operations/booleans/unionGeom3.test.js
+++ b/packages/modeling/src/operations/booleans/unionGeom3.test.js
@@ -4,6 +4,8 @@ import { comparePolygonsAsPoints } from '../../../test/helpers/index.js'
 
 import { geom3 } from '../../geometries/index.js'
 
+import { measureVolume } from '../../measurements/index.js'
+
 import { sphere, cuboid } from '../../primitives/index.js'
 
 import { center } from '../transforms/index.js'
@@ -67,6 +69,8 @@ test('union of one or more geom3 objects produces expected geometry', (t) => {
     [[8.65956056235493e-17, 8.659560562354935e-17, 2], [1.4142135623730951, 3.4638242249419736e-16, 1.414213562373095], [0.9999999999999998, 1.0000000000000002, 1.414213562373095]]
   ]
   t.notThrows.skip(() => geom3.validate(result1))
+  t.is(measureVolume(result1), 25.751611331979678)
+  t.is(obs.length, 32)
   t.true(comparePolygonsAsPoints(obs, exp))
 
   // union of two non-overlapping objects
@@ -75,6 +79,7 @@ test('union of one or more geom3 objects produces expected geometry', (t) => {
   const result2 = union(geometry1, geometry2)
   obs = geom3.toPoints(result2)
   t.notThrows.skip(() => geom3.validate(result2))
+  t.is(measureVolume(result2), 89.75161133197969)
   t.is(obs.length, 38)
 
   // union of two partially overlapping objects
@@ -103,6 +108,7 @@ test('union of one or more geom3 objects produces expected geometry', (t) => {
     [[-9, 8, 9], [-9, -9, 9], [9, -9, 9], [9, 8, 9]]
   ]
   t.notThrows.skip(() => geom3.validate(result3))
+  t.is(measureVolume(result3), 5895)
   t.is(obs.length, 18)
   t.true(comparePolygonsAsPoints(obs, exp))
 
@@ -118,6 +124,7 @@ test('union of one or more geom3 objects produces expected geometry', (t) => {
     [[-9, -9, 9], [9, -9, 9], [9, 9, 9], [-9, 9, 9]]
   ]
   t.notThrows(() => geom3.validate(result4))
+  t.is(measureVolume(result4), 5832)
   t.is(obs.length, 6)
   t.true(comparePolygonsAsPoints(obs, exp))
 })
@@ -126,8 +133,9 @@ test('union of geom3 with rounding issues #137', (t) => {
   const geometry1 = center({ relativeTo: [0, 0, -1] }, cuboid({ size: [44, 26, 5] }))
   const geometry2 = center({ relativeTo: [0, 0, -4.400001] }, cuboid({ size: [44, 26, 1.8] })) // introduce precision error
 
-  const obs = union(geometry1, geometry2)
-  const pts = geom3.toPoints(obs)
-  t.notThrows(() => geom3.validate(obs))
+  const result = union(geometry1, geometry2)
+  const pts = geom3.toPoints(result)
+  t.notThrows(() => geom3.validate(result))
+  t.is(measureVolume(result), 7779.201144000001)
   t.is(pts.length, 6) // number of polygons in union
 })

--- a/packages/modeling/src/operations/expansions/offsetGeom2.test.js
+++ b/packages/modeling/src/operations/expansions/offsetGeom2.test.js
@@ -1,6 +1,9 @@
 import test from 'ava'
 
 import { geom2 } from '../../geometries/index.js'
+
+import { measureArea } from '../../measurements/index.js'
+
 import { roundedRectangle } from '../../primitives/index.js'
 
 import { offset } from './index.js'
@@ -8,15 +11,17 @@ import { offset } from './index.js'
 import { comparePoints } from '../../../test/helpers/index.js'
 
 test('offset (options): offsetting of a simple geom2 produces expected offset geom2', (t) => {
-  const geometry = geom2.create([[[-5, -5], [5, -5], [5, 5], [3, 5], [3, 0], [-3, 0], [-3, 5], [-5, 5]]])
+  const geometry = geom2.create([
+    [[-5, -5], [5, -5], [5, 5], [3, 5], [3, 0], [-3, 0], [-3, 5], [-5, 5]]
+  ])
 
   // empty
   const empty = geom2.create()
   let obs = offset({ delta: 1 }, empty)
   let pts = geom2.toPoints(obs)
-  let exp = [
-  ]
+  let exp = []
   t.notThrows(() => geom2.validate(obs))
+  t.is(measureArea(obs), 0)
   t.true(comparePoints(pts, exp))
 
   // expand +
@@ -39,6 +44,8 @@ test('offset (options): offsetting of a simple geom2 produces expected offset ge
     [-6, -5]
   ]
   t.notThrows(() => geom2.validate(obs))
+  t.is(measureArea(obs), 121)
+  t.is(pts.length, 14)
   t.true(comparePoints(pts, exp))
 
   // contract -
@@ -57,6 +64,8 @@ test('offset (options): offsetting of a simple geom2 produces expected offset ge
     [-4.5, 4.5]
   ]
   t.notThrows(() => geom2.validate(obs))
+  t.is(measureArea(obs), 46.25)
+  t.is(pts.length, 10)
   t.true(comparePoints(pts, exp))
 
   // segments 1 - sharp points at corner
@@ -73,6 +82,8 @@ test('offset (options): offsetting of a simple geom2 produces expected offset ge
     [-6, -6]
   ]
   t.notThrows(() => geom2.validate(obs))
+  t.is(measureArea(obs), 124)
+  t.is(pts.length, 8)
   t.true(comparePoints(pts, exp))
 
   // segments 16 - rounded corners
@@ -97,6 +108,8 @@ test('offset (options): offsetting of a simple geom2 produces expected offset ge
     [-4.5, 4.5]
   ]
   t.notThrows(() => geom2.validate(obs))
+  t.is(measureArea(obs), 46.1173165676349)
+  t.is(pts.length, 16)
   t.true(comparePoints(pts, exp))
 })
 
@@ -151,6 +164,7 @@ test('offset (options): offsetting of a complex geom2 produces expected offset g
     [-4, -21]
   ]
   t.notThrows(() => geom2.validate(obs))
+  t.is(measureArea(obs), 17704)
   t.is(pts.length, 20)
   t.true(comparePoints(pts, exp))
 })
@@ -196,6 +210,7 @@ test('offset (options): offsetting of round geom2 produces expected offset geom2
     [8.767810140100096, -3.6317399864658024]
   ]
   t.notThrows(() => geom2.validate(obs))
+  t.is(measureArea(obs), 275.72806620525375)
   t.is(pts.length, 16)
   t.true(comparePoints(pts, exp))
 })

--- a/packages/modeling/src/operations/extrusions/extrudeFromSlices.test.js
+++ b/packages/modeling/src/operations/extrusions/extrudeFromSlices.test.js
@@ -7,6 +7,8 @@ import { mat4 } from '../../maths/index.js'
 
 import { geom2, geom3, poly3, slice } from '../../geometries/index.js'
 
+import { measureVolume } from '../../measurements/index.js'
+
 import { circle, square } from '../../primitives/index.js'
 
 import { extrudeFromSlices } from './index.js'
@@ -38,6 +40,7 @@ test('extrudeFromSlices (defaults)', (t) => {
   pts = geom3.toPoints(geometry3)
 
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureVolume(geometry3), 400.00000000000006)
   t.is(pts.length, 12)
   t.true(comparePolygonsAsPoints(pts, exp))
 })
@@ -71,6 +74,7 @@ test('extrudeFromSlices (torus)', (t) => {
   )
   const pts = geom3.toPoints(geometry3)
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureVolume(geometry3), 29393.876913398108)
   t.is(pts.length, 96)
 })
 
@@ -91,6 +95,7 @@ test('extrudeFromSlices (same shape, changing dimensions)', (t) => {
   const pts = geom3.toPoints(geometry3)
   // expected to throw because capEnd is false (non-closed geometry)
   t.throws(() => geom3.validate(geometry3))
+  t.is(measureVolume(geometry3), 8.5)
   t.is(pts.length, 26)
 })
 
@@ -109,6 +114,7 @@ test('extrudeFromSlices (changing shape, changing dimensions)', (t) => {
   )
   const pts = geom3.toPoints(geometry3)
   t.notThrows.skip(() => geom3.validate(geometry3))
+  t.is(measureVolume(geometry3), 5260.067107417433)
   t.is(pts.length, 304)
 })
 
@@ -154,6 +160,7 @@ test('extrudeFromSlices (holes)', (t) => {
     [[-5, -5, 0], [5, -5, 0], [-10, -10, 0]]
   ]
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureVolume(geometry3), 300)
   t.is(pts.length, 32)
   t.true(comparePolygonsAsPoints(pts, exp))
 })

--- a/packages/modeling/src/operations/extrusions/extrudeLinear.test.js
+++ b/packages/modeling/src/operations/extrusions/extrudeLinear.test.js
@@ -5,6 +5,9 @@ import { comparePolygonsAsPoints } from '../../../test/helpers/index.js'
 import { TAU } from '../../maths/constants.js'
 
 import { geom2, geom3, path2 } from '../../geometries/index.js'
+
+import { measureVolume } from '../../measurements/index.js'
+
 import square from '../../primitives/square.js'
 
 import { extrudeLinear } from './index.js'
@@ -29,6 +32,7 @@ test('extrudeLinear (defaults)', (t) => {
     [[5, 5, 0], [5, -5, 0], [-5, -5, 0]]
   ]
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureVolume(geometry3), 100.00000000000001)
   t.is(pts.length, 12)
   t.true(comparePolygonsAsPoints(pts, exp))
 })
@@ -53,6 +57,7 @@ test('extrudeLinear (no twist)', (t) => {
     [[5, 5, 0], [5, -5, 0], [-5, -5, 0]]
   ]
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureVolume(geometry3), 1500)
   t.is(pts.length, 12)
   t.true(comparePolygonsAsPoints(pts, exp))
 
@@ -73,6 +78,7 @@ test('extrudeLinear (no twist)', (t) => {
     [[5, -5, 0], [5, 5, 0], [-5, 5, 0]]
   ]
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureVolume(geometry3), 1500)
   t.is(pts.length, 12)
   t.true(comparePolygonsAsPoints(pts, exp))
 })
@@ -105,6 +111,7 @@ test('extrudeLinear (twist)', (t) => {
     [[5, 5, 0], [5, -5, 0], [-5, -5, 0]]
   ]
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureVolume(geometry3), 1707.1067811865476)
   t.is(pts.length, 12)
   t.true(comparePolygonsAsPoints(pts, exp))
 
@@ -146,6 +153,7 @@ test('extrudeLinear (twist)', (t) => {
   geometry3 = extrudeLinear({ height: 15, twistAngle: TAU / 2, twistSteps: 30 }, geometry2)
   pts = geom3.toPoints(geometry3)
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureVolume(geometry3), 1444.9967160503095)
   t.is(pts.length, 244)
 })
 
@@ -191,6 +199,7 @@ test('extrudeLinear (holes)', (t) => {
     [[-2, -2, 0], [2, -2, 0], [-5, -5, 0]]
   ]
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureVolume(geometry3), 1260)
   t.is(pts.length, 32)
   t.true(comparePolygonsAsPoints(pts, exp))
 })

--- a/packages/modeling/src/operations/extrusions/extrudeRectangular.test.js
+++ b/packages/modeling/src/operations/extrusions/extrudeRectangular.test.js
@@ -4,6 +4,8 @@ import { TAU } from '../../maths/constants.js'
 
 import { geom2, geom3 } from '../../geometries/index.js'
 
+import { measureVolume } from '../../measurements/index.js'
+
 import { arc, rectangle } from '../../primitives/index.js'
 
 import { extrudeRectangular } from './index.js'
@@ -15,11 +17,13 @@ test('extrudeRectangular (defaults)', (t) => {
   let obs = extrudeRectangular({ }, geometry1)
   let pts = geom3.toPoints(obs)
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureVolume(obs), 15.643446504023084)
   t.is(pts.length, 44)
 
   obs = extrudeRectangular({ }, geometry2)
   pts = geom3.toPoints(obs)
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureVolume(obs), 40)
   t.is(pts.length, 32)
 })
 
@@ -30,11 +34,13 @@ test('extrudeRectangular (chamfer)', (t) => {
   let obs = extrudeRectangular({ corners: 'chamfer' }, geometry1)
   let pts = geom3.toPoints(obs)
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureVolume(obs), 15.627942731474823)
   t.is(pts.length, 60)
 
   obs = extrudeRectangular({ corners: 'chamfer' }, geometry2)
   pts = geom3.toPoints(obs)
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureVolume(obs), 38)
   t.is(pts.length, 48)
 })
 
@@ -45,11 +51,13 @@ test('extrudeRectangular (segments = 8, round)', (t) => {
   let obs = extrudeRectangular({ segments: 8, corners: 'round' }, geometry1)
   let pts = geom3.toPoints(obs)
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureVolume(obs), 18.456369856221006)
   t.is(pts.length, 84)
 
   obs = extrudeRectangular({ segments: 8, corners: 'round' }, geometry2)
   pts = geom3.toPoints(obs)
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureVolume(obs), 38.828427124746185)
   t.is(pts.length, 64)
 })
 
@@ -62,5 +70,6 @@ test('extrudeRectangular (holes)', (t) => {
   const obs = extrudeRectangular({ size: 2, height: 15, segments: 16, corners: 'round' }, geometry2)
   const pts = geom3.toPoints(obs)
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureVolume(obs), 9487.376095070491)
   t.is(pts.length, 192)
 })

--- a/packages/modeling/src/operations/extrusions/extrudeRotate.test.js
+++ b/packages/modeling/src/operations/extrusions/extrudeRotate.test.js
@@ -6,6 +6,8 @@ import { TAU } from '../../maths/constants.js'
 
 import { geom2, geom3 } from '../../geometries/index.js'
 
+import { measureVolume } from '../../measurements/index.js'
+
 import { extrudeRotate } from './index.js'
 
 test('extrudeRotate: (defaults) extruding of a geom2 produces an expected geom3', (t) => {
@@ -14,6 +16,7 @@ test('extrudeRotate: (defaults) extruding of a geom2 produces an expected geom3'
   const geometry3 = extrudeRotate({ }, geometry2)
   const pts = geom3.toPoints(geometry3)
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureVolume(geometry3), 27648.000000000007)
   t.is(pts.length, 96)
 })
 
@@ -38,17 +41,20 @@ test('extrudeRotate: (angle) extruding of a geom2 produces an expected geom3', (
     [[10, 0, -8], [26, 0, -8], [26, 0, 8]]
   ]
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureVolume(geometry3), 3258.3480477076105)
   t.is(pts.length, 12)
   t.true(comparePolygonsAsPoints(pts, exp))
 
   geometry3 = extrudeRotate({ segments: 4, angle: -250 * 0.017453292519943295 }, geometry2)
   pts = geom3.toPoints(geometry3)
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureVolume(geometry3), 13730.527057424617)
   t.is(pts.length, 28)
 
   geometry3 = extrudeRotate({ segments: 4, angle: 250 * 0.017453292519943295 }, geometry2)
   pts = geom3.toPoints(geometry3)
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureVolume(geometry3), 13730.527057424617)
   t.is(pts.length, 28)
 })
 
@@ -64,6 +70,7 @@ test('extrudeRotate: (startAngle) extruding of a geom2 produces an expected geom
     [-11.803752993228215, 23.166169628897567, 8]
   ]
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureVolume(geometry3), 21912.342135440336)
   t.is(pts.length, 40)
   t.true(comparePoints(pts[6], exp))
 
@@ -75,6 +82,7 @@ test('extrudeRotate: (startAngle) extruding of a geom2 produces an expected geom
     [23.166169628897567, 11.803752993228215, 8]
   ]
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureVolume(geometry3), 21912.342135440336)
   t.is(pts.length, 40)
   t.true(comparePoints(pts[6], exp))
 })
@@ -86,11 +94,13 @@ test('extrudeRotate: (segments) extruding of a geom2 produces an expected geom3'
   let geometry3 = extrudeRotate({ segments: 4 }, geometry2)
   let pts = geom3.toPoints(geometry3)
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureVolume(geometry3), 18432)
   t.is(pts.length, 32)
 
   geometry3 = extrudeRotate({ segments: 64 }, geometry2)
   pts = geom3.toPoints(geometry3)
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureVolume(geometry3), 28906.430888871357)
   t.is(pts.length, 512)
 
   // test overlapping edges
@@ -98,6 +108,7 @@ test('extrudeRotate: (segments) extruding of a geom2 produces an expected geom3'
   geometry3 = extrudeRotate({ segments: 8 }, geometry2)
   pts = geom3.toPoints(geometry3)
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureVolume(geometry3), 33.94112549695427)
   t.is(pts.length, 64)
 
   // test overlapping edges that produce hollow shape
@@ -105,6 +116,7 @@ test('extrudeRotate: (segments) extruding of a geom2 produces an expected geom3'
   geometry3 = extrudeRotate({ segments: 8 }, geometry2)
   pts = geom3.toPoints(geometry3)
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureVolume(geometry3), 147078.2104868019)
   t.is(pts.length, 80)
 })
 
@@ -125,6 +137,7 @@ test('extrudeRotate: (overlap +/-) extruding of a geom2 produces an expected geo
     [[7, 0, -8], [7, 0, 8], [0, 0, 8]]
   ]
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureVolume(obs), 391.99999999999994)
   t.is(pts.length, 8)
   t.true(comparePolygonsAsPoints(pts, exp))
 
@@ -154,6 +167,7 @@ test('extrudeRotate: (overlap +/-) extruding of a geom2 produces an expected geo
     [[2, 0, 4], [0, 0, 8], [0, 0, -8]]
   ]
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureVolume(obs), 26.398653164297773)
   t.is(pts.length, 18)
   t.true(comparePolygonsAsPoints(pts, exp))
 })

--- a/packages/modeling/src/operations/extrusions/project.test.js
+++ b/packages/modeling/src/operations/extrusions/project.test.js
@@ -3,6 +3,9 @@ import test from 'ava'
 import { comparePoints } from '../../../test/helpers/index.js'
 
 import { geom2, geom3 } from '../../geometries/index.js'
+
+import { measureArea } from '../../measurements/index.js'
+
 import { cube, torus } from '../../primitives/index.js'
 
 import { project } from './index.js'
@@ -41,6 +44,7 @@ test('project (defaults)', (t) => {
 test('project torus (X and Y axis)', (t) => {
   let result = project({ axis: [1, 0, 0], origin: [1, 0, 0] }, torus({ outerSegments: 4 }))
   t.notThrows(() => geom2.validate(result))
+  t.is(measureArea(result), 19.12144515225805)
   let pts = geom2.toPoints(result)
   let exp = [
     [-1, -4],
@@ -84,6 +88,7 @@ test('project torus (X and Y axis)', (t) => {
 
   result = project({ axis: [0, 1, 0], origin: [0, -1, 0] }, torus({ outerSegments: 4 }))
   t.notThrows(() => geom2.validate(result))
+  t.is(measureArea(result), 19.12144515225805)
   pts = geom2.toPoints(result)
   exp = [
     [-5, 0],
@@ -133,4 +138,5 @@ test('project torus (martinez issue #155)', (t) => {
   )
   const pts = geom2.toPoints(result)
   t.notThrows(() => geom2.validate(result))
+  t.is(measureArea(result), 21.15545050788201)
 })

--- a/packages/modeling/src/operations/transforms/center.test.js
+++ b/packages/modeling/src/operations/transforms/center.test.js
@@ -4,7 +4,7 @@ import { comparePoints, comparePolygonsAsPoints } from '../../../test/helpers/in
 
 import { geom2, geom3, path2 } from '../../geometries/index.js'
 
-import { measureArea } from '../../measurements/index.js'
+import { measureArea, measureVolume } from '../../measurements/index.js'
 
 import { center, centerX, centerY, centerZ } from './index.js'
 
@@ -65,11 +65,13 @@ test('center: centering of a geom3 produces expected changes to polygons', (t) =
     [[-5, -7, 18], [5, -7, 18], [5, 13, 18], [-5, 13, 18]]
   ]
   t.notThrows(() => geom3.validate(centered))
+  t.is(measureVolume(centered), measureVolume(geometry))
   t.true(comparePolygonsAsPoints(pts, exp))
 
   centered = centerX(geometry)
   pts = geom3.toPoints(centered)
   t.notThrows(() => geom3.validate(centered))
+  t.is(measureVolume(centered), measureVolume(geometry))
   t.true(comparePolygonsAsPoints(pts, exp))
 
   // center about Y
@@ -84,11 +86,13 @@ test('center: centering of a geom3 produces expected changes to polygons', (t) =
     [[-2, -10, 18], [8, -10, 18], [8, 10, 18], [-2, 10, 18]]
   ]
   t.notThrows(() => geom3.validate(centered))
+  t.is(measureVolume(centered), measureVolume(geometry))
   t.true(comparePolygonsAsPoints(pts, exp))
 
   centered = centerY(geometry)
   pts = geom3.toPoints(centered)
   t.notThrows(() => geom3.validate(centered))
+  t.is(measureVolume(centered), measureVolume(geometry))
   t.true(comparePolygonsAsPoints(pts, exp))
 
   // center about Z
@@ -103,11 +107,13 @@ test('center: centering of a geom3 produces expected changes to polygons', (t) =
     [[-2, -7, 15], [8, -7, 15], [8, 13, 15], [-2, 13, 15]]
   ]
   t.notThrows(() => geom3.validate(centered))
+  t.is(measureVolume(centered), measureVolume(geometry))
   t.true(comparePolygonsAsPoints(pts, exp))
 
   centered = centerZ(geometry)
   pts = geom3.toPoints(centered)
   t.notThrows(() => geom3.validate(centered))
+  t.is(measureVolume(centered), measureVolume(geometry))
   t.true(comparePolygonsAsPoints(pts, exp))
 })
 

--- a/packages/modeling/src/operations/transforms/center.test.js
+++ b/packages/modeling/src/operations/transforms/center.test.js
@@ -4,6 +4,8 @@ import { comparePoints, comparePolygonsAsPoints } from '../../../test/helpers/in
 
 import { geom2, geom3, path2 } from '../../geometries/index.js'
 
+import { measureArea } from '../../measurements/index.js'
+
 import { center, centerX, centerY, centerZ } from './index.js'
 
 test('center: centering of a path2 produces expected changes to points', (t) => {
@@ -30,11 +32,13 @@ test('center: centering of a geom2 produces expected changes to points', (t) => 
   let pts = geom2.toPoints(centered)
   const exp = [[0, -5], [10, -5], [0, 5]]
   t.notThrows(() => geom2.validate(centered))
+  t.is(measureArea(centered), measureArea(geometry))
   t.true(comparePoints(pts, exp))
 
   centered = centerY(geometry)
   pts = geom2.toPoints(centered)
   t.notThrows(() => geom2.validate(centered))
+  t.is(measureArea(centered), measureArea(geometry))
   t.true(comparePoints(pts, exp))
 })
 

--- a/packages/modeling/src/operations/transforms/mirror.test.js
+++ b/packages/modeling/src/operations/transforms/mirror.test.js
@@ -4,7 +4,7 @@ import { comparePoints, comparePolygonsAsPoints } from '../../../test/helpers/in
 
 import { geom2, geom3, path2 } from '../../geometries/index.js'
 
-import { measureArea } from '../../measurements/index.js'
+import { measureArea, measureVolume } from '../../measurements/index.js'
 
 import { mirror, mirrorX, mirrorY, mirrorZ } from './index.js'
 
@@ -91,12 +91,14 @@ test('mirror: mirroring of geom3 about X/Y/Z produces expected changes to polygo
     [[2, 13, 18], [-8, 13, 18], [-8, -7, 18], [2, -7, 18]]
   ]
   t.notThrows(() => geom3.validate(mirrored))
+  t.is(measureVolume(mirrored), measureVolume(geometry))
   t.true(comparePolygonsAsPoints(obs, exp))
   t.deepEqual(obs, exp)
 
   mirrored = mirrorX(geometry)
   obs = geom3.toPoints(mirrored)
   t.notThrows(() => geom3.validate(mirrored))
+  t.is(measureVolume(mirrored), measureVolume(geometry))
   t.true(comparePolygonsAsPoints(obs, exp))
 
   // mirror about Y
@@ -111,11 +113,13 @@ test('mirror: mirroring of geom3 about X/Y/Z produces expected changes to polygo
     [[-2, -13, 18], [8, -13, 18], [8, 7, 18], [-2, 7, 18]]
   ]
   t.notThrows(() => geom3.validate(mirrored))
+  t.is(measureVolume(mirrored), measureVolume(geometry))
   t.true(comparePolygonsAsPoints(obs, exp))
 
   mirrored = mirrorY(geometry)
   obs = geom3.toPoints(mirrored)
   t.notThrows(() => geom3.validate(mirrored))
+  t.is(measureVolume(mirrored), measureVolume(geometry))
   t.true(comparePolygonsAsPoints(obs, exp))
 
   // mirror about Z
@@ -130,11 +134,13 @@ test('mirror: mirroring of geom3 about X/Y/Z produces expected changes to polygo
     [[-2, 13, -18], [8, 13, -18], [8, -7, -18], [-2, -7, -18]]
   ]
   t.notThrows(() => geom3.validate(mirrored))
+  t.is(measureVolume(mirrored), measureVolume(geometry))
   t.true(comparePolygonsAsPoints(obs, exp))
 
   mirrored = mirrorZ(geometry)
   obs = geom3.toPoints(mirrored)
   t.notThrows(() => geom3.validate(mirrored))
+  t.is(measureVolume(mirrored), measureVolume(geometry))
   t.true(comparePolygonsAsPoints(obs, exp))
 })
 

--- a/packages/modeling/src/operations/transforms/mirror.test.js
+++ b/packages/modeling/src/operations/transforms/mirror.test.js
@@ -4,6 +4,8 @@ import { comparePoints, comparePolygonsAsPoints } from '../../../test/helpers/in
 
 import { geom2, geom3, path2 } from '../../geometries/index.js'
 
+import { measureArea } from '../../measurements/index.js'
+
 import { mirror, mirrorX, mirrorY, mirrorZ } from './index.js'
 
 test('mirror: mirroring of path2 about X/Y produces expected changes to points', (t) => {
@@ -42,11 +44,13 @@ test('mirror: mirroring of geom2 about X/Y produces expected changes to points',
   let obs = geom2.toPoints(mirrored)
   let exp = [[5, -5], [0, 5], [-10, -5]]
   t.notThrows(() => geom2.validate(mirrored))
+  t.is(measureArea(mirrored), -measureArea(geometry))
   t.true(comparePoints(obs, exp))
 
   mirrored = mirrorX(geometry)
   obs = geom2.toPoints(mirrored)
   t.notThrows(() => geom2.validate(mirrored))
+  t.is(measureArea(mirrored), -measureArea(geometry))
   t.true(comparePoints(obs, exp))
 
   // mirror about Y
@@ -54,11 +58,13 @@ test('mirror: mirroring of geom2 about X/Y produces expected changes to points',
   obs = geom2.toPoints(mirrored)
   exp = [[-5, 5], [0, -5], [10, 5]]
   t.notThrows(() => geom2.validate(mirrored))
+  t.is(measureArea(mirrored), -measureArea(geometry))
   t.true(comparePoints(obs, exp))
 
   mirrored = mirrorY(geometry)
   obs = geom2.toPoints(mirrored)
   t.notThrows(() => geom2.validate(mirrored))
+  t.is(measureArea(mirrored), -measureArea(geometry))
   t.true(comparePoints(obs, exp))
 })
 

--- a/packages/modeling/src/operations/transforms/rotate.test.js
+++ b/packages/modeling/src/operations/transforms/rotate.test.js
@@ -4,7 +4,7 @@ import { TAU } from '../../maths/constants.js'
 
 import { geom2, geom3, path2 } from '../../geometries/index.js'
 
-import { measureArea } from '../../measurements/index.js'
+import { measureArea, measureVolume } from '../../measurements/index.js'
 
 import { rotate, rotateX, rotateY, rotateZ } from './index.js'
 
@@ -80,11 +80,13 @@ test('rotate: rotating of a geom3 produces expected changes to polygons', (t) =>
       [8, -18, 13.000000000000002], [-2, -18, 13.000000000000002]]
   ]
   t.notThrows(() => geom3.validate(rotated))
+  t.is(measureVolume(rotated), measureVolume(geometry))
   t.true(comparePolygonsAsPoints(obs, exp))
 
   rotated = rotateX(TAU / 4, geometry)
   obs = geom3.toPoints(rotated)
   t.notThrows(() => geom3.validate(rotated))
+  t.is(measureVolume(rotated), measureVolume(geometry))
   t.true(comparePolygonsAsPoints(obs, exp))
 
   // rotate about Y
@@ -105,10 +107,13 @@ test('rotate: rotating of a geom3 produces expected changes to polygons', (t) =>
       [-18, 13, 8.000000000000002], [-18, 13, -1.999999999999999]]
   ]
   t.notThrows(() => geom3.validate(rotated))
+  t.is(measureVolume(rotated), measureVolume(geometry))
   t.true(comparePolygonsAsPoints(obs, exp))
 
   rotated = rotateY(-TAU / 4, geometry)
   obs = geom3.toPoints(rotated)
+  t.notThrows(() => geom3.validate(rotated))
+  t.is(measureVolume(rotated), measureVolume(geometry))
   t.true(comparePolygonsAsPoints(obs, exp))
 
   // rotate about Z
@@ -129,11 +134,13 @@ test('rotate: rotating of a geom3 produces expected changes to polygons', (t) =>
       [-8.000000000000002, -12.999999999999998, 18], [1.9999999999999984, -13, 18]]
   ]
   t.notThrows(() => geom3.validate(rotated))
+  t.is(measureVolume(rotated), measureVolume(geometry))
   t.true(comparePolygonsAsPoints(obs, exp))
 
   rotated = rotateZ(TAU / 2, geometry)
   obs = geom3.toPoints(rotated)
   t.notThrows(() => geom3.validate(rotated))
+  t.is(measureVolume(rotated), measureVolume(geometry))
   t.true(comparePolygonsAsPoints(obs, exp))
 })
 

--- a/packages/modeling/src/operations/transforms/rotate.test.js
+++ b/packages/modeling/src/operations/transforms/rotate.test.js
@@ -4,6 +4,8 @@ import { TAU } from '../../maths/constants.js'
 
 import { geom2, geom3, path2 } from '../../geometries/index.js'
 
+import { measureArea } from '../../measurements/index.js'
+
 import { rotate, rotateX, rotateY, rotateZ } from './index.js'
 
 import { comparePoints, comparePolygonsAsPoints } from '../../../test/helpers/index.js'
@@ -39,11 +41,13 @@ test('rotate: rotating of a geom2 produces expected changes to points', (t) => {
     new Float32Array([1, 0])
   ]
   t.notThrows(() => geom2.validate(rotated))
+  t.is(measureArea(rotated), measureArea(geometry))
   t.true(comparePoints(obs, exp))
 
   rotated = rotateZ(-TAU / 4, geometry)
   obs = geom2.toPoints(rotated)
   t.notThrows(() => geom2.validate(rotated))
+  t.is(measureArea(rotated), measureArea(geometry))
   t.true(comparePoints(obs, exp))
 })
 

--- a/packages/modeling/src/operations/transforms/scale.test.js
+++ b/packages/modeling/src/operations/transforms/scale.test.js
@@ -4,6 +4,8 @@ import { comparePoints, comparePolygonsAsPoints } from '../../../test/helpers/in
 
 import { geom2, geom3, path2 } from '../../geometries/index.js'
 
+import { measureArea } from '../../measurements/index.js'
+
 import { scale, scaleX, scaleY, scaleZ } from './index.js'
 
 test('scale: scaling of a path2 produces expected changes to points', (t) => {
@@ -42,11 +44,13 @@ test('scale: scaling of a geom2 produces expected changes to points', (t) => {
   let obs = geom2.toPoints(scaled)
   let exp = [[-3, 0], [3, 0], [0, 1]]
   t.notThrows(() => geom2.validate(scaled))
+  t.is(measureArea(scaled), 3 * measureArea(geometry))
   t.true(comparePoints(obs, exp))
 
   scaled = scaleX(3, geometry)
   obs = geom2.toPoints(scaled)
   t.notThrows(() => geom2.validate(scaled))
+  t.is(measureArea(scaled), 3 * measureArea(geometry))
   t.true(comparePoints(obs, exp))
 
   // scale Y
@@ -54,11 +58,13 @@ test('scale: scaling of a geom2 produces expected changes to points', (t) => {
   obs = geom2.toPoints(scaled)
   exp = [[-1, 0], [1, 0], [0, 3]]
   t.notThrows(() => geom2.validate(scaled))
+  t.is(measureArea(scaled), 3 * measureArea(geometry))
   t.true(comparePoints(obs, exp))
 
   scaled = scaleY(3, geometry)
   obs = geom2.toPoints(scaled)
   t.notThrows(() => geom2.validate(scaled))
+  t.is(measureArea(scaled), 3 * measureArea(geometry))
   t.true(comparePoints(obs, exp))
 })
 

--- a/packages/modeling/src/operations/transforms/scale.test.js
+++ b/packages/modeling/src/operations/transforms/scale.test.js
@@ -4,7 +4,7 @@ import { comparePoints, comparePolygonsAsPoints } from '../../../test/helpers/in
 
 import { geom2, geom3, path2 } from '../../geometries/index.js'
 
-import { measureArea } from '../../measurements/index.js'
+import { measureArea, measureVolume } from '../../measurements/index.js'
 
 import { scale, scaleX, scaleY, scaleZ } from './index.js'
 

--- a/packages/modeling/src/operations/transforms/translate.test.js
+++ b/packages/modeling/src/operations/transforms/translate.test.js
@@ -4,6 +4,8 @@ import { comparePoints, comparePolygonsAsPoints } from '../../../test/helpers/in
 
 import { geom2, geom3, path2 } from '../../geometries/index.js'
 
+import { measureArea } from '../../measurements/index.js'
+
 import { translate, translateX, translateY, translateZ } from './index.js'
 
 test('translate: translating of a path2 produces expected changes to points', (t) => {
@@ -42,11 +44,13 @@ test('translate: translating of a geom2 produces expected changes to points', (t
   let obs = geom2.toPoints(translated)
   let exp = [[1, 0], [2, 0], [1, 1]]
   t.notThrows(() => geom2.validate(translated))
+  t.is(measureArea(translated), measureArea(geometry))
   t.true(comparePoints(obs, exp))
 
   translated = translateX(1, geometry)
   obs = geom2.toPoints(translated)
   t.notThrows(() => geom2.validate(translated))
+  t.is(measureArea(translated), measureArea(geometry))
   t.true(comparePoints(obs, exp))
 
   // translate Y
@@ -54,11 +58,13 @@ test('translate: translating of a geom2 produces expected changes to points', (t
   obs = geom2.toPoints(translated)
   exp = [[0, 1], [1, 1], [0, 2]]
   t.notThrows(() => geom2.validate(translated))
+  t.is(measureArea(translated), measureArea(geometry))
   t.true(comparePoints(obs, exp))
 
   translated = translateY(1, geometry)
   obs = geom2.toPoints(translated)
   t.notThrows(() => geom2.validate(translated))
+  t.is(measureArea(translated), measureArea(geometry))
   t.true(comparePoints(obs, exp))
 })
 

--- a/packages/modeling/src/operations/transforms/translate.test.js
+++ b/packages/modeling/src/operations/transforms/translate.test.js
@@ -4,7 +4,7 @@ import { comparePoints, comparePolygonsAsPoints } from '../../../test/helpers/in
 
 import { geom2, geom3, path2 } from '../../geometries/index.js'
 
-import { measureArea } from '../../measurements/index.js'
+import { measureArea, measureVolume } from '../../measurements/index.js'
 
 import { translate, translateX, translateY, translateZ } from './index.js'
 
@@ -91,11 +91,13 @@ test('translate: translating of a geom3 produces expected changes to polygons', 
     [[1, -7, 18], [11, -7, 18], [11, 13, 18], [1, 13, 18]]
   ]
   t.notThrows(() => geom3.validate(translated))
+  t.is(measureVolume(translated), measureVolume(geometry))
   t.true(comparePolygonsAsPoints(obs, exp))
 
   translated = translateX(3, geometry)
   obs = geom3.toPoints(translated)
   t.notThrows(() => geom3.validate(translated))
+  t.is(measureVolume(translated), measureVolume(geometry))
   t.true(comparePolygonsAsPoints(obs, exp))
 
   // translated Y
@@ -110,11 +112,13 @@ test('translate: translating of a geom3 produces expected changes to polygons', 
     [[-2, -4, 18], [8, -4, 18], [8, 16, 18], [-2, 16, 18]]
   ]
   t.notThrows(() => geom3.validate(translated))
+  t.is(measureVolume(translated), measureVolume(geometry))
   t.true(comparePolygonsAsPoints(obs, exp))
 
   translated = translateY(3, geometry)
   obs = geom3.toPoints(translated)
   t.notThrows(() => geom3.validate(translated))
+  t.is(measureVolume(translated), measureVolume(geometry))
   t.true(comparePolygonsAsPoints(obs, exp))
 
   // translate Z
@@ -129,11 +133,13 @@ test('translate: translating of a geom3 produces expected changes to polygons', 
     [[-2, -7, 21], [8, -7, 21], [8, 13, 21], [-2, 13, 21]]
   ]
   t.notThrows(() => geom3.validate(translated))
+  t.is(measureVolume(translated), measureVolume(geometry))
   t.true(comparePolygonsAsPoints(obs, exp))
 
   translated = translateZ(3, geometry)
   obs = geom3.toPoints(translated)
   t.notThrows(() => geom3.validate(translated))
+  t.is(measureVolume(translated), measureVolume(geometry))
   t.true(comparePolygonsAsPoints(obs, exp))
 })
 


### PR DESCRIPTION
Suppose you're a developer for JSCAD. And you are making changes to the modeling library, and they are good changes. But as a result of changes, the order of points change, without actually changing the shape of the geometry. But the JSCAD test suite makes assumptions about point order. So you have to then update a bunch of tests with new point data to match.

This is all fine. But wouldn't it be nice to test against properties of the geometries that do not depend on point order? So you can be more confident that we aren't breaking the geometries. If you see points change, it's not necessarily a problem. If the volume changes, something is definitely wrong.

So this PR adds `measureArea` and `measureVolume` assertions to the existing tests on all operations. [V3]


### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
