### PR TITLE
feat(modeling): preserve color for offset and extrude 

### DIFF
--- a/packages/modeling/src/geometries/geom2/reverse.js
+++ b/packages/modeling/src/geometries/geom2/reverse.js
@@ -13,5 +13,6 @@ import { clone } from './clone.js'
 export const reverse = (geometry) => {
   const reversed = clone(geometry)
   reversed.outlines = reversed.outlines.map((outline) => outline.slice().reverse())
+  if (geometry.color) reversed.color = geometry.color
   return reversed
 }

--- a/packages/modeling/src/geometries/geom2/reverse.js
+++ b/packages/modeling/src/geometries/geom2/reverse.js
@@ -1,4 +1,5 @@
-import { clone } from './clone.js'
+import { create } from './create.js'
+import { toOutlines } from './toOutlines.js'
 
 /**
  * Reverses the given geometry so that the outline points are flipped in the opposite order.
@@ -11,8 +12,9 @@ import { clone } from './clone.js'
  * let newGeometry = reverse(geometry)
  */
 export const reverse = (geometry) => {
-  const reversed = clone(geometry)
-  reversed.outlines = reversed.outlines.map((outline) => outline.slice().reverse())
+  const outlines = toOutlines(geometry)
+    .map((outline) => outline.slice().reverse())
+  const reversed = create(outlines)
   if (geometry.color) reversed.color = geometry.color
   return reversed
 }

--- a/packages/modeling/src/geometries/geom2/reverse.test.js
+++ b/packages/modeling/src/geometries/geom2/reverse.test.js
@@ -1,5 +1,7 @@
 import test from 'ava'
 
+import { colorize } from '../../colors/index.js'
+
 import { create, reverse, toPoints } from './index.js'
 
 import { comparePoints, compareVectors } from '../../../test/helpers/index.js'
@@ -28,4 +30,11 @@ test('reverse: does not modify input geometry', (t) => {
   t.not(geometry, another)
   t.true(comparePoints(toPoints(geometry), forward))
   t.true(comparePoints(toPoints(another), backward))
+})
+
+test('reverse: preserves color', (t) => {
+  const points = [[0, 0], [1, 0], [0, 1]]
+  const geometry = colorize([1, 0, 0], create([points]))
+  const reversed = reverse(geometry)
+  t.deepEqual(reversed.color, [1, 0, 0, 1])
 })

--- a/packages/modeling/src/operations/extrusions/extrudeLinear.test.js
+++ b/packages/modeling/src/operations/extrusions/extrudeLinear.test.js
@@ -40,12 +40,12 @@ test('extrudeLinear (defaults)', (t) => {
 })
 
 test('extrudeLinear: preserves color', (t) => {
-  const red = colorize([1, 0, 0], square())
-  const extruded = extrudeLinear({ }, red)
+  const redSquare = colorize([1, 0, 0], square())
+  const extruded = extrudeLinear({ }, redSquare)
   t.deepEqual(extruded.color, [1, 0, 0, 1])
 
   // one red, one blue
-  const out = extrudeLinear({ }, [red, square()])
+  const out = extrudeLinear({ }, [redSquare, square()])
   t.deepEqual(out[0].color, [1, 0, 0, 1])
   t.is(out[1].color, undefined)
 })

--- a/packages/modeling/src/operations/extrusions/extrudeLinear.test.js
+++ b/packages/modeling/src/operations/extrusions/extrudeLinear.test.js
@@ -4,6 +4,8 @@ import { comparePolygonsAsPoints } from '../../../test/helpers/index.js'
 
 import { TAU } from '../../maths/constants.js'
 
+import { colorize } from '../../colors/index.js'
+
 import { geom2, geom3, path2 } from '../../geometries/index.js'
 
 import { measureVolume } from '../../measurements/index.js'
