### PR TITLE
fix(svg-deserializer): fix quadratic bezier paths

### DIFF
--- a/packages/io/svg-deserializer/src/helpers.js
+++ b/packages/io/svg-deserializer/src/helpers.js
@@ -1,9 +1,10 @@
 const { inchMM, ptMM, pcMM, svgColors } = require('./constants')
 
 // Calculate the CAG length/size from the given SVG value (float)
-const svg2cagX = (v, svgUnitsPmm) => (v / svgUnitsPmm[0])
-
-const svg2cagY = (v, svgUnitsPmm) => 0 - (v / svgUnitsPmm[1])
+const svg2cag = (vec, svgUnitsPmm) => [
+  vec[0] / svgUnitsPmm[0],
+  0 - vec[1] / svgUnitsPmm[1]
+]
 
 // Calculate the CAG length/size from the given CSS value (string)
 const cagLengthX = (css, svgUnitsPmm, svgUnitsX) => {
@@ -186,8 +187,7 @@ const svgColorForTarget = (target, svgObject) => {
 }
 
 module.exports = {
-  svg2cagX,
-  svg2cagY,
+  svg2cag,
   cagLengthX,
   cagLengthY,
   cagLengthP,

--- a/packages/io/svg-deserializer/src/shapesMapGeometry.js
+++ b/packages/io/svg-deserializer/src/shapesMapGeometry.js
@@ -1,7 +1,6 @@
 const { geometries, primitives } = require('@jscad/modeling')
 
-const { svg2cagX, svg2cagY, cagLengthX, cagLengthY, cagLengthP, reflect } = require('./helpers')
-// const { cssPxUnit } = require('./constants')
+const { svg2cag, cagLengthX, cagLengthY, cagLengthP, reflect } = require('./helpers')
 
 const shapesMapGeometry = (obj, objectify, params) => {
   const { svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups, target, segments, pathSelfClosed } = params
@@ -210,14 +209,14 @@ const expandPath = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups
           cx = cx + parseFloat(pts[i++])
           cy = cy + parseFloat(pts[i++])
           newPath()
-          paths[pathName] = appendPoints([[svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]])
+          paths[pathName] = appendPoints([svg2cag([cx, cy], svgUnitsPmm)])
           sx = cx; sy = cy
         }
         // optional implicit relative lineTo (cf SVG spec 8.3.2)
         while (pts.length >= i + 2) {
           cx = cx + parseFloat(pts[i++])
           cy = cy + parseFloat(pts[i++])
-          paths[pathName] = appendPoints([[svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]], paths[pathName])
+          paths[pathName] = appendPoints([svg2cag([cx, cy], svgUnitsPmm)], paths[pathName])
         }
         break
       case 'M': // absolute move to X,Y
@@ -230,14 +229,14 @@ const expandPath = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups
           cx = parseFloat(pts[i++])
           cy = parseFloat(pts[i++])
           newPath()
-          paths[pathName] = appendPoints([[svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]])
+          paths[pathName] = appendPoints([svg2cag([cx, cy], svgUnitsPmm)])
           sx = cx; sy = cy
         }
         // optional implicit absolute lineTo (cf SVG spec 8.3.2)
         while (pts.length >= i + 2) {
           cx = parseFloat(pts[i++])
           cy = parseFloat(pts[i++])
-          paths[pathName] = appendPoints([[svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]], paths[pathName])
+          paths[pathName] = appendPoints([svg2cag([cx, cy], svgUnitsPmm)], paths[pathName])
         }
         break
       case 'a': // relative elliptical arc
@@ -250,7 +249,14 @@ const expandPath = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups
           cx = cx + parseFloat(pts[i++])
           cy = cy + parseFloat(pts[i++])
           ensurePath()
-          paths[pathName] = geometries.path2.appendArc({ segments, endpoint: [svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)], radius: [svg2cagX(rx, svgUnitsPmm), svg2cagY(ry, svgUnitsPmm)], xaxisrotation: ro, clockwise: sf, large: lf }, paths[pathName])
+          paths[pathName] = geometries.path2.appendArc({
+            segments,
+            endpoint: svg2cag([cx, cy], svgUnitsPmm),
+            radius: svg2cag([rx, ry], svgUnitsPmm),
+            xaxisrotation: ro,
+            clockwise: sf,
+            large: lf
+          }, paths[pathName])
         }
         break
       case 'A': // absolute elliptical arc
@@ -263,7 +269,14 @@ const expandPath = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups
           cx = parseFloat(pts[i++])
           cy = parseFloat(pts[i++])
           ensurePath()
