### PR TITLE
feat(cli): reworked logic to use new io package exports and functions

### DIFF
--- a/packages/cli/cli.conversions.test.js
+++ b/packages/cli/cli.conversions.test.js
@@ -1,8 +1,10 @@
-const test = require('ava')
+import fs from 'fs'
+import path from 'path'
+import { cwd } from 'process'
 
-const path = require('path')
-const { execSync } = require('child_process')
-const fs = require('fs')
+import test from 'ava'
+
+import { execSync } from 'child_process'
 
 test.afterEach.always((t) => {
   // remove files
@@ -26,7 +28,7 @@ test.afterEach.always((t) => {
 test.beforeEach((t) => {
   const cliName = './cli.js'
   t.context = {
-    cliPath: path.resolve(__dirname, cliName)
+    cliPath: path.resolve(cwd(), cliName)
   }
 })
 
@@ -38,16 +40,16 @@ test.beforeEach((t) => {
 // the script should produce ALL geometry types
 const createJscad = (id) => {
   const jscadScript = `// test script ${id}
-const { flatten } = require('@jscad/array-utils')
-const { primitives } = require('@jscad/modeling')
+import { flatten } from '@jscad/array-utils'
+import { primitives } from '@jscad/modeling'
 
-const getParameterDefinitions = () => {
+export const getParameterDefinitions = () => {
   return flatten([
     { name: 'segments', caption: 'Segements:', type: 'int', initial: 10, min: 5, max: 20, step: 1 }
   ])
 }
 
-const main = (params) => {
+export const main = (params) => {
   // parameters
   let segments = params.segments || 16
 
@@ -58,12 +60,10 @@ const main = (params) => {
 
   return [apath2, ageom2, ageom3]
 }
-
-module.exports = { main, getParameterDefinitions }
 `
 
-  const fileName = `./test${id}.jscad`
-  const filePath = path.resolve(__dirname, fileName)
+  const fileName = `./base${id}.js`
+  const filePath = path.resolve(cwd(), fileName)
   fs.writeFileSync(filePath, jscadScript)
   return filePath
 }
@@ -78,20 +78,20 @@ test('cli (conversions STL)', (t) => {
   t.context.file1Path = file1Path
 
   const file2Name = `./test${testID}.stl`
-  const file2Path = path.resolve(__dirname, file2Name)
+  const file2Path = path.resolve(cwd(), file2Name)
   t.false(fs.existsSync(file2Path))
 
   t.context.file2Path = file2Path
 
   const cliPath = t.context.cliPath
 
-  let cmd = `node ${cliPath} ${file1Path}`
+  let cmd = `node ${cliPath} ${file1Path} -o ${file2Path}`
   execSync(cmd, { stdio: [0, 1, 2] })
   t.true(fs.existsSync(file2Path))
 
   // convert from STL to JSCAD script
   const file3Name = `./test${testID}.js`
-  const file3Path = path.resolve(__dirname, file3Name)
+  const file3Path = path.resolve(cwd(), file3Name)
   t.false(fs.existsSync(file3Path))
 
   t.context.file3Path = file3Path
@@ -111,53 +111,20 @@ test('cli (conversions DXF)', (t) => {
   t.context.file1Path = file1Path
 
   const file2Name = `./test${testID}.dxf`
-  const file2Path = path.resolve(__dirname, file2Name)
+  const file2Path = path.resolve(cwd(), file2Name)
   t.false(fs.existsSync(file2Path))
 
   t.context.file2Path = file2Path
 
   const cliPath = t.context.cliPath
 
-  let cmd = `node ${cliPath} ${file1Path} -of dxf`
+  let cmd = `node ${cliPath} ${file1Path} -o ${file2Path}`
   execSync(cmd, { stdio: [0, 1, 2] })
   t.true(fs.existsSync(file2Path))
 
   // convert from DXF to JS
   const file3Name = `./test${testID}.js`
-  const file3Path = path.resolve(__dirname, file3Name)
-  t.false(fs.existsSync(file3Path))
-
-  t.context.file3Path = file3Path
-
-  cmd = `node ${cliPath} ${file2Path} -of js`
-  execSync(cmd, { stdio: [0, 1, 2] })
-  t.true(fs.existsSync(file3Path))
-})
-
-test('cli (conversions AMF)', (t) => {
-  const testID = 13
-
-  // convert from JSCAD to AMF
-  const file1Path = createJscad(testID)
-  t.true(fs.existsSync(file1Path))
-
-  t.context.file1Path = file1Path
-
-  const file2Name = `./test${testID}.amf`
-  const file2Path = path.resolve(__dirname, file2Name)
-  t.false(fs.existsSync(file2Path))
-
-  t.context.file2Path = file2Path
-
-  const cliPath = t.context.cliPath
-
-  let cmd = `node ${cliPath} ${file1Path} -of amf`
-  execSync(cmd, { stdio: [0, 1, 2] })
-  t.true(fs.existsSync(file2Path))
-
-  // convert from AMF to JS
-  const file3Name = `./test${testID}.js`
-  const file3Path = path.resolve(__dirname, file3Name)
+  const file3Path = path.resolve(cwd(), file3Name)
   t.false(fs.existsSync(file3Path))
 
   t.context.file3Path = file3Path
@@ -177,20 +144,20 @@ test('cli (conversions JSON)', (t) => {
   t.context.file1Path = file1Path
 
   const file2Name = `./test${testID}.json`
-  const file2Path = path.resolve(__dirname, file2Name)
+  const file2Path = path.resolve(cwd(), file2Name)
   t.false(fs.existsSync(file2Path))
 
   t.context.file2Path = file2Path
 
   const cliPath = t.context.cliPath
 
-  let cmd = `node ${cliPath} ${file1Path} -of json`
+  let cmd = `node ${cliPath} ${file1Path} -o ${file2Path}`
   execSync(cmd, { stdio: [0, 1, 2] })
   t.true(fs.existsSync(file2Path))
 
   // convert from JSON to JS
   const file3Name = `./test${testID}.js`
-  const file3Path = path.resolve(__dirname, file3Name)
+  const file3Path = path.resolve(cwd(), file3Name)
   t.false(fs.existsSync(file3Path))
 
   t.context.file3Path = file3Path
@@ -210,20 +177,20 @@ test('cli (conversions SVG)', (t) => {
   t.context.file1Path = file1Path
 
   const file2Name = `./test${testID}.svg`
-  const file2Path = path.resolve(__dirname, file2Name)
+  const file2Path = path.resolve(cwd(), file2Name)
   t.false(fs.existsSync(file2Path))
 
   t.context.file2Path = file2Path
 
   const cliPath = t.context.cliPath
 
-  let cmd = `node ${cliPath} ${file1Path} -of svg`
+  let cmd = `node ${cliPath} ${file1Path} -o ${file2Path}`
   execSync(cmd, { stdio: [0, 1, 2] })
   t.true(fs.existsSync(file2Path))
 
   // convert from SVG to JS
   const file3Name = `./test${testID}.js`
-  const file3Path = path.resolve(__dirname, file3Name)
+  const file3Path = path.resolve(cwd(), file3Name)
   t.false(fs.existsSync(file3Path))
 
   t.context.file3Path = file3Path
@@ -243,20 +210,20 @@ test('cli (conversions X3D)', (t) => {
   t.context.file1Path = file1Path
 
   const file2Name = `./test${testID}.x3d`
-  const file2Path = path.resolve(__dirname, file2Name)
+  const file2Path = path.resolve(cwd(), file2Name)
   t.false(fs.existsSync(file2Path))
 
   t.context.file2Path = file2Path
 
   const cliPath = t.context.cliPath
 
-  let cmd = `node ${cliPath} ${file1Path} -of x3d`
+  let cmd = `node ${cliPath} ${file1Path} -o ${file2Path}`
   execSync(cmd, { stdio: [0, 1, 2] })
   t.true(fs.existsSync(file2Path))
 
   // convert from X3D to JS
   const file3Name = `./test${testID}.js`
-  const file3Path = path.resolve(__dirname, file3Name)
+  const file3Path = path.resolve(cwd(), file3Name)
   t.false(fs.existsSync(file3Path))
 
   t.context.file3Path = file3Path

--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -3,29 +3,27 @@
 
 // NOTE: this will only run on Node > 6 or needs to be transpiled
 
-// == OpenJSCAD.org CLI interface, written by Rene K. Mueller <spiritdude@gmail.com>, Licensed under MIT License
+// == JSCAD CLI interface, written by Rene K. Mueller <spiritdude@gmail.com>, Licensed under MIT License
 //
 // Description:
-//   openjscad <file> [-of <format>] [-o <output>]
+//   jscad <file> [-of <format>] [-o <output>]
 // e.g.
-//   openjscad test.jscad
-//   openjscad test.jscad -o test.stl
-//   openjscad test.jscad -o test.amf
-//   openjscad test.jscad -o test.dxf
-//   openjscad test.scad -o testFromSCAD.jscad
-//   openjscad test.scad -o test.stl
-//   openjscad test.stl -o test2.stl      # reprocessed: stl -> jscad -> stl
-//   openjscad test.amf -o test2.jscad
-//   openjscad test.jscad -of amf
-//   openjscad test.jscad -of dxf
-//   openjscad test.jscad -of stl
-//   openjscad name_plate.jscad --name "Just Me" --title "CEO" -o amf test.amf
+//   jscad test.jscad
+//   jscad test.jscad -o test.stl
+//   jscad test.jscad -o test.amf
+//   jscad test.jscad -o test.dxf
+//   jscad test.scad -o testFromSCAD.jscad
+//   jscad test.scad -o test.stl
+//   jscad test.stl -o test2.stl      # reprocessed: stl -> jscad -> stl
+//   jscad test.amf -o test2.jscad
+//   jscad test.jscad -of amf
+//   jscad test.jscad -of dxf
+//   jscad test.jscad -of stl
+//   jscad name_plate.jscad --name "Just Me" --title "CEO" -o amf test.amf
 //
 import fs from 'fs'
 
-import { formats } from '@jscad/io'
-
-const { supportedFormats } = formats
+import { supportedFormats } from '@jscad/io'
 
 import generateOutputData from './src/generateOutputData.js'
 import determineOutputNameAndFormat from './src/determineOutputNameAndFormat.js'

--- a/packages/cli/cli.parameters.test.js
+++ b/packages/cli/cli.parameters.test.js
@@ -1,8 +1,9 @@
-const test = require('ava')
+import fs from 'fs'
+import path from 'path'
+import { execSync } from 'child_process'
+import { cwd } from 'process'
 
-const path = require('path')
-const { execSync } = require('child_process')
-const fs = require('fs')
+import test from 'ava'
 
 test.afterEach.always((t) => {
   // remove files
@@ -22,7 +23,7 @@ test.afterEach.always((t) => {
 test.beforeEach((t) => {
   const cliName = './cli.js'
   t.context = {
-    cliPath: path.resolve(__dirname, cliName)
+    cliPath: path.resolve(cwd(), cliName)
   }
 })
 
@@ -34,15 +35,15 @@ test.beforeEach((t) => {
 // the script should produce ALL geometry types
 const createJscad = (id) => {
   const jscadScript = `// test script ${id}
-const { primitives } = require('@jscad/modeling')
+import { primitives } from '@jscad/modeling'
 
-const getParameterDefinitions = () => {
+export const getParameterDefinitions = () => {
   return [
     { name: 'segments', caption: 'Segements:', type: 'int', initial: 10, min: 5, max: 20, step: 1 }
   ]
 }
 
-const main = (params) => {
+export const main = (params) => {
   // parameters
   let segments = params.segments || 16
 
@@ -53,12 +54,10 @@ const main = (params) => {
 
   return [apath2, ageom2, ageom3]
 }
-
-module.exports = { main, getParameterDefinitions }
 `
 
-  const fileName = `./test${id}.jscad`
-  const filePath = path.resolve(__dirname, fileName)
+  const fileName = `./test${id}.js`
+  const filePath = path.resolve(cwd(), fileName)
   fs.writeFileSync(filePath, jscadScript)
   return filePath
 }
@@ -72,7 +71,7 @@ test('cli (single input file)', (t) => {
   t.context.inputPath = inputPath
 
   const outputName = `./test${testID}.stl`
-  const outputPath = path.resolve(__dirname, outputName)
+  const outputPath = path.resolve(cwd(), outputName)
   t.false(fs.existsSync(outputPath))
 
   t.context.outputPath = outputPath
@@ -93,7 +92,7 @@ test('cli (single input file, output format)', (t) => {
   t.context.inputPath = inputPath
 
   const outputName = `./test${testID}.dxf`
-  const outputPath = path.resolve(__dirname, outputName)
+  const outputPath = path.resolve(cwd(), outputName)
   t.false(fs.existsSync(outputPath))
 
   t.context.outputPath = outputPath
@@ -113,8 +112,8 @@ test('cli (single input file, output filename)', (t) => {
 
   t.context.inputPath = inputPath
 
-  const outputName = `./test${testID}.amf`
-  const outputPath = path.resolve(__dirname, outputName)
+  const outputName = `./test${testID}.obj`
+  const outputPath = path.resolve(cwd(), outputName)
   t.false(fs.existsSync(outputPath))
 
   t.context.outputPath = outputPath
@@ -134,7 +133,7 @@ test('cli (folder, output format)', (t) => {
 
   t.context.inputPath = inputPath
 
-  const folderPath = path.resolve(__dirname, './test-folder')
+  const folderPath = path.resolve(cwd(), './test-folder')
   t.false(fs.existsSync(folderPath))
 
   fs.mkdirSync(folderPath)
@@ -142,14 +141,14 @@ test('cli (folder, output format)', (t) => {
 
   t.context.folderPath = folderPath
 
-  const mainPath = path.resolve(__dirname, './test-folder/main.js')
+  const mainPath = path.resolve(cwd(), './test-folder/main.js')
   fs.renameSync(inputPath, mainPath)
   t.true(fs.existsSync(mainPath))
 
   t.context.inputPath = mainPath
 
   const outputName = './test-folder/main.dxf'
-  const outputPath = path.resolve(__dirname, outputName)
+  const outputPath = path.resolve(cwd(), outputName)
   t.false(fs.existsSync(outputPath))
 
   t.context.outputPath = outputPath
@@ -170,7 +169,7 @@ test('cli (single input file, parameters)', (t) => {
   t.context.inputPath = inputPath
 
   const outputName = `./test${testID}.stl`
-  const outputPath = path.resolve(__dirname, outputName)
+  const outputPath = path.resolve(cwd(), outputName)
   t.false(fs.existsSync(outputPath))
 
   t.context.outputPath = outputPath
@@ -182,7 +181,7 @@ test('cli (single input file, parameters)', (t) => {
   t.true(fs.existsSync(outputPath))
 })
 
-test('cli (no parameters)', (t) => {
+test('cli (no parameters, out help)', (t) => {
   const cliPath = t.context.cliPath
 
   const cmd = `node ${cliPath}`

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,6 +39,7 @@
     "@jscad/array-utils": "workspace:2.1.4",
     "@jscad/core": "workspace:2.6.4",
     "@jscad/io": "workspace:2.4.3",
+    "@jscad/io-utils": "^2.0.23",
     "@jscad/modeling": "workspace:2.10.0"
   },
   "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,7 +39,7 @@
     "@jscad/array-utils": "workspace:2.1.4",
     "@jscad/core": "workspace:2.6.4",
     "@jscad/io": "workspace:2.4.3",
-    "@jscad/io-utils": "^2.0.23",
+    "@jscad/io-utils": "workspace:2.0.22",
     "@jscad/modeling": "workspace:2.10.0"
   },
   "devDependencies": {

--- a/packages/cli/src/determineOutputNameAndFormat.js
+++ b/packages/cli/src/determineOutputNameAndFormat.js
@@ -1,6 +1,4 @@
-import { formats } from '@jscad/io'
-
-const { supportedOutputExtensions, supportedOutputFormats } = formats
+import { supportedOutputExtensions, supportedOutputFormats } from '@jscad/io'
 
 export const determineOutputNameAndFormat = (outputFormat, outputFile, inputFile) => {
   const extReg = new RegExp(`\\.(${supportedOutputExtensions().join('|')})$`)

--- a/packages/cli/src/env.js
+++ b/packages/cli/src/env.js
@@ -1,7 +1,7 @@
 const version = '[VI]{version}[/VI]' // version is injected by rollup
 
 export const env = () => {
-  let env = 'OpenJSCAD ' + version
+  let env = 'JSCAD ' + version
   if (typeof document !== 'undefined') {
     const w = document.defaultView
     env = env + ' [' + w.navigator.userAgent + ']'

--- a/packages/cli/src/generateOutputData.js
+++ b/packages/cli/src/generateOutputData.js
@@ -53,8 +53,6 @@ export const generateOutputData = (source, cliparams, options) => {
       resolve(source)
     } else {
       try {
-        // FIXME useFakeFs = true
-console.log("useFakeFs",useFakeFs)
         const solids = rebuildGeometryCli({ mainPath: inputPath, parameterValues: cliparams, useFakeFs, source })
         resolve(solids)
       } catch (error) {

--- a/packages/cli/src/generateOutputData.js
+++ b/packages/cli/src/generateOutputData.js
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import path from 'path'
-import { createRequire } from "module"
+import { createRequire } from 'module'
 
 import { deserialize, getMimeType, serialize } from '@jscad/io'
 import { convertToBlob } from '@jscad/io-utils'
@@ -9,8 +9,6 @@ import { evaluation, io } from '@jscad/core'
 
 const { rebuildGeometryCli } = evaluation
 const { registerAllExtensions } = io
-
-const solidsAsBlob = (solids, params) => convertToBlob(prepareOutput(solids, params))
 
 /**
  * Create a promise to convert the given source in inputFormat to the desired outputFormat.
@@ -35,10 +33,7 @@ export const generateOutputData = (source, cliparams, options) => {
 
   // setup support for require-ing files with .jscad, .stl etc extensions
   // HACK create the require function if necessary
-  if (typeof self === 'undefined') {
-    // create require via Node API
-    var require = createRequire(import.meta.url)
-  }
+  const require = createRequire(import.meta.url)
   registerAllExtensions(fs, require)
 
   return new Promise((resolve, reject) => {
@@ -46,7 +41,7 @@ export const generateOutputData = (source, cliparams, options) => {
     const prevsource = source
     const deserializerOptions = Object.assign({ output: 'script', filename: inputFile }, cliparams)
     source = deserialize(deserializerOptions, inputMimeType, source)
-    let useFakeFs = (source !== prevsource) // conversion, so use a fake file system when rebuilding
+    const useFakeFs = (source !== prevsource) // conversion, so use a fake file system when rebuilding
 
     if (outputMimeType === 'application/javascript') {
       // pass back the source

--- a/packages/cli/src/parseArgs.js
+++ b/packages/cli/src/parseArgs.js
@@ -4,8 +4,7 @@ import path from 'path'
 import { loading } from '@jscad/core'
 const { getDesignEntryPoint } = loading
 
-import { formats } from '@jscad/io'
-const { supportedInputExtensions, supportedOutputExtensions, supportedOutputFormats } = formats
+import { supportedInputExtensions, supportedOutputExtensions, supportedOutputFormats } from '@jscad/io'
 
 import env from './env.js'
 
@@ -17,7 +16,7 @@ export const parseArgs = (args) => {
   // hint: https://github.com/substack/node-optimist
   //       https://github.com/visionmedia/commander.js
   if (args.length < 1) {
-    console.log('USAGE:\n\nopenjscad [-v] <file> [-of <format>] [-o <output>]')
+    console.log('USAGE:\n\njscad [-v] <file> [-of <format>] [-o <output>]')
     console.log(`\t<file>  :\tinput (Supported types: folder, .${inputExtensions.join(', .')})`)
     console.log(`\t<output>:\toutput (Supported types: folder, .${outputExtensions.join(', .')})`)
     console.log(`\t<format>:\t${outputFormats.join(', ')}`)
@@ -79,7 +78,7 @@ export const parseArgs = (args) => {
         inputFormat = path.extname(inputFile).substring(1)
       } else {
         console.log('ERROR: invalid file name or argument <' + args[i] + '>')
-        console.log("Type 'openjscad' for a list of supported types")
+        console.log("Type 'jscad' for a list of supported types")
         process.exit(1)
       }
     }
@@ -89,6 +88,11 @@ export const parseArgs = (args) => {
 
   if (!outputFormat && !outputFile) {
     outputFormat = 'stla'
+  }
+  if (!outputFormats.includes(outputFormat)) {
+    console.log('ERROR: invalid output format <' + outputFormat + '>')
+    console.log("Type 'jscad' for a list of supported types")
+    process.exit(1)
   }
 
   return {

--- a/packages/cli/src/parseArgs.js
+++ b/packages/cli/src/parseArgs.js
@@ -89,6 +89,10 @@ export const parseArgs = (args) => {
   if (!outputFormat && !outputFile) {
     outputFormat = 'stla'
   }
+  if (!outputFormat && outputFile) {
+    outputFormat = path.extname(outputFile).substring(1)
+    if (outputFormat === "stl") outputFormat = 'stla'
+  }
   if (!outputFormats.includes(outputFormat)) {
     console.log('ERROR: invalid output format <' + outputFormat + '>')
     console.log("Type 'jscad' for a list of supported types")

--- a/packages/cli/src/parseArgs.js
+++ b/packages/cli/src/parseArgs.js
@@ -2,11 +2,12 @@ import fs from 'fs'
 import path from 'path'
 
 import { loading } from '@jscad/core'
-const { getDesignEntryPoint } = loading
 
 import { supportedInputExtensions, supportedOutputExtensions, supportedOutputFormats } from '@jscad/io'
 
 import env from './env.js'
+
+const { getDesignEntryPoint } = loading
 
 export const parseArgs = (args) => {
   const inputExtensions = supportedInputExtensions()
@@ -91,7 +92,7 @@ export const parseArgs = (args) => {
   }
   if (!outputFormat && outputFile) {
     outputFormat = path.extname(outputFile).substring(1)
-    if (outputFormat === "stl") outputFormat = 'stla'
+    if (outputFormat === 'stl') outputFormat = 'stla'
   }
   if (!outputFormats.includes(outputFormat)) {
     console.log('ERROR: invalid output format <' + outputFormat + '>')

--- a/packages/core/src/code-evaluation/rebuildGeometryCli.js
+++ b/packages/core/src/code-evaluation/rebuildGeometryCli.js
@@ -7,7 +7,7 @@ import requireDesignFromModule from '../code-loading/requireDesignFromModule.js'
 import getAllParameterDefintionsAndValues from '../parameters/getParameterDefinitionsAndValues.js'
 import makeWebRequire from '../code-loading/webRequire.js'
 
-export const rebuildGeometryCli = (data) => {
+export const rebuildGeometryCli = async (data) => {
   const defaults = {
     apiMainPath: '@jscad/modeling'
   }
@@ -34,7 +34,10 @@ export const rebuildGeometryCli = (data) => {
   }
 
   // rootModule should contain exported main and getParameterDefinitions functions
-  const rootModule = requireDesignFromModule(mainPath, requireFn)
+  // const rootModule = requireDesignFromModule(mainPath, requireFn)
+  // FIXME HACK for designs with import / export
+  const rootModule = await import(mainPath)
+
   // the design (module tree) has been loaded at this stage
   // now we can get our usefull data (definitions and values/defaults)
   const parameters = getAllParameterDefintionsAndValues(rootModule, parameterValues)

--- a/packages/core/src/web/walkFileTree.js
+++ b/packages/core/src/web/walkFileTree.js
@@ -2,7 +2,7 @@ import path from 'path'
 
 import { flatten } from '@jscad/array-utils'
 
-import { formats } from '@jscad/io'
+import { supportedFormats } from '@jscad/io'
 
 import getFileExtensionFromString from '../utils/getFileExtensionFromString.js'
 
@@ -66,7 +66,7 @@ const readFileAsync = (file, fileMeta) => {
 // all known formats are supported
 const isSupportedFormat = (file) => {
   const ext = getFileExtensionFromString(file.name)
-  const mimetype = formats[ext] ? formats[ext].mimetype : binaryMimetypes[ext]
+  const mimetype = supportedFormats[ext] ? supportedFormats[ext].mimetype : binaryMimetypes[ext]
   file.mimetype = file.type && file.type.length ? file.type : mimetype
   return file.mimetype && file.mimetype.length
 }

--- a/packages/io/io/src/formats.js
+++ b/packages/io/io/src/formats.js
@@ -165,6 +165,7 @@ const getMimeType = (extension) => {
   for (const format in supportedFormats) {
     const meta = supportedFormats[format]
     if (meta.extension === extension) return meta.mimetype
+    if (format === extension) return meta.mimetype
   }
   return null
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,7 @@ importers:
       '@jscad/array-utils': workspace:2.1.4
       '@jscad/core': workspace:2.6.4
       '@jscad/io': workspace:2.4.3
+      '@jscad/io-utils': workspace:2.0.22
       '@jscad/modeling': workspace:2.10.0
       ava: 4.3.3
       nyc: 15.1.0
@@ -38,6 +39,7 @@ importers:
       '@jscad/array-utils': link:../utils/array-utils
       '@jscad/core': link:../core
       '@jscad/io': link:../io/io
+      '@jscad/io-utils': link:../io/io-utils
       '@jscad/modeling': link:../modeling
     devDependencies:
       ava: 4.3.3
@@ -74,19 +76,27 @@ importers:
   packages/io/3mf-serializer:
     specifiers:
       '@jscad/array-utils': workspace:2.1.4
+      '@jscad/io-utils': workspace:^2.0.22
       '@jscad/modeling': workspace:2.10.0
+      '@rollup/plugin-commonjs': ^23.0.4
+      '@rollup/plugin-node-resolve': ^15.0.1
       ava: 4.3.3
       fflate: 0.7.3
       nyc: 15.1.0
-      onml: 2.1.0
+      rollup: 2.79.1
+      rollup-plugin-banner: ^0.2.1
     dependencies:
       '@jscad/array-utils': link:../../utils/array-utils
+      '@jscad/io-utils': link:../io-utils
       '@jscad/modeling': link:../../modeling
       fflate: 0.7.3
-      onml: 2.1.0
     devDependencies:
+      '@rollup/plugin-commonjs': 23.0.7_rollup@2.79.1
+      '@rollup/plugin-node-resolve': 15.0.1_rollup@2.79.1
       ava: 4.3.3
       nyc: 15.1.0
+      rollup: 2.79.1
+      rollup-plugin-banner: 0.2.1
 
   packages/io/amf-deserializer:
     specifiers:
@@ -104,14 +114,14 @@ importers:
   packages/io/amf-serializer:
     specifiers:
       '@jscad/array-utils': workspace:2.1.4
+      '@jscad/io-utils': workspace:^2.0.22
       '@jscad/modeling': workspace:2.10.0
       ava: 4.3.3
       nyc: 15.1.0
-      onml: 2.1.0
     dependencies:
       '@jscad/array-utils': link:../../utils/array-utils
+      '@jscad/io-utils': link:../io-utils
       '@jscad/modeling': link:../../modeling
-      onml: 2.1.0
     devDependencies:
       ava: 4.3.3
       nyc: 15.1.0
@@ -121,30 +131,40 @@ importers:
       '@jscad/modeling': workspace:2.10.0
       ava: 4.3.3
       nyc: 15.1.0
+      rollup: 2.79.1
+      rollup-plugin-banner: ^0.2.1
+      rollup-plugin-version-injector: ^1.3.3
     dependencies:
       '@jscad/modeling': link:../../modeling
     devDependencies:
       ava: 4.3.3
       nyc: 15.1.0
+      rollup: 2.79.1
+      rollup-plugin-banner: 0.2.1
+      rollup-plugin-version-injector: 1.3.3
 
   packages/io/dxf-serializer:
     specifiers:
       '@jscad/array-utils': workspace:2.1.4
       '@jscad/modeling': workspace:2.10.0
+      '@rollup/plugin-node-resolve': 15.0.1
       ava: 4.3.3
       nyc: 15.1.0
+      rollup: 2.79.1
+      rollup-plugin-banner: 0.2.1
     dependencies:
       '@jscad/array-utils': link:../../utils/array-utils
       '@jscad/modeling': link:../../modeling
     devDependencies:
+      '@rollup/plugin-node-resolve': 15.0.1_rollup@2.79.1
       ava: 4.3.3
       nyc: 15.1.0
+      rollup: 2.79.1
+      rollup-plugin-banner: 0.2.1
 
   packages/io/io:
     specifiers:
       '@jscad/3mf-serializer': workspace:2.1.6
-      '@jscad/amf-deserializer': workspace:2.3.2
-      '@jscad/amf-serializer': workspace:2.1.12
       '@jscad/array-utils': workspace:2.1.4
       '@jscad/dxf-deserializer': workspace:2.3.19
       '@jscad/dxf-serializer': workspace:2.1.12
@@ -160,10 +180,10 @@ importers:
       '@jscad/svg-serializer': workspace:2.3.10
       '@jscad/x3d-deserializer': workspace:2.2.2
       '@jscad/x3d-serializer': workspace:2.4.2
+      ava: 4.3.3
+      nyc: 15.1.0
     dependencies:
       '@jscad/3mf-serializer': link:../3mf-serializer
-      '@jscad/amf-deserializer': link:../amf-deserializer
-      '@jscad/amf-serializer': link:../amf-serializer
       '@jscad/array-utils': link:../../utils/array-utils
       '@jscad/dxf-deserializer': link:../dxf-deserializer
       '@jscad/dxf-serializer': link:../dxf-serializer
@@ -179,6 +199,9 @@ importers:
       '@jscad/svg-serializer': link:../svg-serializer
       '@jscad/x3d-deserializer': link:../x3d-deserializer
       '@jscad/x3d-serializer': link:../x3d-serializer
+    devDependencies:
+      ava: 4.3.3
+      nyc: 15.1.0
 
   packages/io/io-utils:
     specifiers:
@@ -194,49 +217,71 @@ importers:
     specifiers:
       '@jscad/array-utils': workspace:2.1.4
       '@jscad/modeling': workspace:2.10.0
+      '@rollup/plugin-node-resolve': ^15.0.1
       ava: 4.3.3
       nyc: 15.1.0
+      rollup: 2.79.1
+      rollup-plugin-banner: ^0.2.1
+      rollup-plugin-version-injector: ^1.3.3
     dependencies:
       '@jscad/array-utils': link:../../utils/array-utils
     devDependencies:
       '@jscad/modeling': link:../../modeling
+      '@rollup/plugin-node-resolve': 15.0.1_rollup@2.79.1
       ava: 4.3.3
       nyc: 15.1.0
+      rollup: 2.79.1
+      rollup-plugin-banner: 0.2.1
+      rollup-plugin-version-injector: 1.3.3
 
   packages/io/json-serializer:
     specifiers:
       '@jscad/modeling': workspace:2.10.0
       ava: 4.3.3
       nyc: 15.1.0
+      rollup: 2.79.1
     dependencies:
       '@jscad/modeling': link:../../modeling
     devDependencies:
       ava: 4.3.3
       nyc: 15.1.0
+      rollup: 2.79.1
 
   packages/io/obj-deserializer:
     specifiers:
       '@jscad/modeling': workspace:2.10.0
       ava: 4.3.3
       nyc: 15.1.0
+      rollup: 2.79.1
+      rollup-plugin-banner: ^0.2.1
+      rollup-plugin-version-injector: ^1.3.3
     dependencies:
       '@jscad/modeling': link:../../modeling
     devDependencies:
       ava: 4.3.3
       nyc: 15.1.0
+      rollup: 2.79.1
+      rollup-plugin-banner: 0.2.1
+      rollup-plugin-version-injector: 1.3.3
 
   packages/io/obj-serializer:
     specifiers:
       '@jscad/array-utils': workspace:2.1.4
       '@jscad/modeling': workspace:2.10.0
+      '@rollup/plugin-node-resolve': ^15.0.1
       ava: 4.3.3
       nyc: 15.1.0
+      rollup: 2.79.1
+      rollup-plugin-banner: ^0.2.1
     dependencies:
       '@jscad/array-utils': link:../../utils/array-utils
       '@jscad/modeling': link:../../modeling
     devDependencies:
+      '@rollup/plugin-node-resolve': 15.0.1_rollup@2.79.1
       ava: 4.3.3
       nyc: 15.1.0
+      rollup: 2.79.1
+      rollup-plugin-banner: 0.2.1
 
   packages/io/stl-deserializer:
     specifiers:
@@ -244,103 +289,156 @@ importers:
       '@jscad/modeling': workspace:2.10.0
       ava: 4.3.3
       nyc: 15.1.0
+      rollup: 2.79.1
+      rollup-plugin-banner: ^0.2.1
+      rollup-plugin-version-injector: ^1.3.3
     dependencies:
       '@jscad/io-utils': link:../io-utils
       '@jscad/modeling': link:../../modeling
     devDependencies:
       ava: 4.3.3
       nyc: 15.1.0
+      rollup: 2.79.1
+      rollup-plugin-banner: 0.2.1
+      rollup-plugin-version-injector: 1.3.3
 
   packages/io/stl-serializer:
     specifiers:
       '@jscad/array-utils': workspace:2.1.4
       '@jscad/modeling': workspace:2.10.0
+      '@rollup/plugin-node-resolve': ^15.0.1
       ava: 4.3.3
       nyc: 15.1.0
+      rollup: 2.79.1
+      rollup-plugin-banner: ^0.2.1
     dependencies:
       '@jscad/array-utils': link:../../utils/array-utils
       '@jscad/modeling': link:../../modeling
     devDependencies:
+      '@rollup/plugin-node-resolve': 15.0.1_rollup@2.79.1
       ava: 4.3.3
       nyc: 15.1.0
+      rollup: 2.79.1
+      rollup-plugin-banner: 0.2.1
 
   packages/io/svg-deserializer:
     specifiers:
       '@jscad/array-utils': workspace:2.1.4
       '@jscad/modeling': workspace:2.10.0
+      '@rollup/plugin-commonjs': ^23.0.4
+      '@rollup/plugin-node-resolve': ^15.0.1
       ava: 4.3.3
       nyc: 15.1.0
+      rollup: 2.79.1
+      rollup-plugin-banner: ^0.2.1
+      rollup-plugin-version-injector: ^1.3.3
       saxes: 6.0.0
     dependencies:
       '@jscad/array-utils': link:../../utils/array-utils
       '@jscad/modeling': link:../../modeling
       saxes: 6.0.0
     devDependencies:
+      '@rollup/plugin-commonjs': 23.0.7_rollup@2.79.1
+      '@rollup/plugin-node-resolve': 15.0.1_rollup@2.79.1
       ava: 4.3.3
       nyc: 15.1.0
+      rollup: 2.79.1
+      rollup-plugin-banner: 0.2.1
+      rollup-plugin-version-injector: 1.3.3
 
   packages/io/svg-serializer:
     specifiers:
+      '@jscad/io-utils': workspace:^2.0.22
       '@jscad/modeling': workspace:2.10.0
+      '@rollup/plugin-node-resolve': ^15.0.1
       ava: 4.3.3
       nyc: 15.1.0
-      onml: 2.1.0
+      rollup: 2.79.1
+      rollup-plugin-banner: ^0.2.1
+      rollup-plugin-version-injector: ^1.3.3
     dependencies:
+      '@jscad/io-utils': link:../io-utils
       '@jscad/modeling': link:../../modeling
-      onml: 2.1.0
     devDependencies:
+      '@rollup/plugin-node-resolve': 15.0.1_rollup@2.79.1
       ava: 4.3.3
       nyc: 15.1.0
+      rollup: 2.79.1
+      rollup-plugin-banner: 0.2.1
+      rollup-plugin-version-injector: 1.3.3
+
+  packages/io/test:
+    specifiers: {}
 
   packages/io/x3d-deserializer:
     specifiers:
       '@jscad/array-utils': workspace:2.1.4
       '@jscad/modeling': workspace:2.10.0
+      '@rollup/plugin-commonjs': ^23.0.4
+      '@rollup/plugin-node-resolve': ^15.0.1
       ava: 4.3.3
       nyc: 15.1.0
+      rollup: 2.79.1
+      rollup-plugin-banner: ^0.2.1
+      rollup-plugin-version-injector: ^1.3.3
       saxes: 6.0.0
     dependencies:
       '@jscad/array-utils': link:../../utils/array-utils
       '@jscad/modeling': link:../../modeling
       saxes: 6.0.0
     devDependencies:
+      '@rollup/plugin-commonjs': 23.0.7_rollup@2.79.1
+      '@rollup/plugin-node-resolve': 15.0.1_rollup@2.79.1
       ava: 4.3.3
       nyc: 15.1.0
+      rollup: 2.79.1
+      rollup-plugin-banner: 0.2.1
+      rollup-plugin-version-injector: 1.3.3
 
   packages/io/x3d-serializer:
     specifiers:
       '@jscad/array-utils': workspace:2.1.4
+      '@jscad/io-utils': workspace:^2.0.22
       '@jscad/modeling': workspace:2.10.0
+      '@rollup/plugin-node-resolve': ^15.0.1
       ava: 4.3.3
       nyc: 15.1.0
-      onml: 2.1.0
+      rollup: 2.79.1
+      rollup-plugin-banner: ^0.2.1
     dependencies:
       '@jscad/array-utils': link:../../utils/array-utils
+      '@jscad/io-utils': link:../io-utils
       '@jscad/modeling': link:../../modeling
-      onml: 2.1.0
     devDependencies:
+      '@rollup/plugin-node-resolve': 15.0.1_rollup@2.79.1
       ava: 4.3.3
       nyc: 15.1.0
+      rollup: 2.79.1
+      rollup-plugin-banner: 0.2.1
 
   packages/modeling:
     specifiers:
       ava: 4.3.3
-      browserify: 16.5.1
       nyc: 15.1.0
-      uglifyify: 5.0.2
+      rollup: 2.79.1
+      rollup-plugin-banner: ^0.2.1
     devDependencies:
       ava: 4.3.3
-      browserify: 16.5.1
       nyc: 15.1.0
-      uglifyify: 5.0.2
+      rollup: 2.79.1
+      rollup-plugin-banner: 0.2.1
 
   packages/utils/array-utils:
     specifiers:
       ava: 4.3.3
       nyc: 15.1.0
+      rollup: 2.79.1
+      rollup-plugin-banner: 0.2.1
     devDependencies:
       ava: 4.3.3
       nyc: 15.1.0
+      rollup: 2.79.1
+      rollup-plugin-banner: 0.2.1
 
   packages/utils/img:
     specifiers:
@@ -1222,6 +1320,57 @@ packages:
       '@octokit/openapi-types': 13.13.1
     dev: true
 
+  /@rollup/plugin-commonjs/23.0.7_rollup@2.79.1:
+    resolution: {integrity: sha512-hsSD5Qzyuat/swzrExGG5l7EuIlPhwTsT7KwKbSCQzIcJWjRxiimi/0tyMYY2bByitNb3i1p+6JWEDGa0NvT0Q==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.68.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.0.2_rollup@2.79.1
+      commondir: 1.0.1
+      estree-walker: 2.0.2
+      glob: 8.0.3
+      is-reference: 1.2.1
+      magic-string: 0.27.0
+      rollup: 2.79.1
+    dev: true
+
+  /@rollup/plugin-node-resolve/15.0.1_rollup@2.79.1:
+    resolution: {integrity: sha512-ReY88T7JhJjeRVbfCyNj+NXAG3IIsVMsX9b5/9jC98dRP8/yxlZdz7mHZbHk5zHr24wZZICS5AcXsFZAXYUQEg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.78.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.0.2_rollup@2.79.1
+      '@types/resolve': 1.20.2
+      deepmerge: 4.2.2
+      is-builtin-module: 3.2.0
+      is-module: 1.0.0
+      resolve: 1.22.1
+      rollup: 2.79.1
+    dev: true
+
+  /@rollup/pluginutils/5.0.2_rollup@2.79.1:
+    resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@types/estree': 1.0.0
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+      rollup: 2.79.1
+    dev: true
+
   /@tootallnate/once/2.0.0:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
@@ -1279,6 +1428,10 @@ packages:
 
   /@types/parse-json/4.0.0:
     resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
+    dev: true
+
+  /@types/resolve/1.20.2:
+    resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
     dev: true
 
   /JSONStream/1.3.5:
@@ -2154,6 +2307,11 @@ packages:
       ieee754: 1.2.1
     dev: true
 
+  /builtin-modules/3.3.0:
+    resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
+    engines: {node: '>=6'}
+    dev: true
+
   /builtin-status-codes/3.0.0:
     resolution: {integrity: sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==}
     dev: true
@@ -2893,6 +3051,10 @@ packages:
     resolution: {integrity: sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==}
     dev: true
 
+  /dateformat/4.6.3:
+    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
+    dev: true
+
   /debounce/1.2.1:
     resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
     dev: true
@@ -2961,6 +3123,11 @@ packages:
 
   /deep-is/0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+    dev: true
+
+  /deepmerge/4.2.2:
+    resolution: {integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==}
+    engines: {node: '>=0.10.0'}
     dev: true
 
   /default-gateway/2.7.2:
@@ -3640,6 +3807,10 @@ packages:
   /estree-is-member-expression/1.0.0:
     resolution: {integrity: sha512-Ec+X44CapIGExvSZN+pGkmr5p7HwUVQoPQSd458Lqwvaf4/61k/invHSh4BYK8OXnCkfEhWuIoG5hayKLQStIg==}
     dev: false
+
+  /estree-walker/2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+    dev: true
 
   /esutils/2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
@@ -4798,6 +4969,13 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
+  /is-builtin-module/3.2.0:
+    resolution: {integrity: sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==}
+    engines: {node: '>=6'}
+    dependencies:
+      builtin-modules: 3.3.0
+    dev: true
+
   /is-callable/1.2.6:
     resolution: {integrity: sha512-krO72EO2NptOGAX2KYyqbP9vYMlNAXdB53rq6f8LXY6RY7JdSR/3BD6wLUlPHSAesmY9vstNrjvqGaCiRK/91Q==}
     engines: {node: '>= 0.4'}
@@ -4930,6 +5108,10 @@ packages:
     resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
     dev: true
 
+  /is-module/1.0.0:
+    resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
+    dev: true
+
   /is-negative-zero/2.0.2:
     resolution: {integrity: sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==}
     engines: {node: '>= 0.4'}
@@ -4993,6 +5175,12 @@ packages:
 
   /is-promise/4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+    dev: true
+
+  /is-reference/1.2.1:
+    resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
+    dependencies:
+      '@types/estree': 1.0.0
     dev: true
 
   /is-regex/1.1.4:
@@ -5513,6 +5701,10 @@ packages:
       p-locate: 6.0.0
     dev: true
 
+  /lodash._reinterpolate/3.0.0:
+    resolution: {integrity: sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==}
+    dev: true
+
   /lodash.flattendeep/4.4.0:
     resolution: {integrity: sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==}
     dev: true
@@ -5527,6 +5719,19 @@ packages:
 
   /lodash.sortby/4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
+    dev: true
+
+  /lodash.template/4.5.0:
+    resolution: {integrity: sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==}
+    dependencies:
+      lodash._reinterpolate: 3.0.0
+      lodash.templatesettings: 4.2.0
+    dev: true
+
+  /lodash.templatesettings/4.2.0:
+    resolution: {integrity: sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==}
+    dependencies:
+      lodash._reinterpolate: 3.0.0
     dev: true
 
   /lodash.truncate/4.4.2:
@@ -5573,6 +5778,13 @@ packages:
     dependencies:
       sourcemap-codec: 1.4.8
     dev: false
+
+  /magic-string/0.27.0:
+    resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.14
+    dev: true
 
   /make-dir/2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
@@ -6474,12 +6686,6 @@ packages:
     dependencies:
       mimic-fn: 2.1.0
     dev: true
-
-  /onml/2.1.0:
-    resolution: {integrity: sha512-fvaSZRzprpwLFge/mcwE0CItfniNisVNamDdMK1FQUjh4ArQZ8ZWSkDaJbZc3XaANKZHq0xIa8NJpZ2HSe3oXA==}
-    dependencies:
-      sax: 1.2.4
-    dev: false
 
   /opn/3.0.3:
     resolution: {integrity: sha512-YKyQo/aDk+kLY/ChqYx3DMWW8cbxvZDh+7op1oU60TmLHGWFrn2gPaRWihzDhSwCarAESa9G8dNXzjTGfLx8FQ==}
@@ -7514,6 +7720,28 @@ packages:
       inherits: 2.0.4
     dev: true
 
+  /rollup-plugin-banner/0.2.1:
+    resolution: {integrity: sha512-Bs1uIPCsGpKIkNOwmBsCqn+dJ/xaojWk9PNlvd+1MEScddr1yUQlO6McAXi72wJyNWYL+9u9EI2JAZMpLRH92w==}
+    dependencies:
+      lodash.template: 4.5.0
+    dev: true
+
+  /rollup-plugin-version-injector/1.3.3:
+    resolution: {integrity: sha512-+Rrf0xIFHkwFGuMfphVlAOtd9FlhHFh3vrDwamJ6+YR3IxebRHGVT879qwWzZ1CpWMCLlngb2MmHW5wC5EJqvg==}
+    dependencies:
+      chalk: 4.1.2
+      dateformat: 4.6.3
+      lodash: 4.17.21
+    dev: true
+
+  /rollup/2.79.1:
+    resolution: {integrity: sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
   /run-async/2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
     engines: {node: '>=0.12.0'}
@@ -7555,10 +7783,6 @@ packages:
   /safer-buffer/2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
     dev: true
-
-  /sax/1.2.4:
-    resolution: {integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==}
-    dev: false
 
   /saxes/3.1.11:
     resolution: {integrity: sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==}


### PR DESCRIPTION
These changes do a few things:
- fixed a few of the io package functions
- fixed core package imports of io package functions
- reworked CLI logic to use the new io package exports and functions
- converted CLI tests to use import
- HACK of core to use dynamic import

### So... tests pass now. But it's a hack. But it's a start.

What was learned...
- dynamic import() is the only way to dynamically load designs with import / export
- dynamic import() is asynchronous, therefore calling functions must be async as well... as well as...

What's missing...
- no idea if dynamic import() works in all browsers
- no idea if dynamic import() works in web workers
- no idea if dynamic import() can import whole projects
- no idea if designs with require / module and import / export can be supported

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?