@@ -35,6 +37,17 @@ test('extrudeLinear (defaults)', (t) => {
   t.is(measureVolume(geometry3), 100.00000000000001)
   t.is(pts.length, 12)
   t.true(comparePolygonsAsPoints(pts, exp))
+})
+
+test('extrudeLinear: preserves color', (t) => {
+  const red = colorize([1, 0, 0], square())
+  const extruded = extrudeLinear({ }, red)
+  t.deepEqual(extruded.color, [1, 0, 0, 1])
+
+  // one red, one blue
+  const out = extrudeLinear({ }, [red, square()])
+  t.deepEqual(out[0].color, [1, 0, 0, 1])
+  t.is(out[1].color, undefined)
 })
 
 test('extrudeLinear (no twist)', (t) => {

--- a/packages/modeling/src/operations/extrusions/extrudeLinearGeom2.js
+++ b/packages/modeling/src/operations/extrusions/extrudeLinearGeom2.js
@@ -53,5 +53,7 @@ export const extrudeLinearGeom2 = (options, geometry) => {
     repair,
     callback: createTwist
   }
-  return extrudeFromSlices(options, baseSlice)
+  const output = extrudeFromSlices(options, baseSlice)
+  if (geometry.color) output.color = geometry.color
+  return output
 }

--- a/packages/modeling/src/operations/extrusions/extrudeLinearPath2.js
+++ b/packages/modeling/src/operations/extrusions/extrudeLinearPath2.js
@@ -18,5 +18,6 @@ export const extrudeLinearPath2 = (options, geometry) => {
   // Convert path2 to geom2
   const points = path2.toPoints(geometry)
   const geometry2 = geom2.create([points])
+  if (geometry.color) geometry2.color = geometry.color
   return extrudeLinearGeom2(options, geometry2)
 }

--- a/packages/modeling/src/operations/extrusions/extrudeRotate.js
+++ b/packages/modeling/src/operations/extrusions/extrudeRotate.js
@@ -59,6 +59,7 @@ export const extrudeRotate = (options, geometry) => {
   // convert geometry to an array of sides, easier to deal with
   let shapeSides = geom2.toSides(geometry)
   if (shapeSides.length === 0) throw new Error('the given geometry cannot be empty')
+  let sliceGeometry = geometry
 
   // determine if the extrusion can be computed in the first place
   // ie all the points have to be either x > 0 or x < 0
@@ -87,8 +88,8 @@ export const extrudeRotate = (options, geometry) => {
         return [point0, point1]
       })
       // recreate the geometry from the (-) capped points
-      geometry = geom2.reverse(geom2.fromSides(shapeSides))
-      geometry = mirrorX(geometry)
+      sliceGeometry = geom2.reverse(geom2.fromSides(shapeSides))
+      sliceGeometry = mirrorX(sliceGeometry)
     } else if (pointsWithPositiveX.length >= pointsWithNegativeX.length) {
       shapeSides = shapeSides.map((side) => {
         let point0 = side[0]
@@ -98,13 +99,13 @@ export const extrudeRotate = (options, geometry) => {
         return [point0, point1]
       })
       // recreate the geometry from the (+) capped points
-      geometry = geom2.fromSides(shapeSides)
+      sliceGeometry = geom2.fromSides(shapeSides)
     }
   }
 
   const rotationPerSlice = totalRotation / segments
   const isCapped = Math.abs(totalRotation) < TAU
-  let baseSlice = slice.fromGeom2(geometry)
+  let baseSlice = slice.fromGeom2(sliceGeometry)
   baseSlice = slice.reverse(baseSlice)
 
   const matrix = mat4.create()
@@ -126,5 +127,7 @@ export const extrudeRotate = (options, geometry) => {
     close: !isCapped,
     callback: createSlice
   }
-  return extrudeFromSlices(options, baseSlice)
+  const output = extrudeFromSlices(options, baseSlice)
+  if (geometry.color) output.color = geometry.color
+  return output
 }

