### PR TITLE
fix(cli): rework logic for generating blobs, both singular and multiple as parts

### DIFF
--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -81,13 +81,13 @@ generateOutputData(src, params, { outputFile, outputFormat, inputFile, inputForm
             if (err) {
               console.error(err)
             } else {
-              logFileOutput(zipFilename)              
+              logFileOutput(zipFilename)
             }
           })
         })
       } else {
         for (let i = 0; i < outputData.length; i++) {
-          const filename = outputFile.replace(/\.(\w+)$/, `-part-${i + 1}-of-${outputData.length}.$1`)        
+          const filename = outputFile.replace(/\.(\w+)$/, `-part-${i + 1}-of-${outputData.length}.$1`)
           logFileOutput(filename)
           writeOutput(filename, outputData[i])
         }
@@ -102,7 +102,7 @@ generateOutputData(src, params, { outputFile, outputFormat, inputFile, inputForm
             if (err) {
               console.error(err)
             } else {
-              logFileOutput(zipFilename)              
+              logFileOutput(zipFilename)
             }
           })
         })

--- a/packages/cli/cli.parameters.test.js
+++ b/packages/cli/cli.parameters.test.js
@@ -2,9 +2,15 @@ import fs from 'fs'
 import path from 'path'
 import { execSync } from 'child_process'
 import { cwd } from 'process'
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
 import JSZip from 'jszip'
 
 import test from 'ava'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename);
 
 test.afterEach.always((t) => {
   // remove files
@@ -46,7 +52,7 @@ import { primitives } from '@jscad/modeling'
 
 export const getParameterDefinitions = () => {
   return [
-    { name: 'segments', caption: 'Segements:', type: 'int', initial: 10, min: 5, max: 20, step: 1 }
+    { name: 'segments', caption: 'Segments:', type: 'int', initial: 10, min: 5, max: 20, step: 1 }
   ]
 }
 

--- a/packages/cli/cli.parameters.test.js
+++ b/packages/cli/cli.parameters.test.js
@@ -1,16 +1,15 @@
 import fs from 'fs'
-import path from 'path'
+import { dirname, resolve } from 'path'
 import { execSync } from 'child_process'
 import { cwd } from 'process'
-import { fileURLToPath } from 'url';
-import { dirname } from 'path';
+import { fileURLToPath } from 'url'
 
 import JSZip from 'jszip'
 
 import test from 'ava'
 
 const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename);
+const __dirname = dirname(__filename)
 
 test.afterEach.always((t) => {
   // remove files
@@ -36,7 +35,7 @@ test.afterEach.always((t) => {
 test.beforeEach((t) => {
   const cliName = './cli.js'
   t.context = {
-    cliPath: path.resolve(cwd(), cliName)
+    cliPath: resolve(cwd(), cliName)
   }
 })
 
@@ -65,12 +64,12 @@ export const main = (params) => {
   let ageom2 = primitives.ellipse()
   let ageom3 = primitives.ellipsoid()
 
-  ${multipart ? `return [ageom3, ageom3, ageom3]` : `return [apath2, ageom2, ageom3]`}
+  ${multipart ? 'return [ageom3, ageom3, ageom3]' : 'return [apath2, ageom2, ageom3]'}
 }
 `
 
   const fileName = `./test${id}.js`
-  const filePath = path.resolve(cwd(), fileName)
+  const filePath = resolve(cwd(), fileName)
   fs.writeFileSync(filePath, jscadScript)
   return filePath
 }
@@ -84,7 +83,7 @@ test('cli (single input file)', (t) => {
   t.context.inputPath = inputPath
 
   const outputName = `./test${testID}.stl`
-  const outputPath = path.resolve(cwd(), outputName)
+  const outputPath = resolve(cwd(), outputName)
   t.false(fs.existsSync(outputPath))
 
   t.context.outputPath = outputPath
@@ -105,7 +104,7 @@ test('cli (single input file, output format)', (t) => {
   t.context.inputPath = inputPath
 
   const outputName = `./test${testID}.dxf`
-  const outputPath = path.resolve(cwd(), outputName)
+  const outputPath = resolve(cwd(), outputName)
   t.false(fs.existsSync(outputPath))
 
   t.context.outputPath = outputPath
@@ -126,7 +125,7 @@ test('cli (single input file, output filename)', (t) => {
   t.context.inputPath = inputPath
 
   const outputName = `./test${testID}.obj`
-  const outputPath = path.resolve(cwd(), outputName)
+  const outputPath = resolve(cwd(), outputName)
   t.false(fs.existsSync(outputPath))
 
   t.context.outputPath = outputPath
@@ -146,7 +145,7 @@ test('cli (folder, output format)', (t) => {
 
   t.context.inputPath = inputPath
 
-  const folderPath = path.resolve(cwd(), './test-folder')
+  const folderPath = resolve(cwd(), './test-folder')
   t.false(fs.existsSync(folderPath))
 
   fs.mkdirSync(folderPath)
@@ -154,14 +153,14 @@ test('cli (folder, output format)', (t) => {
 
   t.context.folderPath = folderPath
 
-  const mainPath = path.resolve(cwd(), './test-folder/main.js')
+  const mainPath = resolve(cwd(), './test-folder/main.js')
   fs.renameSync(inputPath, mainPath)
   t.true(fs.existsSync(mainPath))
 
   t.context.inputPath = mainPath
 
   const outputName = './test-folder/main.dxf'
-  const outputPath = path.resolve(cwd(), outputName)
+  const outputPath = resolve(cwd(), outputName)
   t.false(fs.existsSync(outputPath))
 
   t.context.outputPath = outputPath
@@ -182,7 +181,7 @@ test('cli (single input file, parameters)', (t) => {
   t.context.inputPath = inputPath
 
   const outputName = `./test${testID}.stl`
-  const outputPath = path.resolve(cwd(), outputName)
+  const outputPath = resolve(cwd(), outputName)
   t.false(fs.existsSync(outputPath))
 
   t.context.outputPath = outputPath
@@ -220,7 +219,6 @@ test('cli (single input file, invalid jscad)', (t) => {
   })
 })
 
-
 test('cli (single input file, multiple output files)', (t) => {
   const testID = 7
 
@@ -230,9 +228,9 @@ test('cli (single input file, multiple output files)', (t) => {
   t.context.inputPath = inputPath
 
   const outputName = (partNum) => `./test${testID}-part-${partNum}-of-3.stl`
-  const outputPath1 = path.resolve(__dirname, outputName(1))
-  const outputPath2 = path.resolve(__dirname, outputName(2))
-  const outputPath3 = path.resolve(__dirname, outputName(3))
+  const outputPath1 = resolve(__dirname, outputName(1))
+  const outputPath2 = resolve(__dirname, outputName(2))
+  const outputPath3 = resolve(__dirname, outputName(3))
   t.false(fs.existsSync(outputPath1))
   t.false(fs.existsSync(outputPath2))
   t.false(fs.existsSync(outputPath3))
@@ -244,7 +242,7 @@ test('cli (single input file, multiple output files)', (t) => {
   const cliPath = t.context.cliPath
 
   const cmd = `node ${cliPath} ${inputPath} -gp`
-  execSync(cmd, { stdio: [0,1,2] })
+  execSync(cmd, { stdio: [0, 1, 2] })
   t.true(fs.existsSync(outputPath1))
   t.true(fs.existsSync(outputPath2))
   t.true(fs.existsSync(outputPath3))
@@ -259,24 +257,24 @@ test('cli (single multipart input file, zipped output file)', async (t) => {
   t.context.inputPath = inputPath
 
   const outputName = `./test${testID}.zip`
-  const outputPath = path.resolve(__dirname, outputName)
+  const outputPath = resolve(__dirname, outputName)
 
   t.false(fs.existsSync(outputPath))
-  
+
   t.context.outputPath = outputPath
 
   const cliPath = t.context.cliPath
 
   const cmd = `node ${cliPath} ${inputPath} -gp -z`
-  execSync(cmd, { stdio: [0,1,2] })
+  execSync(cmd, { stdio: [0, 1, 2] })
   t.true(fs.existsSync(outputPath))
 
   // check contents of zip file
   const data = await fs.promises.readFile(outputPath)
   const content = await JSZip.loadAsync(data)
-  t.true(content.files[path.resolve(__dirname, `./test${testID}-part-1-of-3.stl`)] !== undefined)
-  t.true(content.files[path.resolve(__dirname, `./test${testID}-part-2-of-3.stl`)] !== undefined)
-  t.true(content.files[path.resolve(__dirname, `./test${testID}-part-3-of-3.stl`)] !== undefined)
+  t.true(content.files[resolve(__dirname, `./test${testID}-part-1-of-3.stl`)] !== undefined)
+  t.true(content.files[resolve(__dirname, `./test${testID}-part-2-of-3.stl`)] !== undefined)
+  t.true(content.files[resolve(__dirname, `./test${testID}-part-3-of-3.stl`)] !== undefined)
 })
 
 test('cli (single input file, zipped output file)', async (t) => {
@@ -286,22 +284,22 @@ test('cli (single input file, zipped output file)', async (t) => {
   t.true(fs.existsSync(inputPath))
 
   t.context.inputPath = inputPath
-  
+
   const outputName = `./test${testID}.zip`
-  const outputPath = path.resolve(__dirname, outputName)
+  const outputPath = resolve(__dirname, outputName)
 
   t.false(fs.existsSync(outputPath))
-  
+
   t.context.outputPath = outputPath
 
   const cliPath = t.context.cliPath
 
   const cmd = `node ${cliPath} ${inputPath} -z`
-  execSync(cmd, { stdio: [0,1,2] })
+  execSync(cmd, { stdio: [0, 1, 2] })
   t.true(fs.existsSync(outputPath))
 
   // check contents of zip file
   const data = await fs.promises.readFile(outputPath)
   const content = await JSZip.loadAsync(data)
-  t.true(content.files[path.resolve(__dirname, `./test${testID}.stl`)] !== undefined)
+  t.true(content.files[resolve(__dirname, `./test${testID}.stl`)] !== undefined)
 })

--- a/packages/cli/src/env.js
+++ b/packages/cli/src/env.js
@@ -1,3 +1,5 @@
+import os from 'os'
+
 const version = '[VI]{version}[/VI]' // version is injected by rollup
 
 export const env = () => {
@@ -6,10 +8,7 @@ export const env = () => {
     const w = document.defaultView
     env = env + ' [' + w.navigator.userAgent + ']'
   } else {
-    if (typeof require === 'function') {
-      const os = require('os')
-      env = env + ' [' + os.type() + ':' + os.release() + ',' + os.platform() + ':' + os.arch() + ']'
-    }
+    env = env + ' [' + os.type() + ':' + os.release() + ',' + os.platform() + ':' + os.arch() + ']'
   }
   console.log(env)
 }

--- a/packages/cli/src/generateOutputData.js
+++ b/packages/cli/src/generateOutputData.js
@@ -62,11 +62,9 @@ export const generateOutputData = (source, cliParams, options) => {
   })
     .then((solids) => {
       if (Array.isArray(solids) && generateParts) {
-        return solids.map((s) => {
-          return convertSolidsToBlob({mimeType: outputMimeType, cliParams}, [s])
-        })
+        return solids.map((s) => convertSolidsToBlob({ mimeType: outputMimeType, cliParams }, [s]))
       }
-      return convertSolidsToBlob({mimeType: outputMimeType, cliParams}, solids)
+      return convertSolidsToBlob({ mimeType: outputMimeType, cliParams }, solids)
     })
 }
 
@@ -74,7 +72,7 @@ export const generateOutputData = (source, cliParams, options) => {
  * Convert the given solids to the target mimeType, and return as a blob for writing to file.
  */
 const convertSolidsToBlob = (options, solids) => {
-  const {mimeType, cliParams} = options
+  const { mimeType, cliParams } = options
 
   if (mimeType === 'application/javascript') {
     // convert the solids (source code) to blob without conversion

--- a/packages/cli/src/generateOutputData.js
+++ b/packages/cli/src/generateOutputData.js
@@ -14,11 +14,11 @@ const { registerAllExtensions } = io
  * Create a promise to convert the given source in inputFormat to the desired outputFormat.
  * The given CLI params are passed into deserializer, main, and serializer.
  * @param {String} source the original source
- * @param {Object} cliparams - parameters as provided on the command line
+ * @param {Object} cliParams - parameters as provided on the command line
  * @param {Object} options - options for conversion; inputFormat and outputFormat are required
  * @return {Promise} promise function which can convert the given source
  */
-export const generateOutputData = (source, cliparams, options) => {
+export const generateOutputData = (source, cliParams, options) => {
   const defaults = {
     outputFile: undefined,
     outputFormat: 'stl',
@@ -44,7 +44,7 @@ export const generateOutputData = (source, cliparams, options) => {
   return new Promise((resolve, reject) => {
     // convert any inputs
     const prevsource = source
-    const deserializerOptions = Object.assign({ output: 'script', filename: inputFile }, cliparams)
+    const deserializerOptions = Object.assign({ output: 'script', filename: inputFile }, cliParams)
     source = deserialize(deserializerOptions, inputMimeType, source)
     const useFakeFs = (source !== prevsource) // conversion, so use a fake file system when rebuilding
 
@@ -53,7 +53,7 @@ export const generateOutputData = (source, cliparams, options) => {
       resolve(source)
     } else {
       try {
-        const solids = rebuildGeometryCli({ mainPath: inputPath, parameterValues: cliparams, useFakeFs, source })
+        const solids = rebuildGeometryCli({ mainPath: inputPath, parameterValues: cliParams, useFakeFs, source })
         resolve(solids)
       } catch (error) {
         reject(error)
@@ -61,18 +61,27 @@ export const generateOutputData = (source, cliparams, options) => {
     }
   })
     .then((solids) => {
-      if (generateParts) {
-        let blobs = []
-        for (let i = 0; i < solids.length; i++) {
-          blobs.push(convertToBlob({ data: solids[i], mimeType: outputMimeType }))
-        }
-        return blobs
-      } else if (outputMimeType === 'application/javascript') {
-        // convert the source (solids) to blob for writing to file
-        return convertToBlob({ data: [solids], mimeType: outputMimeType })
-      } else {
-        const serializerOptions = Object.assign({}, cliparams)
-        return convertToBlob(serialize(serializerOptions, outputMimeType, solids))
+      if (Array.isArray(solids) && generateParts) {
+        return solids.map((s) => {
+          return convertSolidsToBlob({mimeType: outputMimeType, cliParams}, [s])
+        })
       }
+      return convertSolidsToBlob({mimeType: outputMimeType, cliParams}, solids)
     })
+}
+
+/*
+ * Convert the given solids to the target mimeType, and return as a blob for writing to file.
+ */
+const convertSolidsToBlob = (options, solids) => {
+  const {mimeType, cliParams} = options
+
+  if (mimeType === 'application/javascript') {
+    // convert the solids (source code) to blob without conversion
+    return convertToBlob({ data: [solids], mimeType })
+  } else {
+    // convert the solids into the mimeType via serializers
+    const serializerOptions = Object.assign({}, cliParams)
+    return convertToBlob(serialize(serializerOptions, mimeType, solids))
+  }
 }

--- a/packages/cli/src/parseArgs.js
+++ b/packages/cli/src/parseArgs.js
@@ -17,7 +17,8 @@ export const parseArgs = (args) => {
   // hint: https://github.com/substack/node-optimist
   //       https://github.com/visionmedia/commander.js
   if (args.length < 1) {
-    console.log('USAGE:\n\njscad [-v] <file> [-of <format>] [-o <output>]')
+    console.log('USAGE:\n\njscad [-v]\n\n')
+    console.log('jscad [-gp] [-z] <file> [-of <format>] [-o <output>]')
     console.log(`\t<file>  :\tinput (Supported types: folder, .${inputExtensions.join(', .')})`)
     console.log(`\t<output>:\toutput (Supported types: folder, .${outputExtensions.join(', .')})`)
     console.log(`\t<format>:\t${outputFormats.join(', ')}`)

--- a/packages/modeling/src/measurements/measureBoundingSphere.d.ts
+++ b/packages/modeling/src/measurements/measureBoundingSphere.d.ts
@@ -1,9 +1,6 @@
 import { Geometry } from '../geometries/types'
 import RecursiveArray from '../utils/recursiveArray'
 
-type Centroid = [number, number, number]
+import { BoundingSphere } from './types'
 
-export default measureBoundingSphere
-
-declare function measureBoundingSphere(geometry: Geometry): [Centroid, number]
-declare function measureBoundingSphere(...geometries: RecursiveArray<Geometry>): [Centroid, number][]
+export function measureBoundingSphere(...geometries: RecursiveArray<Geometry>): BoundingSphere

--- a/packages/modeling/src/measurements/measureCenter.d.ts
+++ b/packages/modeling/src/measurements/measureCenter.d.ts
@@ -1,7 +1,5 @@
 import { Geometry } from '../geometries/types'
 import RecursiveArray from '../utils/recursiveArray'
 
-export default measureCenter
-
-declare function measureCenter(geometry: Geometry): [number, number, number]
-declare function measureCenter(...geometries: RecursiveArray<Geometry>): [number, number, number][]
+export function measureCenter(geometry: Geometry): [number, number, number]
+export function measureCenter(...geometries: RecursiveArray<Geometry>): [number, number, number][]

--- a/packages/modeling/src/measurements/measureCenterOfMass.d.ts
+++ b/packages/modeling/src/measurements/measureCenterOfMass.d.ts
@@ -1,7 +1,5 @@
 import { Geometry } from '../geometries/types'
 import RecursiveArray from '../utils/recursiveArray'
 
-export default measureCenterOfMass
-
-declare function measureCenterOfMass(geometry: Geometry): [number, number, number]
-declare function measureCenterOfMass(...geometries: RecursiveArray<Geometry>): [number, number, number][]
+export function measureCenterOfMass(geometry: Geometry): [number, number, number]
+export function measureCenterOfMass(...geometries: RecursiveArray<Geometry>): [number, number, number][]

--- a/packages/modeling/src/measurements/measureDimensions.d.ts
+++ b/packages/modeling/src/measurements/measureDimensions.d.ts
@@ -1,7 +1,5 @@
 import { Geometry } from '../geometries/types'
 import RecursiveArray from '../utils/recursiveArray'
 
-export default measureDimensions
-
-declare function measureDimensions(geometry: Geometry): [number, number, number]
-declare function measureDimensions(...geometries: RecursiveArray<Geometry>): [number, number, number][]
+export function measureDimensions(geometry: Geometry): [number, number, number]
+export function measureDimensions(...geometries: RecursiveArray<Geometry>): [number, number, number][]

--- a/packages/modeling/src/measurements/types.d.ts
+++ b/packages/modeling/src/measurements/types.d.ts
@@ -1,3 +1,4 @@
 import { Vec3 } from '../maths/vec3/type'
 
 export type BoundingBox = [Vec3, Vec3]
+export type BoundingSphere = [Vec3, number]


### PR DESCRIPTION
Corrections to the CLI to generate blobs correctly as singular or multiple parts. The generate parts option now works properly.

NOTE: There are also some changes to the Typescript definitions in order to get the CI running again.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Does your submission pass tests?