### PR TITLE
fix(modeling): arcLengthToT first argument is required

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -20,3 +20,4 @@ jobs:
           node-version: ${{ matrix.node }}
       - run: npm install
       - run: npm test
+      - run: npm run test:tsd

--- a/packages/modeling/src/curves/bezier/arcLengthToT.d.ts
+++ b/packages/modeling/src/curves/bezier/arcLengthToT.d.ts
@@ -7,4 +7,4 @@ export interface ArcLengthToTOptions {
   segments?: Number
 }
 
-declare function arcLengthToT(options?: ArcLengthToTOptions, bezier: Bezier): number
+declare function arcLengthToT(options: ArcLengthToTOptions, bezier: Bezier): number


### PR DESCRIPTION
Fix the type definitions in `arcLengthToT.d.ts` to make the first argument required.

Also add `tsd:test` to CI.

Fixes #1223


### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
