### PR TITLE
fix(modeling): boolean argument checks

### DIFF
--- a/packages/modeling/src/operations/booleans/intersect.js
+++ b/packages/modeling/src/operations/booleans/intersect.js
@@ -31,15 +31,15 @@ import { intersectGeom3 } from './intersectGeom3.js'
  */
 export const intersect = (...geometries) => {
   geometries = flatten(geometries)
-  if (geometries.length === 0) throw new Error('wrong number of arguments')
+  if (geometries.length === 0) throw new Error('intersect wrong number of arguments')
 
   if (!areAllShapesTheSameType(geometries)) {
-    throw new Error('only intersect of the types are supported')
+    throw new Error('intersect arguments must be the same geometry type')
   }
 
   const geometry = geometries[0]
   // if (path.isA(geometry)) return intersectPath(matrix, geometries)
   if (geom2.isA(geometry)) return intersectGeom2(geometries)
   if (geom3.isA(geometry)) return intersectGeom3(geometries)
-  return geometry
+  throw new Error('intersect unsupported geometry type')
 }

--- a/packages/modeling/src/operations/booleans/intersect.test.js
+++ b/packages/modeling/src/operations/booleans/intersect.test.js
@@ -1,0 +1,25 @@
+import test from 'ava'
+
+import { geom2, geom3 } from '../../geometries/index.js'
+
+import { intersect } from './index.js'
+
+test('intersect error wrong number of arguments', (t) => {
+  const message = 'intersect wrong number of arguments'
+  t.throws(() => intersect(), { message })
+  t.throws(() => intersect([]), { message })
+  t.throws(() => intersect([[], []]), { message })
+})
+
+test('intersect error different geometry types', (t) => {
+  const message = 'intersect arguments must be the same geometry type'
+  t.throws(() => intersect(geom2.create(), geom3.create()), { message })
+})
+
+test('intersect error non-geometries', (t) => {
+  const message = 'intersect unsupported geometry type'
+  t.throws(() => intersect([1, 2, 3], [4, 5, 6]), { message })
+  t.throws(() => intersect([], [123]), { message })
+  t.throws(() => intersect("one", "two"), { message })
+  t.throws(() => intersect(null, null), { message })
+})

