### PR TITLE
fix(modeling): V3 small fixes

### DIFF
--- a/packages/modeling/src/geometries/geom2/create.js
+++ b/packages/modeling/src/geometries/geom2/create.js
@@ -1,7 +1,7 @@
 import * as mat4 from '../../maths/mat4/index.js'
 
 /**
- * Represents a 2D geometry consisting of a outlines, where each outline is an ordered list of points.
+ * Represents a 2D geometry consisting of outlines, where each outline is an ordered list of points.
  * @typedef {Object} geom2
  * @property {Array} outlines - list of polygon outlines
  * @property {mat4} transforms - transforms to apply to the geometry, see transform()

--- a/packages/modeling/src/geometries/geom2/index.js
+++ b/packages/modeling/src/geometries/geom2/index.js
@@ -1,5 +1,5 @@
 /**
- * Represents a 2D geometry consisting of a outlines, where each outline is an ordered list of points.
+ * Represents a 2D geometry consisting of outlines, where each outline is an ordered list of points.
  * The outline is always closed between the first and last points.
  * @see {@link geom2} for data structure information.
  * @module modeling/geometries/geom2

--- a/packages/modeling/src/geometries/geom2/toString.test.js
+++ b/packages/modeling/src/geometries/geom2/toString.test.js
@@ -1,18 +1,17 @@
 import test from 'ava'
 
-import create from './create.js'
-import toString from './toString.js'
+import { create, toString } from './index.js'
 
 test('toString: serialize empty geom2 into a string', (t) => {
   const geometry = create()
-  const compacted = toString(geometry)
+  const result = toString(geometry)
   const expected = 'geom2 (0 outlines):\n[\n]\n'
-  t.is(compacted, expected)
+  t.is(result, expected)
 })
 
 test('toString: serialize geom2 into a string', (t) => {
   const geometry = create([[[0, 0], [0, 1], [2, 0]]])
-  const compacted = toString(geometry)
+  const result = toString(geometry)
   const expected = 'geom2 (1 outlines):\n[\n  [[0.0000000, 0.0000000],[0.0000000, 1.0000000],[2.0000000, 0.0000000]]\n]\n'
-  t.is(compacted, expected)
+  t.is(result, expected)
 })

--- a/packages/modeling/src/geometries/geom3/toString.test.js
+++ b/packages/modeling/src/geometries/geom3/toString.test.js
@@ -1,0 +1,17 @@
+import test from 'ava'
+
+import { create, fromPoints, toString } from './index.js'
+
+test('toString: serialize empty geom3 into a string', (t) => {
+  const geometry = create()
+  const result = toString(geometry)
+  const expected = 'geom3 (0 polygons):\n'
+  t.is(result, expected)
+})
+
+test('toString: serialize geom3 into a string', (t) => {
+  const geometry = fromPoints([[[0, 0, 3], [0, 1, 3], [2, 0, 3]]])
+  const result = toString(geometry)
+  const expected = 'geom3 (1 polygons):\n  poly3: [[0.0000000, 0.0000000, 3.0000000], [0.0000000, 1.0000000, 3.0000000], [2.0000000, 0.0000000, 3.0000000]]\n'
+  t.is(result, expected)
+})

--- a/packages/modeling/src/geometries/poly2/isConvex.test.js
+++ b/packages/modeling/src/geometries/poly2/isConvex.test.js
@@ -9,7 +9,7 @@ test('poly2: isConvex() should return correct values', (t) => {
   const ply2 = create([[0, 0], [1, 0], [1, 1]])
   t.true(isConvex(ply2))
 
-  // Counter Clockwise
+  // Counterclockwise
   const ply3 = create([[5, 5], [5, -5], [-5, -5], [-5, 5]])
   t.true(isConvex(ply3))
 

--- a/packages/modeling/src/geometries/poly2/toString.js
+++ b/packages/modeling/src/geometries/poly2/toString.js
@@ -7,12 +7,7 @@ import * as vec2 from '../../maths/vec2/index.js'
  * @alias module:modeling/geometries/poly2.toString
  */
 export const toString = (polygon) => {
-  let result = 'poly2: points: ['
-  polygon.points.forEach((point) => {
-    result += `${vec2.toString(point)}, `
-  })
-  result += ']'
-  return result
+  return `poly2: [${polygon.points.map(vec2.toString).join(', ')}]`
 }
 
 export default toString