-          paths[pathName] = geometries.path2.appendArc({ segments, endpoint: [svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)], radius: [svg2cagX(rx, svgUnitsPmm), svg2cagY(ry, svgUnitsPmm)], xaxisrotation: ro, clockwise: sf, large: lf }, paths[pathName])
+          paths[pathName] = geometries.path2.appendArc({
+            segments,
+            endpoint: svg2cag([cx, cy], svgUnitsPmm),
+            radius: svg2cag([rx, ry], svgUnitsPmm),
+            xaxisrotation: ro,
+            clockwise: sf,
+            large: lf
+          }, paths[pathName])
         }
         break
       case 'c': // relative cubic Bézier
@@ -275,7 +288,14 @@ const expandPath = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups
           cx = cx + parseFloat(pts[i++])
           cy = cy + parseFloat(pts[i++])
           ensurePath()
-          paths[pathName] = geometries.path2.appendBezier({ segments, controlPoints: [[svg2cagX(x1, svgUnitsPmm), svg2cagY(y1, svgUnitsPmm)], [svg2cagX(bx, svgUnitsPmm), svg2cagY(by, svgUnitsPmm)], [svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]] }, paths[pathName])
+          paths[pathName] = geometries.path2.appendBezier({
+            segments,
+            controlPoints: [
+              svg2cag([x1, y1], svgUnitsPmm),
+              svg2cag([bx, by], svgUnitsPmm),
+              svg2cag([cx, cy], svgUnitsPmm)
+            ]
+          }, paths[pathName])
           const rf = reflect(bx, by, cx, cy)
           bx = rf[0]
           by = rf[1]
@@ -290,7 +310,14 @@ const expandPath = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups
           cx = parseFloat(pts[i++])
           cy = parseFloat(pts[i++])
           ensurePath()
-          paths[pathName] = geometries.path2.appendBezier({ segments, controlPoints: [[svg2cagX(x1, svgUnitsPmm), svg2cagY(y1, svgUnitsPmm)], [svg2cagX(bx, svgUnitsPmm), svg2cagY(by, svgUnitsPmm)], [svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]] }, paths[pathName])
+          paths[pathName] = geometries.path2.appendBezier({
+            segments,
+            controlPoints: [
+              svg2cag([x1, y1], svgUnitsPmm),
+              svg2cag([bx, by], svgUnitsPmm),
+              svg2cag([cx, cy], svgUnitsPmm)
+            ]
+          }, paths[pathName])
           const rf = reflect(bx, by, cx, cy)
           bx = rf[0]
           by = rf[1]