--- a/packages/modeling/src/operations/extrusions/extrudeRotate.js
+++ b/packages/modeling/src/operations/extrusions/extrudeRotate.js
@@ -58,7 +58,7 @@ export const extrudeRotate = (options, geometry) => {
 
   // convert geometry to an array of sides, easier to deal with
   let shapeSides = geom2.toSides(geometry)
-  if (shapeSides.length === 0) throw new Error('the given geometry cannot be empty')
+  if (shapeSides.length === 0) return geometry
   let sliceGeometry = geometry
 
   // determine if the extrusion can be computed in the first place

--- a/packages/modeling/src/operations/extrusions/extrudeRotate.test.js
+++ b/packages/modeling/src/operations/extrusions/extrudeRotate.test.js
@@ -4,9 +4,13 @@ import { comparePoints, comparePolygonsAsPoints } from '../../../test/helpers/in
 
 import { TAU } from '../../maths/constants.js'
 
+import { colorize } from '../../colors/index.js'
+
 import { geom2, geom3 } from '../../geometries/index.js'
 
 import { measureVolume } from '../../measurements/index.js'
+
+import { square } from '../../primitives/index.js'
 
 import { extrudeRotate } from './index.js'
 
@@ -18,6 +22,12 @@ test('extrudeRotate: (defaults) extruding of a geom2 produces an expected geom3'
   t.notThrows(() => geom3.validate(geometry3))
   t.is(measureVolume(geometry3), 27648.000000000007)
   t.is(pts.length, 96)
+})
+
+test('extrudeRotate: preserves color', (t) => {
+  const red = colorize([1, 0, 0], square())
+  const extruded = extrudeRotate({ }, red)
+  t.deepEqual(extruded.color, [1, 0, 0, 1])
 })
 
 test('extrudeRotate: (angle) extruding of a geom2 produces an expected geom3', (t) => {

--- a/packages/modeling/src/operations/extrusions/project.js
+++ b/packages/modeling/src/operations/extrusions/project.js
@@ -56,7 +56,9 @@ const projectGeom3 = (options, geometry) => {
     return geom2.create([cloned])
   })
 
-  return unionGeom2(projGeoms)
+  const output = unionGeom2(projGeoms)
+  if (geometry.color) output.color = geometry.color
+  return output
 }
 
 /**

--- a/packages/modeling/src/operations/extrusions/project.test.js
+++ b/packages/modeling/src/operations/extrusions/project.test.js
@@ -143,7 +143,14 @@ test('project torus (martinez issue #155)', (t) => {
 })
 
 test('project: preserves color', (t) => {
-  const red = colorize([1, 0, 0], cube())
-  const result = project({ }, red)
+  const redCube = colorize([1, 0, 0], cube())
+  const result = project({ }, redCube)
   t.deepEqual(result.color, [1, 0, 0, 1])
+})
+
+test('project: empty geometry', (t) => {
+  const obj = geom3.create()
+  const result = project({ }, obj)
+  t.notThrows(() => geom2.validate(result))
+  t.is(measureArea(result), 0)
 })

--- a/packages/modeling/src/operations/extrusions/project.test.js
+++ b/packages/modeling/src/operations/extrusions/project.test.js
@@ -2,6 +2,8 @@ import test from 'ava'
 
 import { comparePoints } from '../../../test/helpers/index.js'
 
+import { colorize } from '../../colors/index.js'
+
 import { geom2, geom3 } from '../../geometries/index.js'
 
 import { measureArea } from '../../measurements/index.js'
@@ -138,4 +140,10 @@ test('project torus (martinez issue #155)', (t) => {
   )
   t.notThrows(() => geom2.validate(result))
   t.is(measureArea(result), 21.15545050788201)
+})
+
+test('project: preserves color', (t) => {
+  const red = colorize([1, 0, 0], cube())
+  const result = project({ }, red)
+  t.deepEqual(result.color, [1, 0, 0, 1])
 })

--- a/packages/modeling/src/operations/hulls/hull.test.js
+++ b/packages/modeling/src/operations/hulls/hull.test.js
@@ -1,9 +1,8 @@
 import test from 'ava'
 
 import { geom2, geom3, path2 } from '../../geometries/index.js'
-
+import { measureArea } from '../../measurements/measureArea.js'
 import { sphere, cuboid, ellipsoid } from '../../primitives/index.js'
-
 import { center } from '../transforms/index.js'
 
 import { hull } from './index.js'
@@ -15,15 +14,15 @@ test('hull (single, geom2)', (t) => {
 
   let obs = hull(geometry)
   let pts = geom2.toPoints(obs)
-
-  t.notThrows(() => geom2.validate(geometry))
+  t.notThrows(() => geom2.validate(obs))
+  t.is(measureArea(obs), 0)
   t.is(pts.length, 0)
 
   geometry = geom2.create([[[5, 5], [-5, 5], [-5, -5], [5, -5]]])
   obs = hull(geometry)
   pts = geom2.toPoints(obs)
-
-  t.notThrows(() => geom2.validate(geometry))
+  t.notThrows(() => geom2.validate(obs))
+  t.is(measureArea(obs), 100)
   t.is(pts.length, 4)
 
   // convex C shape
@@ -41,8 +40,7 @@ test('hull (single, geom2)', (t) => {
   ]])
   obs = hull(geometry)
   pts = geom2.toPoints(obs)
-
-  t.notThrows(() => geom2.validate(geometry))
+  t.notThrows(() => geom2.validate(obs))
   t.is(pts.length, 7)
 })
 

--- a/packages/modeling/src/operations/hulls/hullChain.js
+++ b/packages/modeling/src/operations/hulls/hullChain.js
@@ -31,9 +31,11 @@ import { hull } from './hull.js'
  */
 export const hullChain = (...geometries) => {
   geometries = flatten(geometries)
-  if (geometries.length < 2) throw new Error('wrong number of arguments')
-
   const hulls = []
+
+  if (geometries.length === 0) throw new Error('wrong number of arguments')
+  if (geometries.length === 1) hulls.push(geometries[0])
+
   for (let i = 1; i < geometries.length; i++) {
     hulls.push(hull(geometries[i - 1], geometries[i]))
   }

--- a/packages/modeling/src/operations/hulls/hullChain.test.js
+++ b/packages/modeling/src/operations/hulls/hullChain.test.js
@@ -1,8 +1,17 @@
 import test from 'ava'
 
 import { geom2, geom3 } from '../../geometries/index.js'
+import { measureArea } from '../../measurements/measureArea.js'
+import { square } from '../../primitives/square.js'
 
 import { hullChain } from './index.js'
+
+test('hullChain: hullChain single geometry', (t) => {
+  const result = hullChain([ square({ size: 1 }) ])
+  t.notThrows(() => geom2.validate(result))
+  t.is(measureArea(result), 1)
+  t.is(geom2.toPoints(result).length, 4)
+})
 
 test('hullChain (two, geom2)', (t) => {
   const geometry1 = geom2.create([[[6, 6], [3, 6], [3, 3], [6, 3]]])

--- a/packages/modeling/src/operations/offsets/offsetFromPoints.js
+++ b/packages/modeling/src/operations/offsets/offsetFromPoints.js
@@ -27,6 +27,7 @@ export const offsetFromPoints = (options, points) => {
   let { delta, corners, closed, segments } = Object.assign({ }, defaults, options)
 
   if (Math.abs(delta) < EPS) return points
+  if (points.length < 2) return points
 
   let rotation = options.closed ? area(points) : 1.0 // + counter clockwise, - clockwise
   if (rotation === 0) rotation = 1.0

--- a/packages/modeling/src/operations/offsets/offsetFromPoints.test.js
+++ b/packages/modeling/src/operations/offsets/offsetFromPoints.test.js
@@ -7,6 +7,16 @@ import { offsetFromPoints } from './index.js'
 
 import { comparePoints } from '../../../test/helpers/index.js'
 
+test('offset: offset empty points', (t) => {
+  const offsetPoints = offsetFromPoints({ }, [])
+  t.is(offsetPoints.length, 0)
+})
+
+test('offset: offset single point', (t) => {
+  const offsetPoints = offsetFromPoints({ corners: 'round' }, [[2, 2]])
+  t.is(offsetPoints.length, 1)
+})
+
 test('offset: offsetting a straight line produces expected geometry', (t) => {
   const points = [[0, 0], [0, 10]]
 

--- a/packages/modeling/src/operations/offsets/offsetGeom2.js
+++ b/packages/modeling/src/operations/offsets/offsetGeom2.js
@@ -46,7 +46,10 @@ export const offsetGeom2 = (options, geometry) => {
     }
     return offsetFromPoints(options, outline)
   })
+  // TODO: union outlines that expanded into each other
 
   // create a composite geometry from the new outlines
-  return geom2.create(newOutlines)
+  const output = geom2.create(newOutlines)
+  if (geometry.color) output.color = geometry.color
+  return output
 }

--- a/packages/modeling/src/operations/offsets/offsetGeom2.test.js
+++ b/packages/modeling/src/operations/offsets/offsetGeom2.test.js
@@ -1,9 +1,8 @@
 import test from 'ava'
 
+import { colorize } from '../../colors/index.js'
 import { geom2 } from '../../geometries/index.js'
-
 import { measureArea } from '../../measurements/index.js'
-
 import { roundedRectangle, square } from '../../primitives/index.js'
 
 import { offset } from './index.js'
@@ -12,12 +11,10 @@ import { comparePoints } from '../../../test/helpers/index.js'
 
 test('offset: offset an empty geom2', (t) => {
   const empty = geom2.create()
-  const obs = offset({ delta: 1 }, empty)
-  const pts = geom2.toPoints(obs)
-  const exp = []
-  t.notThrows(() => geom2.validate(obs))
-  t.is(measureArea(obs), 0)
-  t.true(comparePoints(pts, exp))
+  const result = offset({ delta: 1 }, empty)
+  t.notThrows(() => geom2.validate(result))
+  t.is(measureArea(result), 0)
+  t.is(geom2.toPoints(result).length, 0)
 })
 
 test('offset: offset option validation', (t) => {
@@ -36,6 +33,12 @@ test('offset: offset option validation', (t) => {
   t.throws(() => offset({ corners: undefined }, empty), { message: 'corners must be "edge", "chamfer", or "round"' })
   t.throws(() => offset({ corners: 4 }, empty), { message: 'corners must be "edge", "chamfer", or "round"' })
   t.throws(() => offset({ corners: 'fluffy' }, empty), { message: 'corners must be "edge", "chamfer", or "round"' })
+})
+
+test('offset: offset geom2 preserves color', (t) => {
+  const geometry = colorize([1, 0, 0], square({ }))
+  const result = offset({ }, geometry)
+  t.deepEqual(result.color, [1, 0, 0, 1])
 })
 
 test('offset: offset of a geom2 produces expected changes to points', (t) => {

--- a/packages/modeling/src/operations/offsets/offsetGeom3.js
+++ b/packages/modeling/src/operations/offsets/offsetGeom3.js
@@ -25,10 +25,9 @@ export const offsetGeom3 = (options, geometry) => {
     throw new Error('corners must be "round" for 3D geometries')
   }
 
-  const polygons = geom3.toPolygons(geometry)
-  if (polygons.length === 0) throw new Error('the given geometry cannot be empty')
-
   options = { delta, corners, segments }
   const expanded = offsetShell(options, geometry)
-  return union(geometry, expanded)
+  const output = union(geometry, expanded)
+  if (geometry.color) output.color = geometry.color
+  return output
 }

--- a/packages/modeling/src/operations/offsets/offsetGeom3.test.js
+++ b/packages/modeling/src/operations/offsets/offsetGeom3.test.js
@@ -2,11 +2,27 @@ import test from 'ava'
 
 import { comparePoints } from '../../../test/helpers/index.js'
 
+import { colorize } from '../../colors/index.js'
 import { geom3, poly3 } from '../../geometries/index.js'
-
-import { sphere } from '../../primitives/index.js'
+import { measureVolume } from '../../measurements/index.js'
+import { cube, sphere } from '../../primitives/index.js'
 
 import { offset } from './index.js'
+
+test('offset: offset empty geom3', (t) => {
+  const geometry = geom3.create()
+  const result = offset({ }, geometry)
+  t.notThrows(() => geom3.validate(result))
+  t.is(measureVolume(result), 0)
+  t.is(geom3.toPolygons(result).length, 0)
+  t.is(geom3.toPoints(result).length, 0)
+})
+
+test('offset: offset geom3 preserves color', (t) => {
+  const geometry = colorize([1, 0, 0], cube({ }))
+  const result = offset({ }, geometry)
+  t.deepEqual(result.color, [1, 0, 0, 1])
+})
 
 test('offset: offset of a geom3 produces expected changes to polygons', (t) => {
   const polygonsAsPoints = [

--- a/packages/modeling/src/operations/offsets/offsetPath2.js
+++ b/packages/modeling/src/operations/offsets/offsetPath2.js
@@ -4,11 +4,13 @@ import * as vec2 from '../../maths/vec2/index.js'
 
 import * as geom2 from '../../geometries/geom2/index.js'
 import * as path2 from '../../geometries/path2/index.js'
+import { circle } from '../../primitives/circle.js'
 
 import { offsetFromPoints } from './offsetFromPoints.js'
 
-const createGeometryFromClosedOffsets = (paths) => {
+const createGeometryFromClosedPath = (paths) => {
   let { external, internal } = paths
+  if (external.length < 2) return geom2.create()
   if (area(external) < 0) {
     external = external.reverse()
   } else {
@@ -17,8 +19,10 @@ const createGeometryFromClosedOffsets = (paths) => {
   return geom2.create([external, internal])
 }
 
-const createGeometryFromExpandedOpenPath = (paths, segments, corners, delta) => {
+const createGeometryFromOpenPath = (paths, segments, corners, delta) => {
   const { points, external, internal } = paths
+  if (points.length === 0) return geom2.create()
+  if (points.length === 1) return circle({ center: points[0], radius: delta })
   const capSegments = Math.floor(segments / 2) // rotation is 180 degrees
   const e2iCap = []
   const i2eCap = []
@@ -74,7 +78,6 @@ export const offsetPath2 = (options, geometry) => {
 
   const closed = geometry.isClosed
   const points = path2.toPoints(geometry)
-  if (points.length === 0) return geometry
 
   const paths = {
     points,
@@ -83,8 +86,8 @@ export const offsetPath2 = (options, geometry) => {
   }
 
   const output = geometry.isClosed ?
-    createGeometryFromClosedOffsets(paths) :
-    createGeometryFromExpandedOpenPath(paths, segments, corners, delta)
+    createGeometryFromClosedPath(paths) :
+    createGeometryFromOpenPath(paths, segments, corners, delta)
   if (geometry.color) output.color = geometry.color
   return output
 }

--- a/packages/modeling/src/operations/offsets/offsetPath2.js
+++ b/packages/modeling/src/operations/offsets/offsetPath2.js
@@ -74,17 +74,17 @@ export const offsetPath2 = (options, geometry) => {
 
   const closed = geometry.isClosed
   const points = path2.toPoints(geometry)
-  if (points.length === 0) throw new Error('the given geometry cannot be empty')
+  if (points.length === 0) return geometry
 
   const paths = {
-    points: points,
+    points,
     external: offsetFromPoints({ delta, corners, segments, closed }, points),
     internal: offsetFromPoints({ delta: -delta, corners, segments, closed }, points)
   }
 
-  if (geometry.isClosed) {
-    return createGeometryFromClosedOffsets(paths)
-  } else {
-    return createGeometryFromExpandedOpenPath(paths, segments, corners, delta)
-  }
+  const output = geometry.isClosed ?
+    createGeometryFromClosedOffsets(paths) :
+    createGeometryFromExpandedOpenPath(paths, segments, corners, delta)
+  if (geometry.color) output.color = geometry.color
+  return output
 }

--- a/packages/modeling/src/operations/offsets/offsetPath2.test.js
+++ b/packages/modeling/src/operations/offsets/offsetPath2.test.js
@@ -2,13 +2,28 @@ import test from 'ava'
 
 import { comparePoints, nearlyEqual } from '../../../test/helpers/index.js'
 
+import { colorize } from '../../colors/index.js'
 import { geom2, geom3, path2 } from '../../geometries/index.js'
-import { measureBoundingBox } from '../../measurements/index.js'
+import { measureArea, measureBoundingBox } from '../../measurements/index.js'
 import { area } from '../../maths/utils/index.js'
 import { TAU } from '../../maths/constants.js'
 import { sphere, square } from '../../primitives/index.js'
 
 import { offset } from './index.js'
+
+test('offset: offset empty path2', (t) => {
+  const geometry = path2.create()
+  const result = offset({ }, geometry)
+  t.notThrows(() => path2.validate(result))
+  t.is(measureArea(result), 0)
+  t.is(path2.toPoints(result).length, 0)
+})
+
+test('offset: offset path2 preserves color', (t) => {
+  const geometry = colorize([1, 0, 0], path2.create())
+  const result = offset({ }, geometry)
+  t.deepEqual(result.color, [1, 0, 0, 1])
+})
 
 test('offset: edge-expanding a straight line produces rectangle', (t) => {
   const points = [[0, 0], [0, 10]]

--- a/packages/modeling/src/operations/offsets/offsetPath2.test.js
+++ b/packages/modeling/src/operations/offsets/offsetPath2.test.js
@@ -3,20 +3,35 @@ import test from 'ava'
 import { comparePoints, nearlyEqual } from '../../../test/helpers/index.js'
 
 import { colorize } from '../../colors/index.js'
-import { geom2, geom3, path2 } from '../../geometries/index.js'
+import { geom2, path2 } from '../../geometries/index.js'
 import { measureArea, measureBoundingBox } from '../../measurements/index.js'
 import { area } from '../../maths/utils/index.js'
 import { TAU } from '../../maths/constants.js'
-import { sphere, square } from '../../primitives/index.js'
 
 import { offset } from './index.js'
 
 test('offset: offset empty path2', (t) => {
   const geometry = path2.create()
-  const result = offset({ }, geometry)
-  t.notThrows(() => path2.validate(result))
+  const result = offset({ corners: 'round' }, geometry)
+  t.notThrows(() => geom2.validate(result))
   t.is(measureArea(result), 0)
-  t.is(path2.toPoints(result).length, 0)
+  t.is(geom2.toPoints(result).length, 0)
+})
+
+test('offset: offset empty path2 closed', (t) => {
+  const geometry = path2.fromPoints({ closed: true }, [])
+  const result = offset({ }, geometry)
+  t.notThrows(() => geom2.validate(result))
+  t.is(measureArea(result), 0)
+  t.is(geom2.toPoints(result).length, 0)
+})
+
+test('offset: offset single point path2 round', (t) => {
+  const geometry = path2.create([[2, 2]])
+  const result = offset({ delta: 1, corners: 'round', segments: 16 }, geometry)
+  t.notThrows(() => geom2.validate(result))
+  nearlyEqual(t, measureArea(result), 3.12, 0.01)
+  t.is(geom2.toPoints(result).length, 32)
 })
 
 test('offset: offset path2 preserves color', (t) => {

--- a/packages/modeling/src/operations/offsets/offsetShell.js
+++ b/packages/modeling/src/operations/offsets/offsetShell.js
@@ -71,9 +71,6 @@ export const offsetShell = (options, geometry) => {
   }
   const { delta, segments } = Object.assign({ }, defaults, options)
 
-  const polygons = geom3.toPolygons(geometry)
-  if (polygons.length === 0) return geometry
-
   let result = geom3.create()
   const vertices2planes = new Map() // {vertex: [vertex, [plane, ...]]}
   const edges2planes = new Map() // {edge: [[vertex, vertex], [plane, ...]]}
@@ -85,7 +82,8 @@ export const offsetShell = (options, geometry) => {
   // - extruded the polygon, and add to the composite result
   // - add the plane to the unique vertex map
   // - add the plane to the unique edge map
-  polygons.forEach((polygon, index) => {
+  const polygons = geom3.toPolygons(geometry)
+  polygons.forEach((polygon) => {
     const extrudeVector = vec3.scale(vec3.create(), poly3.plane(polygon), 2 * delta)
     const translatedPolygon = poly3.transform(mat4.fromTranslation(mat4.create(), vec3.scale(vec3.create(), extrudeVector, -0.5)), polygon)
     const extrudedFace = extrudePolygon(extrudeVector, translatedPolygon)

--- a/packages/modeling/src/operations/offsets/offsetShell.js
+++ b/packages/modeling/src/operations/offsets/offsetShell.js
@@ -71,6 +71,9 @@ export const offsetShell = (options, geometry) => {
   }
   const { delta, segments } = Object.assign({ }, defaults, options)
 
+  const polygons = geom3.toPolygons(geometry)
+  if (polygons.length === 0) return geometry
+
   let result = geom3.create()
   const vertices2planes = new Map() // {vertex: [vertex, [plane, ...]]}
   const edges2planes = new Map() // {edge: [[vertex, vertex], [plane, ...]]}
@@ -82,7 +85,6 @@ export const offsetShell = (options, geometry) => {
   // - extruded the polygon, and add to the composite result
   // - add the plane to the unique vertex map
   // - add the plane to the unique edge map
-  const polygons = geom3.toPolygons(geometry)
   polygons.forEach((polygon, index) => {
     const extrudeVector = vec3.scale(vec3.create(), poly3.plane(polygon), 2 * delta)
     const translatedPolygon = poly3.transform(mat4.fromTranslation(mat4.create(), vec3.scale(vec3.create(), extrudeVector, -0.5)), polygon)


### PR DESCRIPTION
This PR preserves the color attribute when applying operations like `offset` and `extrude` and `project`.

This seems like a clear improvement for users of JSCAD. If you have a 2D object with color like on the left, would you expect extrusion to preserve the color? Or lose it?

![extrudeColor](https://github.com/jscad/OpenJSCAD.org/assets/1766297/275086b8-3fd1-4049-8df1-059db413fe3e)

<details>
  <summary>preserve-color.js</summary>

```js
import * as jscad from '@jscad/modeling'
const { colorize } = jscad.colors
const { extrudeLinear } = jscad.extrusions
const { square } = jscad.primitives
const { translate } = jscad.transforms

export const main = () => {
  const obj2d = [
    colorize([1, 0, 0], square({ center: [0, -4] })),
    colorize([0, 1, 0], square({ center: [0, 0] })),
    colorize([0, 0, 1], square({ center: [0, 4] })),
  ]
  return [
    translate([-4, 0], obj2d),
    translate([4, 0, 0], extrudeLinear({}, obj2d)),
  ]
}
```

</details>

If someone really want no color, it's easy to remove using `colorize`. But if you _want_ to preserve color of sub-components through an operation... there's really no good way to do it without this change.



### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
