### PR TITLE
V3 prerelease part 3

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -24,7 +24,7 @@
       "packages/modeling/src/maths/vec4",
       "packages/modeling/src/measurements",
       "packages/modeling/src/operations/booleans",
-      "packages/modeling/src/operations/expansions",
+      "packages/modeling/src/operations/offsets",
       "packages/modeling/src/operations/extrusions",
       "packages/modeling/src/operations/hulls",
       "packages/modeling/src/operations/modifiers",

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
   "npmClient": "pnpm",
   "command": {
     "version": {
-      "allowBranch": "v3-prerelease",
+      "allowBranch": "v3-prerelease-part-3",
       "conventionalCommits": true,
       "exact": true,
       "message": "chore(release): publish",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "web": "cd ./packages/web && pnpm run dev",
     "preversion": "pnpm run test && pnpm run docs",
     "publish": "lerna publish --include-merged-tags --no-private --no-push --conventional-prerelease --dist-tag alpha --pre-dist-tag alpha",
-    "publish-dryrun": "lerna version --include-merged-tags --no-private --no-push --conventional-prerelease"
+    "publish-dryrun": "lerna version premajor --include-merged-tags --no-private --no-push --conventional-prerelease"
   },
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "graph": "lerna list --graph",
     "list": "lerna ls",
     "web": "cd ./packages/web && pnpm run dev",
-    "preversion": "pnpm run test && pnpm run docs",
+    "preversion": "pnpm run test && pnpm run test:tsd && pnpm run docs",
     "publish": "lerna publish --include-merged-tags --no-private --no-push --conventional-prerelease --dist-tag alpha --pre-dist-tag alpha",
     "publish-dryrun": "lerna version premajor --include-merged-tags --no-private --no-push --conventional-prerelease"
   },

--- a/packages/io/amf-deserializer/package.json
+++ b/packages/io/amf-deserializer/package.json
@@ -5,9 +5,8 @@
   "repository": "https://github.com/jscad/OpenJSCAD.org/",
   "main": "src/index.js",
   "type": "module",
+  "private": true,
   "scripts": {
-    "coverage": "c8 --all --reporter=html --reporter=text npm test",
-    "test": "ava --verbose --timeout 2m 'tests/**/*.test.js'"
   },
   "contributors": [
     {

--- a/packages/io/amf-serializer/package.json
+++ b/packages/io/amf-serializer/package.json
@@ -6,9 +6,8 @@
   "repository": "https://github.com/jscad/OpenJSCAD.org",
   "main": "src/index.js",
   "type": "module",
+  "private": true,
   "scripts": {
-    "coverage": "c8 --all --reporter=html --reporter=text npm test",
-    "test": "ava --verbose --timeout 2m 'tests/**/*.test.js'"
   },
   "contributors": [
     {

--- a/packages/io/test/package.json
+++ b/packages/io/test/package.json
@@ -1,5 +1,6 @@
 {
   "name": "test",
   "version": "0.0.0",
-  "type": "module"
+  "type": "module",
+  "private": true
 }

--- a/packages/modeling/src/maths/mat4/invert.d.ts
+++ b/packages/modeling/src/maths/mat4/invert.d.ts
@@ -1,0 +1,3 @@
+import type { Mat4 } from './type.d.ts'
+
+export function invert(out: Mat4, matrix: Mat4): Mat4

--- a/packages/modeling/src/maths/mat4/invert.js
+++ b/packages/modeling/src/maths/mat4/invert.js
@@ -5,7 +5,6 @@
  * @author Julian Lloyd
  * code from https://github.com/jlmakes/rematrix/blob/master/src/index.js
  *
- * @typedef {import("./type.d.ts").Mat4} Mat4
  * @param {Mat4} out - receiving matrix
  * @param {Mat4} matrix - matrix to invert
  * @returns {Mat4?} out

--- a/packages/modeling/src/maths/mat4/isIdentity.d.ts
+++ b/packages/modeling/src/maths/mat4/isIdentity.d.ts
@@ -1,3 +1,3 @@
 import type { Mat4 } from './type.d.ts'
 
-export function isIdentity(matrix: Mat4): Mat4
+export function isIdentity(matrix: Mat4): boolean

--- a/packages/modeling/src/maths/mat4/isIdentity.d.ts
+++ b/packages/modeling/src/maths/mat4/isIdentity.d.ts
@@ -1,0 +1,3 @@
+import type { Mat4 } from './type.d.ts'
+
+export function isIdentity(matrix: Mat4): Mat4

--- a/packages/modeling/src/maths/mat4/isIdentity.js
+++ b/packages/modeling/src/maths/mat4/isIdentity.js
@@ -4,7 +4,6 @@
  *
  *     mat4.equals(mat4.create(), matrix)
  *
- * @typedef {import("./type.d.ts").Mat4} Mat4
  * @param {Mat4} matrix - the matrix
  * @returns {boolean} true if matrix is the identity transform
  * @alias module:modeling/maths/mat4.isIdentity

--- a/packages/modeling/src/maths/mat4/isOnlyTransformScale.d.ts
+++ b/packages/modeling/src/maths/mat4/isOnlyTransformScale.d.ts
@@ -1,0 +1,3 @@
+import type { Mat4 } from './type.d.ts'
+
+export function isOnlyTransformScale(matrix: Mat4): boolean

--- a/packages/modeling/src/maths/mat4/isOnlyTransformScale.js
+++ b/packages/modeling/src/maths/mat4/isOnlyTransformScale.js
@@ -3,7 +3,6 @@
  * Determine whether the given matrix is only translate and/or scale.
  * This code returns true for TAU / 2 rotation as it can be interpreted as scale.
  *
- * @typedef {import("./type.d.ts").Mat4} Mat4
  * @param {Mat4} matrix - the matrix
  * @returns {boolean} true if matrix is for translate and/or scale
  * @alias module:modeling/maths/mat4.isOnlyTransformScale


### PR DESCRIPTION
These changes are in preparation for publishing V3 alpha versions of the packages.

There are some code changes to modeling, as JSDOC barfed on those '@typedef' docs strings in mat4. I added proper TS definitions for those functions, and all is good again.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Does your submission pass tests?