--- a/packages/modeling/src/geometries/poly2/toString.test.js
+++ b/packages/modeling/src/geometries/poly2/toString.test.js
@@ -1,0 +1,10 @@
+import test from 'ava'
+
+import { create, toString } from './index.js'
+
+test('toString: serialize poly2 into a string', (t) => {
+  const geometry = create([[0, 0], [0, 1], [2, 0]])
+  const result = toString(geometry)
+  const expected = 'poly2: [[0.0000000, 0.0000000], [0.0000000, 1.0000000], [2.0000000, 0.0000000]]'
+  t.is(result, expected)
+})

--- a/packages/modeling/src/geometries/poly2/validate.test.js
+++ b/packages/modeling/src/geometries/poly2/validate.test.js
@@ -9,13 +9,11 @@ test('validate: identifies polygons', (t) => {
   const ply2 = create([[0, 0], [1, 0], [1, 1]])
   t.notThrows(() => validate(ply2))
 
-  const string = toString(ply2)
-
   // Clockwise
   const ply3 = create([[5, 5], [5, -5], [-5, -5], [-5, 5]])
   t.throws(() => validate(ply3), { message: 'poly2 area must be greater than zero' })
 
-  // Counter Clockwise
+  // Counterclockwise
   const ply4 = create([[5, 5], [-5, 5], [-5, -5], [5, -5]])
   t.notThrows(() => validate(ply4))
 
@@ -27,7 +25,7 @@ test('validate: identifies polygons', (t) => {
   const ply6 = create([[0, 0], [5, 5], [5, -5], [0, 0], [-5, -5], [-5, 5]])
   t.throws(() => validate(ply6), { message: 'poly2 area must be greater than zero' })
 
-  // Counter Clockwise with duplicate points
+  // Counterclockwise with duplicate points
   const ply7 = create([[5, 5], [-5, 5], [-5, 5], [-5, -5], [5, -5]])
   t.throws(() => validate(ply7), { message: 'poly2 duplicate point at 1: [-5,5]' })
 })

--- a/packages/modeling/src/geometries/poly3/toString.js
+++ b/packages/modeling/src/geometries/poly3/toString.js
@@ -1,17 +1,13 @@
 import * as vec3 from '../../maths/vec3/index.js'
 
 /**
- * @param {poly3} polygon - the polygon to measure
+ * Convert the given polygon to a readable string.
+ * @param {poly3} polygon - the polygon to convert
  * @return {String} the string representation
  * @alias module:modeling/geometries/poly3.toString
  */
 export const toString = (polygon) => {
-  let result = 'poly3: vertices: ['
-  polygon.vertices.forEach((vertex) => {
-    result += `${vec3.toString(vertex)}, `
-  })
-  result += ']'
-  return result
+  return `poly3: [${polygon.vertices.map(vec3.toString).join(', ')}]`
 }
 
 export default toString

--- a/packages/modeling/src/geometries/poly3/toString.test.js
+++ b/packages/modeling/src/geometries/poly3/toString.test.js
@@ -1,0 +1,10 @@
+import test from 'ava'
+
+import { create, toString } from './index.js'
+
+test('toString: serialize poly3 into a string', (t) => {
+  const geometry = create([[0, 0, 3], [0, 1, 3], [2, 0, 3]])
+  const result = toString(geometry)
+  const expected = 'poly3: [[0.0000000, 0.0000000, 3.0000000], [0.0000000, 1.0000000, 3.0000000], [2.0000000, 0.0000000, 3.0000000]]'
+  t.is(result, expected)
+})

--- a/packages/modeling/src/geometries/slice/earcut/polygonHierarchy.js
+++ b/packages/modeling/src/geometries/slice/earcut/polygonHierarchy.js
@@ -1,4 +1,3 @@
-import * as plane from '../../../maths/plane/index.js'
 import * as vec2 from '../../../maths/vec2/index.js'
 import * as vec3 from '../../../maths/vec3/index.js'
 

--- a/packages/modeling/src/geometries/slice/toString.js
+++ b/packages/modeling/src/geometries/slice/toString.js
@@ -1,15 +1,18 @@
 import * as vec3 from '../../maths/vec3/index.js'
 
-const edgesToString = (edges) =>
-  edges.reduce((result, edge) => (
-    result += `[${vec3.toString(edge[0])}, ${vec3.toString(edge[1])}], `
-  ), '')
-
 /**
+ * Convert the given slice to a readable string.
  * @param {slice} slice - the slice
  * @return {String} the string representation
  * @alias module:modeling/geometries/slice.toString
  */
-export const toString = (slice) => `[${edgesToString(slice.edges)}]`
+export const toString = (slice) => {
+  let result = 'slice (' + slice.contours.length + ' contours):\n[\n'
+  slice.contours.forEach((contour) => {
+    result += '  [' + contour.map(vec3.toString).join() + '],\n'
+  })
+  result += ']\n'
+  return result
+}
 
 export default toString

--- a/packages/modeling/src/geometries/slice/toString.test.js
+++ b/packages/modeling/src/geometries/slice/toString.test.js
@@ -1,0 +1,17 @@
+import test from 'ava'
+
+import { create, toString } from './index.js'
+
+test('toString: serialize empty slice into a string', (t) => {
+  const geometry = create()
+  const result = toString(geometry)
+  const expected = 'slice (0 contours):\n[\n]\n'
+  t.is(result, expected)
+})
+
+test('toString: serialize slice into a string', (t) => {
+  const geometry = create([[[0, 0, 3], [0, 1, 3], [2, 0, 3]]])
+  const result = toString(geometry)
+  const expected = 'slice (1 contours):\n[\n  [[0.0000000, 0.0000000, 3.0000000],[0.0000000, 1.0000000, 3.0000000],[2.0000000, 0.0000000, 3.0000000]],\n]\n'
+  t.is(result, expected)
+})

--- a/packages/modeling/src/maths/utils/intersect.d.ts
+++ b/packages/modeling/src/maths/utils/intersect.d.ts
@@ -2,4 +2,4 @@ import Vec2 from '../vec2/type'
 
 export default intersect
 
-declare function intersect(p1: Vec2, p2: Vec2, p3: Vec2, p4: Vec2): Vec2
+declare function intersect(p1: Vec2, p2: Vec2, p3: Vec2, p4: Vec2, endpointTouch: boolean): Vec2

--- a/packages/modeling/src/maths/utils/intersect.test.js
+++ b/packages/modeling/src/maths/utils/intersect.test.js
@@ -1,0 +1,39 @@
+import test from 'ava'
+
+import { intersect } from './index.js'
+
+//   A     __F
+//  / \ __E
+// B   D   \
+//  \ /     \
+//   C       G
+
+const a = [0, 1]
+const b = [-1, 0]
+const c = [0, -1]
+const d = [1, 0]
+const e = [2, 0.5]
+const f = [3, 1]
+const g = [2, -1]
+
+test('utils: intersect() for intersecting lines', (t) => {
+  t.deepEqual(intersect(a, c, b, d), [0, 0])
+  t.deepEqual(intersect(a, b, b, c), b)
+  t.deepEqual(intersect(d, f, e, g), e)
+})
+
+test('utils: intersect() for non-intersecting lines', (t) => {
+  t.is(intersect(a, a, b, c), undefined)
+  t.is(intersect(a, d, b, c), undefined)
+  t.is(intersect(a, b, d, e), undefined)
+})
+
+test('utils: intersect() endpointTouch parameter', (t) => {
+  // endpoint touching
+  t.deepEqual(intersect(a, b, b, c), b)
+  t.deepEqual(intersect(a, b, b, c, true), b)
+  t.deepEqual(intersect(a, b, b, c, false), undefined)
+  t.deepEqual(intersect(d, f, e, g), e)
+  t.deepEqual(intersect(d, f, e, g, true), e)
+  t.deepEqual(intersect(d, f, e, g, false), undefined)
+})


### PR DESCRIPTION
Misc fixes and testing enhancements for V3. Includes:

 - Fix `maths.utils.intersect` type defintion. Thanks @youssefsharief
 - Add tests for `maths.utils.intersect`
 - Fix `slice.toString`
 - Add tests for `*.toString` to all geometries
 - Make `toString` more similar across geometries
 - Minor comment fixes


### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