--- a/packages/modeling/src/operations/booleans/scission.js
+++ b/packages/modeling/src/operations/booleans/scission.js
@@ -27,7 +27,6 @@ import { scissionGeom3 } from './scissionGeom3.js'
  */
 export const scission = (...objects) => {
   objects = flatten(objects)
-  if (objects.length === 0) throw new Error('wrong number of arguments')
 
   const results = objects.map((object) => {
     // if (path2.isA(object)) return path2.transform(matrix, object)

--- a/packages/modeling/src/operations/booleans/scission.js
+++ b/packages/modeling/src/operations/booleans/scission.js
@@ -27,6 +27,7 @@ import { scissionGeom3 } from './scissionGeom3.js'
  */
 export const scission = (...objects) => {
   objects = flatten(objects)
+  if (objects.length === 0) throw new Error('wrong number of arguments')
 
   const results = objects.map((object) => {
     // if (path2.isA(object)) return path2.transform(matrix, object)

--- a/packages/modeling/src/operations/booleans/subtract.js
+++ b/packages/modeling/src/operations/booleans/subtract.js
@@ -31,15 +31,15 @@ import { subtractGeom3 } from './subtractGeom3.js'
  */
 export const subtract = (...geometries) => {
   geometries = flatten(geometries)
-  if (geometries.length === 0) throw new Error('wrong number of arguments')
+  if (geometries.length === 0) throw new Error('subtract wrong number of arguments')
 
   if (!areAllShapesTheSameType(geometries)) {
-    throw new Error('only subtract of the types are supported')
+    throw new Error('subtract arguments must be the same geometry type')
   }
 
   const geometry = geometries[0]
   // if (path.isA(geometry)) return subtractPath(matrix, geometries)
   if (geom2.isA(geometry)) return subtractGeom2(geometries)
   if (geom3.isA(geometry)) return subtractGeom3(geometries)
-  return geometry
+  throw new Error('subtract unsupported geometry type')
 }

--- a/packages/modeling/src/operations/booleans/subtract.test.js
+++ b/packages/modeling/src/operations/booleans/subtract.test.js
@@ -1,0 +1,25 @@
+import test from 'ava'
+
+import { geom2, geom3 } from '../../geometries/index.js'
+
+import { subtract } from './index.js'
+
+test('subtract error wrong number of arguments', (t) => {
+  const message = 'subtract wrong number of arguments'
+  t.throws(() => subtract(), { message })
+  t.throws(() => subtract([]), { message })
+  t.throws(() => subtract([[], []]), { message })
+})
+
+test('subtract error different geometry types', (t) => {
+  const message = 'subtract arguments must be the same geometry type'
+  t.throws(() => subtract(geom2.create(), geom3.create()), { message })
+})
+
+test('subtract error non-geometries', (t) => {
+  const message = 'subtract unsupported geometry type'
+  t.throws(() => subtract([1, 2, 3], [4, 5, 6]), { message })
+  t.throws(() => subtract([], [123]), { message })
+  t.throws(() => subtract("one", "two"), { message })
+  t.throws(() => subtract(null, null), { message })
+})

--- a/packages/modeling/src/operations/booleans/union.js
+++ b/packages/modeling/src/operations/booleans/union.js
@@ -30,15 +30,15 @@ import { unionGeom3 } from './unionGeom3.js'
  */
 export const union = (...geometries) => {
   geometries = flatten(geometries)
-  if (geometries.length === 0) throw new Error('wrong number of arguments')
+  if (geometries.length === 0) throw new Error('union wrong number of arguments')
 
   if (!areAllShapesTheSameType(geometries)) {
-    throw new Error('only unions of the same type are supported')
+    throw new Error('union arguments must be the same geometry type')
   }
 
   const geometry = geometries[0]
   // if (path.isA(geometry)) return unionPath(matrix, geometries)
   if (geom2.isA(geometry)) return unionGeom2(geometries)
   if (geom3.isA(geometry)) return unionGeom3(geometries)
-  return geometry
+  throw new Error('union unsupported geometry type')
 }

--- a/packages/modeling/src/operations/booleans/union.test.js
+++ b/packages/modeling/src/operations/booleans/union.test.js
@@ -1,0 +1,25 @@
+import test from 'ava'
+
+import { geom2, geom3 } from '../../geometries/index.js'
+
+import { union } from './index.js'
+
+test('union error wrong number of arguments', (t) => {
+  const message = 'union wrong number of arguments'
+  t.throws(() => union(), { message })
+  t.throws(() => union([]), { message })
+  t.throws(() => union([[], []]), { message })
+})
+
+test('union error different geometry types', (t) => {
+  const message = 'union arguments must be the same geometry type'
+  t.throws(() => union(geom2.create(), geom3.create()), { message })
+})
+
+test('union error non-geometries', (t) => {
+  const message = 'union unsupported geometry type'
+  t.throws(() => union([1, 2, 3], [4, 5, 6]), { message })
+  t.throws(() => union([], [123]), { message })
+  t.throws(() => union("one", "two"), { message })
+  t.throws(() => union(null, null), { message })
+})


### PR DESCRIPTION
A user on discord had a question, and I realized that his design revealed a weird behavior in `union` when invalid geometries are given. Simplified user code:
```js
return union(vectorText({ input: 'I' }), vectorText({ input: ' ' }))
```

Rather than throwing an error in `union`, this actually returns the value `4`. Weird.

It makes sense when you look at the code. `vectorText` returns an array of points like:
```js
vectorText({ input: 'I' }) => [[[4, 21], [4, 0]]]
```
Which gets flattened by union, and then union doesn't know how to deal with non-geometries so it just returns the first element from the flattened list which is the number `4`. Very weird.

I don't like throwing errors if we can avoid it. But in this case, it feels like the right thing to do is to tell the user "hey this is not a valid geometry" as soon as possible, to make debugging easier. So in this case I added `throw new Error('union unsupported geometry type')`

I added tests for this behavior. I also tried to make the error messages easier to understand and with better grammar, but open to suggestions here.


### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