@@ -298,12 +325,22 @@ const expandPath = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups
         break
       case 'q': // relative quadratic Bézier
         while (pts.length >= i + 4) {
+          const p0 = [cx, cy] // previous point
           qx = cx + parseFloat(pts[i++])
           qy = cy + parseFloat(pts[i++])
           cx = cx + parseFloat(pts[i++])
           cy = cy + parseFloat(pts[i++])
+          const q1 = [p0[0] + (2/3) * (qx - p0[0]), p0[1] + (2/3) * (qy - p0[1])]
+          const q2 = [q1[0] + (1/3) * (cx - p0[0]), q1[1] + (1/3) * (cy - p0[1])]
           ensurePath()
-          paths[pathName] = geometries.path2.appendBezier({ segments, controlPoints: [[svg2cagX(qx, svgUnitsPmm), svg2cagY(qy, svgUnitsPmm)], [svg2cagX(qx, svgUnitsPmm), svg2cagY(qy, svgUnitsPmm)], [svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]] }, paths[pathName])
+          paths[pathName] = geometries.path2.appendBezier({
+            segments,
+            controlPoints: [
+              svg2cag(q1, svgUnitsPmm),
+              svg2cag(q2, svgUnitsPmm),
+              svg2cag([cx, cy], svgUnitsPmm)
+            ]
+          }, paths[pathName])
           const rf = reflect(qx, qy, cx, cy)
           qx = rf[0]
           qy = rf[1]
@@ -311,12 +348,22 @@ const expandPath = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups
         break
       case 'Q': // absolute quadratic Bézier
         while (pts.length >= i + 4) {
+          const p0 = [cx, cy] // previous point
           qx = parseFloat(pts[i++])
           qy = parseFloat(pts[i++])
           cx = parseFloat(pts[i++])
           cy = parseFloat(pts[i++])
+          const q1 = [p0[0] + (2/3) * (qx - p0[0]), p0[1] + (2/3) * (qy - p0[1])]
+          const q2 = [q1[0] + (1/3) * (cx - p0[0]), q1[1] + (1/3) * (cy - p0[1])]
           ensurePath()
-          paths[pathName] = geometries.path2.appendBezier({ segments, controlPoints: [[svg2cagX(qx, svgUnitsPmm), svg2cagY(qy, svgUnitsPmm)], [svg2cagX(qx, svgUnitsPmm), svg2cagY(qy, svgUnitsPmm)], [svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]] }, paths[pathName])
+          paths[pathName] = geometries.path2.appendBezier({
+            segments,
+            controlPoints: [
+              svg2cag(q1, svgUnitsPmm),
+              svg2cag(q2, svgUnitsPmm),
+              svg2cag([cx, cy], svgUnitsPmm)
+            ]
+          }, paths[pathName])
           const rf = reflect(qx, qy, cx, cy)
           qx = rf[0]
           qy = rf[1]
@@ -324,10 +371,20 @@ const expandPath = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups
         break
       case 't': // relative quadratic Bézier shorthand
         while (pts.length >= i + 2) {
+          const p0 = [cx, cy] // previous point
           cx = cx + parseFloat(pts[i++])
           cy = cy + parseFloat(pts[i++])
+          const q1 = [p0[0] + (2/3) * (qx - p0[0]), p0[1] + (2/3) * (qy - p0[1])]
+          const q2 = [q1[0] + (1/3) * (cx - p0[0]), q1[1] + (1/3) * (cy - p0[1])]
           ensurePath()
-          paths[pathName] = geometries.path2.appendBezier({ segments, controlPoints: [[svg2cagX(qx, svgUnitsPmm), svg2cagY(qy, svgUnitsPmm)], [svg2cagX(qx, svgUnitsPmm), svg2cagY(qy, svgUnitsPmm)], [cx, cy]] }, paths[pathName])
+          paths[pathName] = geometries.path2.appendBezier({
+            segments,
+            controlPoints: [
+              svg2cag(q1, svgUnitsPmm),
+              svg2cag(q2, svgUnitsPmm),
+              svg2cag([cx, cy], svgUnitsPmm)
+            ]
+          }, paths[pathName])
           const rf = reflect(qx, qy, cx, cy)
           qx = rf[0]
           qy = rf[1]
@@ -335,10 +392,20 @@ const expandPath = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups
         break
       case 'T': // absolute quadratic Bézier shorthand
         while (pts.length >= i + 2) {
+          const p0 = [cx, cy] // previous point
           cx = parseFloat(pts[i++])
           cy = parseFloat(pts[i++])
+          const q1 = [p0[0] + (2/3) * (qx - p0[0]), p0[1] + (2/3) * (qy - p0[1])]
+          const q2 = [q1[0] + (1/3) * (cx - p0[0]), q1[1] + (1/3) * (cy - p0[1])]
           ensurePath()
-          paths[pathName] = geometries.path2.appendBezier({ segments, controlPoints: [[svg2cagX(qx, svgUnitsPmm), svg2cagY(qy, svgUnitsPmm)], [svg2cagX(qx, svgUnitsPmm), svg2cagY(qy, svgUnitsPmm)], [svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]] }, paths[pathName])
+          paths[pathName] = geometries.path2.appendBezier({
+            segments,
+            controlPoints: [
+              svg2cag(q1, svgUnitsPmm),
+              svg2cag(q2, svgUnitsPmm),
+              svg2cag([cx, cy], svgUnitsPmm)
+            ]
+          }, paths[pathName])
           const rf = reflect(qx, qy, cx, cy)
           qx = rf[0]
           qy = rf[1]
@@ -353,7 +420,13 @@ const expandPath = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups
           cx = cx + parseFloat(pts[i++])
           cy = cy + parseFloat(pts[i++])
           ensurePath()
-          paths[pathName] = geometries.path2.appendBezier({ segments, controlPoints: [[svg2cagX(x1, svgUnitsPmm), svg2cagY(y1, svgUnitsPmm)], [svg2cagX(bx, svgUnitsPmm), svg2cagY(by, svgUnitsPmm)], [svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]] }, paths[pathName])
+          paths[pathName] = geometries.path2.appendBezier({
+            segments, controlPoints: [
+              svg2cag([x1, y1], svgUnitsPmm),
+              svg2cag([bx, by], svgUnitsPmm),
+              svg2cag([cx, cy], svgUnitsPmm)
+            ]
+          }, paths[pathName])
           const rf = reflect(bx, by, cx, cy)
           bx = rf[0]
           by = rf[1]
@@ -368,7 +441,14 @@ const expandPath = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups
           cx = parseFloat(pts[i++])
           cy = parseFloat(pts[i++])
           ensurePath()
-          paths[pathName] = geometries.path2.appendBezier({ segments, controlPoints: [[svg2cagX(x1, svgUnitsPmm), svg2cagY(y1, svgUnitsPmm)], [svg2cagX(bx, svgUnitsPmm), svg2cagY(by, svgUnitsPmm)], [svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]] }, paths[pathName])
+          paths[pathName] = geometries.path2.appendBezier({
+            segments,
+            controlPoints: [
+              svg2cag([x1, y1], svgUnitsPmm),
+              svg2cag([bx, by], svgUnitsPmm),
+              svg2cag([cx, cy], svgUnitsPmm)
+            ]
+          }, paths[pathName])
           const rf = reflect(bx, by, cx, cy)
           bx = rf[0]
           by = rf[1]
@@ -377,39 +457,39 @@ const expandPath = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups
       case 'h': // relative Horzontal line to
         while (pts.length >= i + 1) {
           cx = cx + parseFloat(pts[i++])
-          paths[pathName] = appendPoints([[svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]], paths[pathName])
+          paths[pathName] = appendPoints([svg2cag([cx, cy], svgUnitsPmm)], paths[pathName])
         }
         break
       case 'H': // absolute Horzontal line to
         while (pts.length >= i + 1) {
           cx = parseFloat(pts[i++])
-          paths[pathName] = appendPoints([[svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]], paths[pathName])
+          paths[pathName] = appendPoints([svg2cag([cx, cy], svgUnitsPmm)], paths[pathName])
         }
         break
       case 'l': // relative line to
         while (pts.length >= i + 2) {
           cx = cx + parseFloat(pts[i++])
           cy = cy + parseFloat(pts[i++])
-          paths[pathName] = appendPoints([[svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]], paths[pathName])
+          paths[pathName] = appendPoints([svg2cag([cx, cy], svgUnitsPmm)], paths[pathName])
         }
         break
       case 'L': // absolute line to
         while (pts.length >= i + 2) {
           cx = parseFloat(pts[i++])
           cy = parseFloat(pts[i++])
-          paths[pathName] = appendPoints([[svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]], paths[pathName])
+          paths[pathName] = appendPoints([svg2cag([cx, cy], svgUnitsPmm)], paths[pathName])
         }
         break
       case 'v': // relative Vertical line to
         while (pts.length >= i + 1) {
           cy = cy + parseFloat(pts[i++])
-          paths[pathName] = appendPoints([[svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]], paths[pathName])
+          paths[pathName] = appendPoints([svg2cag([cx, cy], svgUnitsPmm)], paths[pathName])
         }
         break
       case 'V': // absolute Vertical line to
         while (pts.length >= i + 1) {
           cy = parseFloat(pts[i++])
-          paths[pathName] = appendPoints([[svg2cagX(cx, svgUnitsPmm), svg2cagY(cy, svgUnitsPmm)]], paths[pathName])
+          paths[pathName] = appendPoints([svg2cag([cx, cy], svgUnitsPmm)], paths[pathName])
         }
         break
       case 'z': // close current line

--- a/packages/io/svg-deserializer/src/shapesMapJscad.js
+++ b/packages/io/svg-deserializer/src/shapesMapJscad.js
@@ -1,4 +1,4 @@
-const { svg2cagX, svg2cagY, cagLengthX, cagLengthY, cagLengthP, reflect } = require('./helpers')
+const { svg2cag, cagLengthX, cagLengthY, cagLengthP, reflect } = require('./helpers')
 
 const shapesMap = (obj, codify, params) => {
   const { level, indent, on, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, svgGroups, target, segments } = params
@@ -169,14 +169,14 @@ const path = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGrou
           pi++
           pc = false
           pathName = on + pi
-          tmpCode += `${indent}${pathName} = geometries.path2.fromPoints({}, [[${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]])\n`
+          tmpCode += `${indent}${pathName} = geometries.path2.fromPoints({}, [[${svg2cag([cx, cy], svgUnitsPmm)}]])\n`
           sx = cx; sy = cy
         }
         // optional implicit relative lineTo (cf SVG spec 8.3.2)
         while (pts.length >= 2) {
           cx = cx + parseFloat(pts.shift())
           cy = cy + parseFloat(pts.shift())
-          tmpCode += `${indent}${pathName} = geometries.path2.appendPoints([${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}], ${pathName})\n`
+          tmpCode += `${indent}${pathName} = geometries.path2.appendPoints([${svg2cag([cx, cy], svgUnitsPmm)}], ${pathName})\n`
         }
         break
       case 'M': // absolute move to X,Y
@@ -191,14 +191,14 @@ const path = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGrou
           pi++
           pc = false
           pathName = on + pi
-          tmpCode += `${indent}${pathName} = geometries.path2.fromPoints({}, [[${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]])\n`
+          tmpCode += `${indent}${pathName} = geometries.path2.fromPoints({}, [[${svg2cag([cx, cy], svgUnitsPmm)}]])\n`
           sx = cx; sy = cy
         }
         // optional implicit absolute lineTo (cf SVG spec 8.3.2)
         while (pts.length >= 2) {
           cx = parseFloat(pts.shift())
           cy = parseFloat(pts.shift())
-          tmpCode += `${indent}${pathName} = geometries.path2.appendPoints([${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}], ${pathName})\n`
+          tmpCode += `${indent}${pathName} = geometries.path2.appendPoints([${svg2cag([cx, cy], svgUnitsPmm)}], ${pathName})\n`
         }
         break
       case 'a': // relative elliptical arc
@@ -210,7 +210,7 @@ const path = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGrou
           const sf = (pts.shift() === '1')
           cx = cx + parseFloat(pts.shift())
           cy = cy + parseFloat(pts.shift())
-          tmpCode += `${indent}${pathName} = geometries.path2.appendArc({segments: ${segments}, endpoint: [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}], radius: [${svg2cagX(rx, svgUnitsPmm)}, ${svg2cagY(ry, svgUnitsPmm)}], xaxisrotation: ${ro}, clockwise: ${sf}, large: ${lf}}, ${pathName})\n`
+          tmpCode += `${indent}${pathName} = geometries.path2.appendArc({segments: ${segments}, endpoint: [${svg2cag([cx, cy], svgUnitsPmm)}], radius: [${svg2cag([rx, ry], svgUnitsPmm)}], xaxisrotation: ${ro}, clockwise: ${sf}, large: ${lf}}, ${pathName})\n`
         }
         break
       case 'A': // absolute elliptical arc
@@ -222,7 +222,7 @@ const path = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGrou
           const sf = (pts.shift() === '1')
           cx = parseFloat(pts.shift())
           cy = parseFloat(pts.shift())
-          tmpCode += `${indent}${pathName} = geometries.path2.appendArc({segments: ${segments}, endpoint: [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}], radius: [${svg2cagX(rx, svgUnitsPmm)}, ${svg2cagY(ry, svgUnitsPmm)}], xaxisrotation: ${ro}, clockwise: ${sf}, large: ${lf}}, ${pathName})\n`
+          tmpCode += `${indent}${pathName} = geometries.path2.appendArc({segments: ${segments}, endpoint: [${svg2cag([cx, cy], svgUnitsPmm)}], radius: [${svg2cag([rx, ry], svgUnitsPmm)}], xaxisrotation: ${ro}, clockwise: ${sf}, large: ${lf}}, ${pathName})\n`
         }
         break
       case 'c': // relative cubic Bézier
@@ -233,7 +233,7 @@ const path = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGrou
           by = cy + parseFloat(pts.shift())
           cx = cx + parseFloat(pts.shift())
           cy = cy + parseFloat(pts.shift())
-          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({segments: ${segments}, controlPoints: [[${svg2cagX(x1, svgUnitsPmm)}, ${svg2cagY(y1, svgUnitsPmm)}], [${svg2cagX(bx, svgUnitsPmm)}, ${svg2cagY(by, svgUnitsPmm)}], [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]]}, ${pathName})\n`
+          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({segments: ${segments}, controlPoints: [[${svg2cag([x1, y1], svgUnitsPmm)}], [${svg2cag([bx, by], svgUnitsPmm)}], [${svg2cag([cx, cy], svgUnitsPmm)}]]}, ${pathName})\n`
           const rf = reflect(bx, by, cx, cy)
           bx = rf[0]
           by = rf[1]
@@ -247,7 +247,7 @@ const path = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGrou
           by = parseFloat(pts.shift())
           cx = parseFloat(pts.shift())
           cy = parseFloat(pts.shift())
-          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({segments: ${segments}, controlPoints: [[${svg2cagX(x1, svgUnitsPmm)}, ${svg2cagY(y1, svgUnitsPmm)}], [${svg2cagX(bx, svgUnitsPmm)}, ${svg2cagY(by, svgUnitsPmm)}], [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]]}, ${pathName})\n`
+          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({segments: ${segments}, controlPoints: [[${svg2cag([x1, y1], svgUnitsPmm)}], [${svg2cag([bx, by], svgUnitsPmm)}], [${svg2cag([cx, cy], svgUnitsPmm)}]]}, ${pathName})\n`
           const rf = reflect(bx, by, cx, cy)
           bx = rf[0]
           by = rf[1]
@@ -255,11 +255,14 @@ const path = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGrou
         break
       case 'q': // relative quadratic Bézier
         while (pts.length >= 4) {
+          const p0 = [cx, cy] // previous point
           qx = cx + parseFloat(pts.shift())
           qy = cy + parseFloat(pts.shift())
           cx = cx + parseFloat(pts.shift()) // end point
           cy = cy + parseFloat(pts.shift())
-          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({segments: ${segments}, controlPoints: [[${svg2cagX(qx, svgUnitsPmm)}, ${svg2cagY(qy, svgUnitsPmm)}], [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]]}, ${pathName})\n`
+          const q1 = [p0[0] + (2/3) * (qx - p0[0]), p0[1] + (2/3) * (qy - p0[1])]
+          const q2 = [q1[0] + (1/3) * (cx - p0[0]), q1[1] + (1/3) * (cy - p0[1])]
+          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({segments: ${segments}, controlPoints: [[${svg2cag(q1, svgUnitsPmm)}], [${svg2cag(q2, svgUnitsPmm)}], [${svg2cag([cx, cy], svgUnitsPmm)}]]}, ${pathName})\n`
           const rf = reflect(qx, qy, cx, cy)
           qx = rf[0]
           qy = rf[1]
@@ -267,11 +270,14 @@ const path = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGrou
         break
       case 'Q': // absolute quadratic Bézier
         while (pts.length >= 4) {
+          const p0 = [cx, cy] // previous point
           qx = parseFloat(pts.shift())
           qy = parseFloat(pts.shift())
           cx = parseFloat(pts.shift()) // end point
           cy = parseFloat(pts.shift())
-          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({segments: ${segments}, controlPoints: [[${svg2cagX(qx, svgUnitsPmm)}, ${svg2cagY(qy, svgUnitsPmm)}], [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]]}, ${pathName})\n`
+          const q1 = [p0[0] + (2/3) * (qx - p0[0]), p0[1] + (2/3) * (qy - p0[1])]
+          const q2 = [q1[0] + (1/3) * (cx - p0[0]), q1[1] + (1/3) * (cy - p0[1])]
+          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({segments: ${segments}, controlPoints: [[${svg2cag(q1, svgUnitsPmm)}], [${svg2cag(q2, svgUnitsPmm)}], [${svg2cag([cx, cy], svgUnitsPmm)}]]}, ${pathName})\n`
           const rf = reflect(qx, qy, cx, cy)
           qx = rf[0]
           qy = rf[1]
@@ -279,9 +285,12 @@ const path = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGrou
         break
       case 't': // relative quadratic Bézier shorthand
         while (pts.length >= 2) {
+          const p0 = [cx, cy] // previous point
           cx = cx + parseFloat(pts.shift()) // end point
           cy = cy + parseFloat(pts.shift())
-          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({segments: ${segments}, controlPoints: [[${svg2cagX(qx, svgUnitsPmm)}, ${svg2cagY(qy, svgUnitsPmm)}], [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]]}, ${pathName})\n`
+          const q1 = [p0[0] + (2/3) * (qx - p0[0]), p0[1] + (2/3) * (qy - p0[1])]
+          const q2 = [q1[0] + (1/3) * (cx - p0[0]), q1[1] + (1/3) * (cy - p0[1])]
+          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({segments: ${segments}, controlPoints: [[[${svg2cag(q1, svgUnitsPmm)}], [${svg2cag(q2, svgUnitsPmm)}], [${svg2cag([cx, cy], svgUnitsPmm)}]]}, ${pathName})\n`
           const rf = reflect(qx, qy, cx, cy)
           qx = rf[0]
           qy = rf[1]
@@ -289,9 +298,12 @@ const path = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGrou
         break
       case 'T': // absolute quadratic Bézier shorthand
         while (pts.length >= 2) {
+          const p0 = [cx, cy] // previous point
           cx = parseFloat(pts.shift()) // end point
           cy = parseFloat(pts.shift())
-          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({segments: ${segments}, controlPoints: [[${svg2cagX(qx, svgUnitsPmm)}, ${svg2cagY(qy, svgUnitsPmm)}], [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]]}, ${pathName})\n`
+          const q1 = [p0[0] + (2/3) * (qx - p0[0]), p0[1] + (2/3) * (qy - p0[1])]
+          const q2 = [q1[0] + (1/3) * (cx - p0[0]), q1[1] + (1/3) * (cy - p0[1])]
+          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({segments: ${segments}, controlPoints: [[[${svg2cag(q1, svgUnitsPmm)}], [${svg2cag(q2, svgUnitsPmm)}], [${svg2cag([cx, cy], svgUnitsPmm)}]]}, ${pathName})\n`
           const rf = reflect(qx, qy, cx, cy)
           qx = rf[0]
           qy = rf[1]
@@ -305,7 +317,7 @@ const path = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGrou
           by = cy + parseFloat(pts.shift())
           cx = cx + parseFloat(pts.shift())
           cy = cy + parseFloat(pts.shift())
-          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({segments: ${segments}, controlPoints: [[${svg2cagX(x1, svgUnitsPmm)}, ${svg2cagY(y1, svgUnitsPmm)}], [${svg2cagX(bx, svgUnitsPmm)}, ${svg2cagY(by, svgUnitsPmm)}], [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]]}, ${pathName})\n`
+          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({segments: ${segments}, controlPoints: [[${svg2cag([x1, y1], svgUnitsPmm)}], [${svg2cag([bx, by], svgUnitsPmm)}], [${svg2cag([cx, cy], svgUnitsPmm)}]]}, ${pathName})\n`
           const rf = reflect(bx, by, cx, cy)
           bx = rf[0]
           by = rf[1]
@@ -319,7 +331,7 @@ const path = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGrou
           by = parseFloat(pts.shift())
           cx = parseFloat(pts.shift())
           cy = parseFloat(pts.shift())
-          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({segments: ${segments}, controlPoints: [[${svg2cagX(x1, svgUnitsPmm)}, ${svg2cagY(y1, svgUnitsPmm)}], [${svg2cagX(bx, svgUnitsPmm)}, ${svg2cagY(by, svgUnitsPmm)}], [${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]]}, ${pathName})\n`
+          tmpCode += `${indent}${pathName} = geometries.path2.appendBezier({segments: ${segments}, controlPoints: [[${svg2cag([x1, y1], svgUnitsPmm)}], [${svg2cag([bx, by], svgUnitsPmm)}], [${svg2cag([cx, cy], svgUnitsPmm)}]]}, ${pathName})\n`
           const rf = reflect(bx, by, cx, cy)
           bx = rf[0]
           by = rf[1]
@@ -328,39 +340,39 @@ const path = (obj, svgUnitsPmm, svgUnitsX, svgUnitsY, svgUnitsV, params, svgGrou
       case 'h': // relative Horzontal line to
         while (pts.length >= 1) {
           cx = cx + parseFloat(pts.shift())
-          tmpCode += `${indent}${pathName} = geometries.path2.appendPoints([[${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]], ${pathName})\n`
+          tmpCode += `${indent}${pathName} = geometries.path2.appendPoints([[${svg2cag([cx, cy], svgUnitsPmm)}]], ${pathName})\n`
         }
         break
       case 'H': // absolute Horzontal line to
         while (pts.length >= 1) {
           cx = parseFloat(pts.shift())
-          tmpCode += `${indent}${pathName} = geometries.path2.appendPoints([[${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]], ${pathName})\n`
+          tmpCode += `${indent}${pathName} = geometries.path2.appendPoints([[${svg2cag([cx, cy], svgUnitsPmm)}]], ${pathName})\n`
         }
         break
       case 'l': // relative line to
         while (pts.length >= 2) {
           cx = cx + parseFloat(pts.shift())
           cy = cy + parseFloat(pts.shift())
-          tmpCode += `${indent}${pathName} = geometries.path2.appendPoints([[${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]], ${pathName})\n`
+          tmpCode += `${indent}${pathName} = geometries.path2.appendPoints([[${svg2cag([cx, cy], svgUnitsPmm)}]], ${pathName})\n`
         }
         break
       case 'L': // absolute line to
         while (pts.length >= 2) {
           cx = parseFloat(pts.shift())
           cy = parseFloat(pts.shift())
-          tmpCode += `${indent}${pathName} = geometries.path2.appendPoints([[${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]], ${pathName})\n`
+          tmpCode += `${indent}${pathName} = geometries.path2.appendPoints([[${svg2cag([cx, cy], svgUnitsPmm)}]], ${pathName})\n`
         }
         break
       case 'v': // relative Vertical line to
         while (pts.length >= 1) {
           cy = cy + parseFloat(pts.shift())
-          tmpCode += `${indent}${pathName} = geometries.path2.appendPoints([[${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]], ${pathName})\n`
+          tmpCode += `${indent}${pathName} = geometries.path2.appendPoints([[${svg2cag([cx, cy], svgUnitsPmm)}]], ${pathName})\n`
         }
         break
       case 'V': // absolute Vertical line to
         while (pts.length >= 1) {
           cy = parseFloat(pts.shift())
-          tmpCode += `${indent}${pathName} = geometries.path2.appendPoints([[${svg2cagX(cx, svgUnitsPmm)}, ${svg2cagY(cy, svgUnitsPmm)}]], ${pathName})\n`
+          tmpCode += `${indent}${pathName} = geometries.path2.appendPoints([[${svg2cag([cx, cy], svgUnitsPmm)}]], ${pathName})\n`
         }
         break
       case 'z': // close current line

--- a/packages/io/svg-deserializer/tests/instantiate.test.js
+++ b/packages/io/svg-deserializer/tests/instantiate.test.js
@@ -264,17 +264,17 @@ test('deserialize : instantiate svg (path: with bezier) to objects', (t) => {
   let observed = deserializer.deserialize({ output: 'geometry', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   let shape = observed[0]
-  t.is(shape.sides.length, 16)
+  t.is(shape.sides.length, 14)
 
   observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
-  t.is(shape.points.length, 16)
+  t.is(shape.points.length, 14)
 
   observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false, segments: 16 }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
-  t.is(shape.points.length, 11)
+  t.is(shape.points.length, 9)
 
   // absolute CUBIC bezier
   // relative CUBIC bezier
@@ -300,12 +300,12 @@ test('deserialize : instantiate svg (path: with bezier) to objects', (t) => {
   observed = deserializer.deserialize({ output: 'geometry', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
-  t.is(shape.sides.length, 40)
+  t.is(shape.sides.length, 28)
 
   observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
-  t.is(shape.points.length, 40)
+  t.is(shape.points.length, 28)
 
   // absolute CUBIC bezier shorthand
   // relative CUBIC bezier shorthand
@@ -334,12 +334,12 @@ test('deserialize : instantiate svg (path: with bezier) to objects', (t) => {
   observed = deserializer.deserialize({ output: 'geometry', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
-  t.is(shape.points.length, 37) // open path
+  t.is(shape.points.length, 29) // open path
 
   observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
-  t.is(shape.points.length, 37)
+  t.is(shape.points.length, 29)
 
   // test fill color
   sourceSvg = `<svg height="500" width="500">
@@ -349,13 +349,13 @@ test('deserialize : instantiate svg (path: with bezier) to objects', (t) => {
   observed = deserializer.deserialize({ output: 'geometry', target: 'geom2', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
-  t.is(shape.sides.length, 126)
+  t.is(shape.sides.length, 101)
   t.deepEqual(shape.color, [1, 0, 0, 1])
 
   observed = deserializer.deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
   shape = observed[0]
-  t.is(shape.points.length, 126)
+  t.is(shape.points.length, 101)
 })
 
 // ################################


### PR DESCRIPTION
Fix a bunch of bugs in the svg-deserializer. Specifically we were not computing quadratic bezier paths correctly.

To convert a quadratic bezier curve to a cubic curve requires generating the following control points:
```
C0 = Q0
C1 = Q0 + (2/3) (Q1 - Q0)
C2 = Q2 + (2/3) (Q1 - Q2)
C3 = Q2
```

But the code was previously doing:
```
C0 = Q0
C1 = Q1
C2 = Q1
C3 = Q2
```

Visually this means we were using the green dot twice, instead of computing the red dots:

![quad2cubic](https://user-images.githubusercontent.com/1766297/230760573-1bb43bab-518b-493a-a801-2f2b16fcca19.png)


Fixes #1222

![33](https://user-images.githubusercontent.com/1766297/230760534-0877b9c0-217f-4913-b3dd-a34874431f01.png)

Also found a bug where we were not converting svg unit for `[cx, cy]` on the svg `t` command. 

Cleaned up the code style to make more readable. Changes to functionality were only in `q`, `Q`, `t`, and `T` svg commands.


### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
