### PR TITLE
test(modeling): measureArea for all tests

### DIFF
--- a/packages/modeling/src/operations/booleans/intersectGeom3.test.js
+++ b/packages/modeling/src/operations/booleans/intersectGeom3.test.js
@@ -4,7 +4,7 @@ import { comparePolygonsAsPoints } from '../../../test/helpers/index.js'
 
 import { geom3 } from '../../geometries/index.js'
 
-import { measureVolume } from '../../measurements/index.js'
+import { measureArea, measureVolume } from '../../measurements/index.js'
 
 import { sphere, cuboid } from '../../primitives/index.js'
 
@@ -69,6 +69,7 @@ test('intersect: intersect of one or more geom3 objects produces expected geomet
     [[8.65956056235493e-17, 8.659560562354935e-17, 2], [1.4142135623730951, 3.4638242249419736e-16, 1.414213562373095], [0.9999999999999998, 1.0000000000000002, 1.414213562373095]]
   ]
   t.notThrows.skip(() => geom3.validate(result1))
+  t.is(measureArea(result1), 44.053756306589825)
   t.is(measureVolume(result1), 25.751611331979678)
   t.is(obs.length, 32)
   t.true(comparePolygonsAsPoints(obs, exp))
@@ -79,6 +80,7 @@ test('intersect: intersect of one or more geom3 objects produces expected geomet
   const result2 = intersect(geometry1, geometry2)
   obs = geom3.toPoints(result2)
   t.notThrows(() => geom3.validate(result2))
+  t.is(measureArea(result2), 0)
   t.is(measureVolume(result2), 0)
   t.is(obs.length, 0)
 
@@ -99,6 +101,7 @@ test('intersect: intersect of one or more geom3 objects produces expected geomet
   ]
 
   t.notThrows(() => geom3.validate(result3))
+  t.is(measureArea(result3), 6)
   t.is(measureVolume(result3), 1.0000000000000009)
   t.is(obs.length, 6)
   t.true(comparePolygonsAsPoints(obs, exp))
@@ -107,6 +110,7 @@ test('intersect: intersect of one or more geom3 objects produces expected geomet
   const result4 = intersect(geometry1, geometry3)
   obs = geom3.toPoints(result4)
   t.notThrows.skip(() => geom3.validate(result4))
+  t.is(measureArea(result4), 44.053756306589825)
   t.is(measureVolume(result4), 25.751611331979678)
   t.is(obs.length, 32)
 })

--- a/packages/modeling/src/operations/booleans/scission.test.js
+++ b/packages/modeling/src/operations/booleans/scission.test.js
@@ -2,6 +2,8 @@ import test from 'ava'
 
 import { geom3 } from '../../geometries/index.js'
 
+import { measureArea, measureVolume } from '../../measurements/index.js'
+
 import { cube, torus } from '../../primitives/index.js'
 
 import { scission, union } from './index.js'
@@ -42,6 +44,10 @@ test('scission: scission of complex geom3 produces expected geometry', (t) => {
   t.is(result1.length, 2)
   t.notThrows.skip(() => geom3.validate(result1[0]))
   t.notThrows.skip(() => geom3.validate(result1[1]))
+  t.is(measureArea(result1[0]), 7720.0306508548)
+  t.is(measureArea(result1[1]), 3860.0153254273987)
+  t.is(measureVolume(result1[0]), 18745.166004060953)
+  t.is(measureVolume(result1[1]), 9372.583002030477)
 
   const rc1 = geom3.toPolygons(result1[0]).length
   const rc2 = geom3.toPolygons(result1[1]).length

--- a/packages/modeling/src/operations/booleans/subtractGeom3.test.js
+++ b/packages/modeling/src/operations/booleans/subtractGeom3.test.js
@@ -4,7 +4,7 @@ import { comparePolygonsAsPoints } from '../../../test/helpers/index.js'
 
 import { geom3 } from '../../geometries/index.js'
 
-import { measureVolume } from '../../measurements/index.js'
+import { measureArea, measureVolume } from '../../measurements/index.js'
 
 import { sphere, cuboid } from '../../primitives/index.js'
 
@@ -69,6 +69,7 @@ test('subtract: subtract of one or more geom3 objects produces expected geometry
     [[8.65956056235493e-17, 8.659560562354935e-17, 2], [1.4142135623730951, 3.4638242249419736e-16, 1.414213562373095], [0.9999999999999998, 1.0000000000000002, 1.414213562373095]]
   ]
   t.notThrows.skip(() => geom3.validate(result1))
+  t.is(measureArea(result1), 44.053756306589825)
   t.is(measureVolume(result1), 25.751611331979678)
   t.is(obs.length, 32)
   t.true(comparePolygonsAsPoints(obs, exp))
@@ -79,6 +80,7 @@ test('subtract: subtract of one or more geom3 objects produces expected geometry
   const result2 = subtract(geometry1, geometry2)
   obs = geom3.toPoints(result2)
   t.notThrows.skip(() => geom3.validate(result2))
+  t.is(measureArea(result2), 44.053756306589825)
   t.is(measureVolume(result2), 25.751611331979678)
   t.is(obs.length, 32)
 
@@ -102,6 +104,7 @@ test('subtract: subtract of one or more geom3 objects produces expected geometry
     [[12, 9, 8], [12, 8, 8], [9, 8, 8], [9, 9, 8]]
   ]
   t.notThrows.skip(() => geom3.validate(result3))
+  t.is(measureArea(result3), 96)
   t.is(measureVolume(result3), 63)
   t.is(obs.length, 12)
   t.true(comparePolygonsAsPoints(obs, exp))
@@ -110,6 +113,7 @@ test('subtract: subtract of one or more geom3 objects produces expected geometry
   const result4 = subtract(geometry1, geometry3)
   obs = geom3.toPoints(result4)
   t.notThrows(() => geom3.validate(result4))
+  t.is(measureArea(result4), 0)
   t.is(measureVolume(result4), 0)
   t.is(obs.length, 0)
 })

--- a/packages/modeling/src/operations/booleans/unionGeom3.test.js
+++ b/packages/modeling/src/operations/booleans/unionGeom3.test.js
@@ -4,7 +4,7 @@ import { comparePolygonsAsPoints } from '../../../test/helpers/index.js'
 
 import { geom3 } from '../../geometries/index.js'
 
-import { measureVolume } from '../../measurements/index.js'
+import { measureArea, measureVolume } from '../../measurements/index.js'
 
 import { sphere, cuboid } from '../../primitives/index.js'
 
@@ -69,6 +69,7 @@ test('union of one or more geom3 objects produces expected geometry', (t) => {
     [[8.65956056235493e-17, 8.659560562354935e-17, 2], [1.4142135623730951, 3.4638242249419736e-16, 1.414213562373095], [0.9999999999999998, 1.0000000000000002, 1.414213562373095]]
   ]
   t.notThrows.skip(() => geom3.validate(result1))
+  t.is(measureArea(result1), 44.053756306589825)
   t.is(measureVolume(result1), 25.751611331979678)
   t.is(obs.length, 32)
   t.true(comparePolygonsAsPoints(obs, exp))
@@ -79,6 +80,7 @@ test('union of one or more geom3 objects produces expected geometry', (t) => {
   const result2 = union(geometry1, geometry2)
   obs = geom3.toPoints(result2)
   t.notThrows.skip(() => geom3.validate(result2))
+  t.is(measureArea(result2), 140.05375630658983)
   t.is(measureVolume(result2), 89.75161133197969)
   t.is(obs.length, 38)
 
@@ -108,6 +110,7 @@ test('union of one or more geom3 objects produces expected geometry', (t) => {
     [[-9, 8, 9], [-9, -9, 9], [9, -9, 9], [9, 8, 9]]
   ]
   t.notThrows.skip(() => geom3.validate(result3))
+  t.is(measureArea(result3), 2034)
   t.is(measureVolume(result3), 5895)
   t.is(obs.length, 18)
   t.true(comparePolygonsAsPoints(obs, exp))
@@ -124,6 +127,7 @@ test('union of one or more geom3 objects produces expected geometry', (t) => {
     [[-9, -9, 9], [9, -9, 9], [9, 9, 9], [-9, 9, 9]]
   ]
   t.notThrows(() => geom3.validate(result4))
+  t.is(measureArea(result4), 1944)
   t.is(measureVolume(result4), 5832)
   t.is(obs.length, 6)
   t.true(comparePolygonsAsPoints(obs, exp))
@@ -136,6 +140,7 @@ test('union of geom3 with rounding issues #137', (t) => {
   const result = union(geometry1, geometry2)
   const pts = geom3.toPoints(result)
   t.notThrows(() => geom3.validate(result))
+  t.is(measureArea(result), 3240.00014)
   t.is(measureVolume(result), 7779.201144000001)
   t.is(pts.length, 6) // number of polygons in union
 })

--- a/packages/modeling/src/operations/extrusions/extrudeFromSlices.test.js
+++ b/packages/modeling/src/operations/extrusions/extrudeFromSlices.test.js
@@ -7,7 +7,7 @@ import { mat4 } from '../../maths/index.js'
 
 import { geom2, geom3, poly3, slice } from '../../geometries/index.js'
 
-import { measureVolume } from '../../measurements/index.js'
+import { measureArea, measureVolume } from '../../measurements/index.js'
 
 import { circle, square } from '../../primitives/index.js'
 
@@ -32,6 +32,8 @@ test('extrudeFromSlices (defaults)', (t) => {
     [[-10, -10, 0], [-10, 10, 0], [10, 10, 0]],
     [[10, 10, 0], [10, -10, 0], [-10, -10, 0]]
   ]
+  t.is(measureArea(geometry3), 880)
+  t.is(measureVolume(geometry3), 400.00000000000006)
   t.is(pts.length, 12)
   t.true(comparePolygonsAsPoints(pts, exp))
 
@@ -40,6 +42,7 @@ test('extrudeFromSlices (defaults)', (t) => {
   pts = geom3.toPoints(geometry3)
 
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureArea(geometry3), 880)
   t.is(measureVolume(geometry3), 400.00000000000006)
   t.is(pts.length, 12)
   t.true(comparePolygonsAsPoints(pts, exp))
@@ -74,6 +77,7 @@ test('extrudeFromSlices (torus)', (t) => {
   )
   const pts = geom3.toPoints(geometry3)
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureArea(geometry3), 7070.694617452831)
   t.is(measureVolume(geometry3), 29393.876913398108)
   t.is(pts.length, 96)
 })
@@ -95,6 +99,7 @@ test('extrudeFromSlices (same shape, changing dimensions)', (t) => {
   const pts = geom3.toPoints(geometry3)
   // expected to throw because capEnd is false (non-closed geometry)
   t.throws(() => geom3.validate(geometry3))
+  t.is(measureArea(geometry3), 53.70100297794013)
   t.is(measureVolume(geometry3), 8.5)
   t.is(pts.length, 26)
 })
@@ -114,6 +119,7 @@ test('extrudeFromSlices (changing shape, changing dimensions)', (t) => {
   )
   const pts = geom3.toPoints(geometry3)
   t.notThrows.skip(() => geom3.validate(geometry3))
+  t.is(measureArea(geometry3), 1965.8643589631802)
   t.is(measureVolume(geometry3), 5260.067107417433)
   t.is(pts.length, 304)
 })
@@ -160,6 +166,7 @@ test('extrudeFromSlices (holes)', (t) => {
     [[-5, -5, 0], [5, -5, 0], [-10, -10, 0]]
   ]
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureArea(geometry3), 720)
   t.is(measureVolume(geometry3), 300)
   t.is(pts.length, 32)
   t.true(comparePolygonsAsPoints(pts, exp))

--- a/packages/modeling/src/operations/extrusions/extrudeLinear.test.js
+++ b/packages/modeling/src/operations/extrusions/extrudeLinear.test.js
@@ -8,7 +8,7 @@ import { colorize } from '../../colors/index.js'
 
 import { geom2, geom3, path2 } from '../../geometries/index.js'
 
-import { measureVolume } from '../../measurements/index.js'
+import { measureArea, measureVolume } from '../../measurements/index.js'
 
 import { square } from '../../primitives/index.js'
 
@@ -34,6 +34,7 @@ test('extrudeLinear (defaults)', (t) => {
     [[5, 5, 0], [5, -5, 0], [-5, -5, 0]]
   ]
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureArea(geometry3), 240)
   t.is(measureVolume(geometry3), 100.00000000000001)
   t.is(pts.length, 12)
   t.true(comparePolygonsAsPoints(pts, exp))
@@ -70,6 +71,7 @@ test('extrudeLinear (no twist)', (t) => {
     [[5, 5, 0], [5, -5, 0], [-5, -5, 0]]
   ]
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureArea(geometry3), 800)
   t.is(measureVolume(geometry3), 1500)
   t.is(pts.length, 12)
   t.true(comparePolygonsAsPoints(pts, exp))
@@ -91,6 +93,7 @@ test('extrudeLinear (no twist)', (t) => {
     [[5, -5, 0], [5, 5, 0], [-5, 5, 0]]
   ]
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureArea(geometry3), 800)
   t.is(measureVolume(geometry3), 1500)
   t.is(pts.length, 12)
   t.true(comparePolygonsAsPoints(pts, exp))
@@ -124,6 +127,7 @@ test('extrudeLinear (twist)', (t) => {
     [[5, 5, 0], [5, -5, 0], [-5, -5, 0]]
   ]
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureArea(geometry3), 805.6920958788816)
   t.is(measureVolume(geometry3), 1707.1067811865476)
   t.is(pts.length, 12)
   t.true(comparePolygonsAsPoints(pts, exp))
@@ -166,6 +170,7 @@ test('extrudeLinear (twist)', (t) => {
   geometry3 = extrudeLinear({ height: 15, twistAngle: TAU / 2, twistSteps: 30 }, geometry2)
   pts = geom3.toPoints(geometry3)
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureArea(geometry3), 1091.9932843446968)
   t.is(measureVolume(geometry3), 1444.9967160503095)
   t.is(pts.length, 244)
 })
@@ -212,6 +217,7 @@ test('extrudeLinear (holes)', (t) => {
     [[-2, -2, 0], [2, -2, 0], [-5, -5, 0]]
   ]
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureArea(geometry3), 1008)
   t.is(measureVolume(geometry3), 1260)
   t.is(pts.length, 32)
   t.true(comparePolygonsAsPoints(pts, exp))

--- a/packages/modeling/src/operations/extrusions/extrudeRotate.test.js
+++ b/packages/modeling/src/operations/extrusions/extrudeRotate.test.js
@@ -8,7 +8,7 @@ import { colorize } from '../../colors/index.js'
 
 import { geom2, geom3 } from '../../geometries/index.js'
 
-import { measureVolume } from '../../measurements/index.js'
+import { measureArea, measureVolume } from '../../measurements/index.js'
 
 import { square } from '../../primitives/index.js'
 
@@ -20,6 +20,7 @@ test('extrudeRotate: (defaults) extruding of a geom2 produces an expected geom3'
   const geometry3 = extrudeRotate({ }, geometry2)
   const pts = geom3.toPoints(geometry3)
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureArea(geometry3), 7033.914479497244)
   t.is(measureVolume(geometry3), 27648.000000000007)
   t.is(pts.length, 96)
 })
@@ -51,6 +52,7 @@ test('extrudeRotate: (angle) extruding of a geom2 produces an expected geom3', (
     [[10, 0, -8], [26, 0, -8], [26, 0, 8]]
   ]
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureArea(geometry3), 1360.144820048035)
   t.is(measureVolume(geometry3), 3258.3480477076105)
   t.is(pts.length, 12)
   t.true(comparePolygonsAsPoints(pts, exp))
@@ -58,12 +60,14 @@ test('extrudeRotate: (angle) extruding of a geom2 produces an expected geom3', (
   geometry3 = extrudeRotate({ segments: 4, angle: -250 * 0.017453292519943295 }, geometry2)
   pts = geom3.toPoints(geometry3)
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureArea(geometry3), 4525.850393739846)
   t.is(measureVolume(geometry3), 13730.527057424617)
   t.is(pts.length, 28)
 
   geometry3 = extrudeRotate({ segments: 4, angle: 250 * 0.017453292519943295 }, geometry2)
   pts = geom3.toPoints(geometry3)
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureArea(geometry3), 4525.8503937398455)
   t.is(measureVolume(geometry3), 13730.527057424617)
   t.is(pts.length, 28)
 })
@@ -80,6 +84,7 @@ test('extrudeRotate: (startAngle) extruding of a geom2 produces an expected geom
     [-11.803752993228215, 23.166169628897567, 8]
   ]
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureArea(geometry3), 6124.6858201346895)
   t.is(measureVolume(geometry3), 21912.342135440336)
   t.is(pts.length, 40)
   t.true(comparePoints(pts[6], exp))
@@ -92,6 +97,7 @@ test('extrudeRotate: (startAngle) extruding of a geom2 produces an expected geom
     [23.166169628897567, 11.803752993228215, 8]
   ]
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureArea(geometry3), 6124.685820134688)
   t.is(measureVolume(geometry3), 21912.342135440336)
   t.is(pts.length, 40)
   t.true(comparePoints(pts[6], exp))
@@ -104,12 +110,14 @@ test('extrudeRotate: (segments) extruding of a geom2 produces an expected geom3'
   let geometry3 = extrudeRotate({ segments: 4 }, geometry2)
   let pts = geom3.toPoints(geometry3)
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureArea(geometry3), 5562.34804770761)
   t.is(measureVolume(geometry3), 18432)
   t.is(pts.length, 32)
 
   geometry3 = extrudeRotate({ segments: 64 }, geometry2)
   pts = geom3.toPoints(geometry3)
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureArea(geometry3), 7230.965353920782)
   t.is(measureVolume(geometry3), 28906.430888871357)
   t.is(pts.length, 512)
 
@@ -118,6 +126,7 @@ test('extrudeRotate: (segments) extruding of a geom2 produces an expected geom3'
   geometry3 = extrudeRotate({ segments: 8 }, geometry2)
   pts = geom3.toPoints(geometry3)
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureArea(geometry3), 84.28200374166053)
   t.is(measureVolume(geometry3), 33.94112549695427)
   t.is(pts.length, 64)
 
@@ -126,6 +135,7 @@ test('extrudeRotate: (segments) extruding of a geom2 produces an expected geom3'
   geometry3 = extrudeRotate({ segments: 8 }, geometry2)
   pts = geom3.toPoints(geometry3)
   t.notThrows(() => geom3.validate(geometry3))
+  t.is(measureArea(geometry3), 17692.315375839215)
   t.is(measureVolume(geometry3), 147078.2104868019)
   t.is(pts.length, 80)
 })
@@ -147,6 +157,7 @@ test('extrudeRotate: (overlap +/-) extruding of a geom2 produces an expected geo
     [[7, 0, -8], [7, 0, 8], [0, 0, 8]]
   ]
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 431.3919189857867)
   t.is(measureVolume(obs), 391.99999999999994)
   t.is(pts.length, 8)
   t.true(comparePolygonsAsPoints(pts, exp))
@@ -177,6 +188,7 @@ test('extrudeRotate: (overlap +/-) extruding of a geom2 produces an expected geo
     [[2, 0, 4], [0, 0, 8], [0, 0, -8]]
   ]
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 86.47516025670329)
   t.is(measureVolume(obs), 26.398653164297773)
   t.is(pts.length, 18)
   t.true(comparePolygonsAsPoints(pts, exp))

--- a/packages/modeling/src/operations/hulls/hull.test.js
+++ b/packages/modeling/src/operations/hulls/hull.test.js
@@ -1,8 +1,11 @@
 import test from 'ava'
 
 import { geom2, geom3, path2 } from '../../geometries/index.js'
-import { measureArea } from '../../measurements/measureArea.js'
+
+import { measureArea, measureVolume } from '../../measurements/index.js'
+
 import { sphere, cuboid, ellipsoid } from '../../primitives/index.js'
+
 import { center } from '../transforms/index.js'
 
 import { hull } from './index.js'
@@ -41,6 +44,7 @@ test('hull (single, geom2)', (t) => {
   obs = hull(geometry)
   pts = geom2.toPoints(obs)
   t.notThrows(() => geom2.validate(obs))
+  t.is(measureArea(obs), 232.09469999999993)
   t.is(pts.length, 7)
 })
 
@@ -68,6 +72,7 @@ test('hull (multiple, overlapping, geom2)', (t) => {
   let pts = geom2.toPoints(obs)
 
   t.notThrows(() => geom2.validate(obs))
+  t.is(measureArea(obs), 100)
   t.is(pts.length, 4)
 
   // one inside another
@@ -75,6 +80,7 @@ test('hull (multiple, overlapping, geom2)', (t) => {
   pts = geom2.toPoints(obs)
 
   t.notThrows(() => geom2.validate(obs))
+  t.is(measureArea(obs), 100)
   t.is(pts.length, 4)
 
   // one overlapping another
@@ -82,12 +88,14 @@ test('hull (multiple, overlapping, geom2)', (t) => {
   pts = geom2.toPoints(obs)
 
   t.notThrows(() => geom2.validate(obs))
+  t.is(measureArea(obs), 116)
   t.is(pts.length, 8)
 
   obs = hull(geometry2, geometry4)
   pts = geom2.toPoints(obs)
 
   t.notThrows(() => geom2.validate(obs))
+  t.is(measureArea(obs), 232.09469999999993)
   t.is(pts.length, 7)
 })
 
@@ -114,26 +122,31 @@ test('hull (multiple, various, geom2)', (t) => {
   let obs = hull(geometry1, geometry2)
   let pts = geom2.toPoints(obs)
   t.notThrows(() => geom2.validate(obs))
+  t.is(measureArea(obs), 99)
   t.is(pts.length, 5)
 
   obs = hull(geometry1, geometry3)
   pts = geom2.toPoints(obs)
   t.notThrows(() => geom2.validate(obs))
+  t.is(measureArea(obs), 308)
   t.is(pts.length, 5)
 
   obs = hull(geometry2, geometry3)
   pts = geom2.toPoints(obs)
   t.notThrows(() => geom2.validate(obs))
+  t.is(measureArea(obs), 308)
   t.is(pts.length, 5)
 
   obs = hull(geometry1, geometry2, geometry3)
   pts = geom2.toPoints(obs)
   t.notThrows(() => geom2.validate(obs))
+  t.is(measureArea(obs), 341)
   t.is(pts.length, 6)
 
   obs = hull(geometry5, geometry4)
   pts = geom2.toPoints(obs)
   t.notThrows(() => geom2.validate(obs))
+  t.is(measureArea(obs), 513.39595)
   t.is(pts.length, 8)
 })
 
@@ -216,6 +229,8 @@ test('hull (single, geom3)', (t) => {
   pts = geom3.toPoints(obs)
 
   t.notThrows.skip(() => geom3.validate(obs))
+  t.is(measureArea(obs), 44.053756306589825)
+  t.is(measureVolume(obs), 25.751611331979678)
   t.is(pts.length, 32)
 })
 
@@ -234,6 +249,8 @@ test('hull (multiple, geom3)', (t) => {
   ]
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 24)
+  t.is(measureVolume(obs), 7.999999999999999)
   t.is(pts.length, 6)
   t.true(comparePolygonsAsPoints(pts, exp))
 
@@ -257,6 +274,8 @@ test('hull (multiple, geom3)', (t) => {
   ]
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 145.59502802663923)
+  t.is(measureVolume(obs), 112.49999999999999)
   t.is(pts.length, 12)
   t.true(comparePolygonsAsPoints(pts, exp))
 })
@@ -270,5 +289,7 @@ test('hull (multiple, overlapping, geom3)', (t) => {
   const pts = geom3.toPoints(obs)
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 282.26819685563686)
+  t.is(measureVolume(obs), 366.67641200012866)
   t.is(pts.length, 92)
 })

--- a/packages/modeling/src/operations/hulls/hullChain.test.js
+++ b/packages/modeling/src/operations/hulls/hullChain.test.js
@@ -1,7 +1,9 @@
 import test from 'ava'
 
 import { geom2, geom3 } from '../../geometries/index.js'
-import { measureArea } from '../../measurements/measureArea.js'
+
+import { measureArea, measureVolume } from '../../measurements/index.js'
+
 import { square } from '../../primitives/square.js'
 
 import { hullChain } from './index.js'
@@ -22,6 +24,7 @@ test('hullChain (two, geom2)', (t) => {
   let pts = geom2.toPoints(obs)
 
   t.notThrows(() => geom2.validate(obs))
+  t.is(measureArea(obs), 9)
   t.is(pts.length, 4)
 
   // different
@@ -29,6 +32,7 @@ test('hullChain (two, geom2)', (t) => {
   pts = geom2.toPoints(obs)
 
   t.notThrows(() => geom2.validate(obs))
+  t.is(measureArea(obs), 81)
   t.is(pts.length, 6)
 })
 
@@ -43,6 +47,7 @@ test('hullChain (three, geom2)', (t) => {
 
   // the sides change based on the bestplane chosen in trees/Node.js
   t.notThrows(() => geom2.validate(obs))
+  t.is(measureArea(obs), 126)
   t.is(pts.length, 10)
 
   // closed
@@ -51,6 +56,7 @@ test('hullChain (three, geom2)', (t) => {
 
   // the sides change based on the bestplane chosen in trees/Node.js
   t.notThrows(() => geom2.validate(obs))
+  t.is(measureArea(obs), 148.21875)
   t.is(pts.length, 10)
 })
 
@@ -85,6 +91,8 @@ test('hullChain (three, geom3)', (t) => {
   let pts = geom3.toPoints(obs)
 
   t.notThrows.skip(() => geom3.validate(obs))
+  t.is(measureArea(obs), 266.1454764345133)
+  t.is(measureVolume(obs), 239.2012987012987)
   t.is(pts.length, 23)
 
   // closed
@@ -92,5 +100,7 @@ test('hullChain (three, geom3)', (t) => {
   pts = geom3.toPoints(obs)
 
   t.notThrows.skip(() => geom3.validate(obs))
+  t.is(measureArea(obs), 272.2887171436021)
+  t.is(measureVolume(obs), 261.96982218883045)
   t.is(pts.length, 28)
 })

--- a/packages/modeling/src/operations/offsets/offsetGeom2.test.js
+++ b/packages/modeling/src/operations/offsets/offsetGeom2.test.js
@@ -61,6 +61,7 @@ test('offset: offset of a geom2 produces expected changes to points', (t) => {
     [-10, -8]
   ]
   t.notThrows(() => geom2.validate(obs))
+  t.is(measureArea(obs), 395.3137084989848)
   t.is(pts.length, 12)
   t.true(comparePoints(pts, exp))
 })

--- a/packages/modeling/src/operations/offsets/offsetGeom3.test.js
+++ b/packages/modeling/src/operations/offsets/offsetGeom3.test.js
@@ -3,8 +3,11 @@ import test from 'ava'
 import { comparePoints } from '../../../test/helpers/index.js'
 
 import { colorize } from '../../colors/index.js'
+
 import { geom3, poly3 } from '../../geometries/index.js'
-import { measureVolume } from '../../measurements/index.js'
+
+import { measureArea, measureVolume } from '../../measurements/index.js'
+
 import { cube, sphere } from '../../primitives/index.js'
 
 import { offset } from './index.js'
@@ -13,6 +16,7 @@ test('offset: offset empty geom3', (t) => {
   const geometry = geom3.create()
   const result = offset({ }, geometry)
   t.notThrows(() => geom3.validate(result))
+  t.is(measureArea(result), 0)
   t.is(measureVolume(result), 0)
   t.is(geom3.toPolygons(result).length, 0)
   t.is(geom3.toPoints(result).length, 0)
@@ -50,6 +54,8 @@ test('offset: offset of a geom3 produces expected changes to polygons', (t) => {
   ]
 
   t.notThrows.skip(() => geom3.validate(obs))
+  t.is(measureArea(obs), 3178.8059464475555)
+  t.is(measureVolume(obs), 13504.574121271067)
   t.is(pts.length, 62)
   t.true(comparePoints(pts[0], exp0))
   t.true(comparePoints(pts[61], exp61))
@@ -58,6 +64,8 @@ test('offset: offset of a geom3 produces expected changes to polygons', (t) => {
   const obs2 = offset({ delta: 5 }, geometry2)
   const pts2 = geom3.toPoints(obs2)
   t.notThrows.skip(() => geom3.validate(obs2))
+  t.is(measureArea(obs), 3178.8059464475555)
+  t.is(measureVolume(obs), 13504.574121271067)
   t.is(pts2.length, 864)
 })
 

--- a/packages/modeling/src/primitives/arc.test.js
+++ b/packages/modeling/src/primitives/arc.test.js
@@ -13,7 +13,7 @@ test('arc (defaults)', (t) => {
   const obs = path2.toPoints(geometry)
 
   t.notThrows(() => path2.validate(geometry))
-  t.deepEqual(obs.length, 33)
+  t.is(obs.length, 33)
 })
 
 test('arc (options)', (t) => {
@@ -41,7 +41,7 @@ test('arc (options)', (t) => {
   let obs = path2.toPoints(geometry)
 
   t.notThrows(() => path2.validate(geometry))
-  t.deepEqual(obs.length, 17)
+  t.is(obs.length, 17)
   t.true(comparePoints(obs, exp))
 
   // test radius
@@ -68,7 +68,7 @@ test('arc (options)', (t) => {
   obs = path2.toPoints(geometry)
 
   t.notThrows(() => path2.validate(geometry))
-  t.deepEqual(obs.length, 17)
+  t.is(obs.length, 17)
   t.true(comparePoints(obs, exp))
 
   // test startAngle
@@ -92,7 +92,7 @@ test('arc (options)', (t) => {
   obs = path2.toPoints(geometry)
 
   t.notThrows(() => path2.validate(geometry))
-  t.deepEqual(obs.length, 14)
+  t.is(obs.length, 14)
   t.true(comparePoints(obs, exp))
 
   // test endAngle
@@ -108,7 +108,7 @@ test('arc (options)', (t) => {
   obs = path2.toPoints(geometry)
 
   t.notThrows(() => path2.validate(geometry))
-  t.deepEqual(obs.length, 6)
+  t.is(obs.length, 6)
   t.true(comparePoints(obs, exp))
 
   // test makeTangent
@@ -137,7 +137,7 @@ test('arc (options)', (t) => {
   obs = path2.toPoints(geometry)
 
   t.notThrows(() => path2.validate(geometry))
-  t.deepEqual(obs.length, 19)
+  t.is(obs.length, 19)
   t.true(comparePoints(obs, exp))
 
   // test segments
@@ -156,7 +156,7 @@ test('arc (options)', (t) => {
   obs = path2.toPoints(geometry)
 
   t.notThrows(() => path2.validate(geometry))
-  t.deepEqual(obs.length, 9)
+  t.is(obs.length, 9)
   t.true(comparePoints(obs, exp))
 })
 
@@ -173,7 +173,7 @@ test('arc (rotations)', (t) => {
   let obs = path2.toPoints(geometry)
 
   t.notThrows(() => path2.validate(geometry))
-  t.deepEqual(obs.length, 6)
+  t.is(obs.length, 6)
   t.true(comparePoints(obs, exp))
 
   exp = [
@@ -192,7 +192,7 @@ test('arc (rotations)', (t) => {
   obs = path2.toPoints(geometry)
 
   t.notThrows(() => path2.validate(geometry))
-  t.deepEqual(obs.length, 10)
+  t.is(obs.length, 10)
   t.true(comparePoints(obs, exp))
 
   exp = [
@@ -211,7 +211,7 @@ test('arc (rotations)', (t) => {
   obs = path2.toPoints(geometry)
 
   t.notThrows(() => path2.validate(geometry))
-  t.deepEqual(obs.length, 10)
+  t.is(obs.length, 10)
   t.true(comparePoints(obs, exp))
 
   exp = [[-1.8369701987210297e-16, -1]]
@@ -219,6 +219,6 @@ test('arc (rotations)', (t) => {
   obs = path2.toPoints(geometry)
 
   t.notThrows(() => path2.validate(geometry))
-  t.deepEqual(obs.length, 1)
+  t.is(obs.length, 1)
   t.true(comparePoints(obs, exp))
 })

--- a/packages/modeling/src/primitives/circle.test.js
+++ b/packages/modeling/src/primitives/circle.test.js
@@ -1,8 +1,10 @@
 import test from 'ava'
 
+import { geom2 } from '../geometries/index.js'
+
 import { TAU } from '../maths/constants.js'
 
-import { geom2 } from '../geometries/index.js'
+import { measureArea } from '../measurements/measureArea.js'
 
 import { comparePoints } from '../../test/helpers/index.js'
 
@@ -13,7 +15,8 @@ test('circle (defaults)', (t) => {
   const pts = geom2.toPoints(geometry)
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(pts.length, 32)
+  t.is(measureArea(geometry), 3.1214451522580537)
+  t.is(pts.length, 32)
 })
 
 test('circle (options)', (t) => {
@@ -56,7 +59,8 @@ test('circle (options)', (t) => {
   ]
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(pts.length, 32)
+  t.is(measureArea(geometry), 38.23770311516116)
+  t.is(pts.length, 32)
   t.true(comparePoints(pts, exp))
 
   // test radius
@@ -82,7 +86,8 @@ test('circle (options)', (t) => {
   ]
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(pts.length, 16)
+  t.is(measureArea(geometry), 37.5029763717788)
+  t.is(pts.length, 16)
   t.true(comparePoints(pts, exp))
 
   // test startAngle
@@ -106,7 +111,8 @@ test('circle (options)', (t) => {
   ]
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(pts.length, 14)
+  t.is(measureArea(geometry), 28.127232278834093)
+  t.is(pts.length, 14)
   t.true(comparePoints(pts, exp))
 
   // test endAngle
@@ -122,7 +128,8 @@ test('circle (options)', (t) => {
   ]
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(pts.length, 6)
+  t.is(measureArea(geometry), 9.3757440929447)
+  t.is(pts.length, 6)
   t.true(comparePoints(pts, exp))
 
   // test full rotation with non-zero startAngle
@@ -130,7 +137,8 @@ test('circle (options)', (t) => {
   pts = geom2.toPoints(geometry)
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(pts.length, 32)
+  t.is(measureArea(geometry), 3.1214451522580537)
+  t.is(pts.length, 32)
 
   // test segments
   geometry = circle({ radius: 3.5, segments: 5 })
@@ -144,7 +152,8 @@ test('circle (options)', (t) => {
   ]
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(pts.length, 5)
+  t.is(measureArea(geometry), 29.126105811539073)
+  t.is(pts.length, 5)
   t.true(comparePoints(pts, exp))
 })
 
@@ -152,5 +161,6 @@ test('circle (radius zero)', (t) => {
   const geometry = circle({ radius: 0 })
   const pts = geom2.toPoints(geometry)
   t.notThrows(() => geom2.validate(geometry))
+  t.is(measureArea(geometry), 0)
   t.is(pts.length, 0)
 })

--- a/packages/modeling/src/primitives/cube.test.js
+++ b/packages/modeling/src/primitives/cube.test.js
@@ -2,6 +2,8 @@ import test from 'ava'
 
 import { geom3 } from '../geometries/index.js'
 
+import { measureArea, measureVolume } from '../measurements/index.js'
+
 import { cube } from './index.js'
 
 import { comparePolygonsAsPoints } from '../../test/helpers/index.js'
@@ -10,6 +12,8 @@ test('cube (defaults)', (t) => {
   const obs = cube()
   const pts = geom3.toPoints(obs)
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 24)
+  t.is(measureVolume(obs), 7.999999999999999)
   t.is(pts.length, 6)
 })
 
@@ -27,6 +31,8 @@ test('cube (options)', (t) => {
   ]
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 294)
+  t.is(measureVolume(obs), 343)
   t.is(pts.length, 6)
   t.true(comparePolygonsAsPoints(pts, exp))
 
@@ -43,6 +49,8 @@ test('cube (options)', (t) => {
   ]
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 294)
+  t.is(measureVolume(obs), 343)
   t.is(pts.length, 6)
   t.true(comparePolygonsAsPoints(pts, exp))
 })
@@ -51,5 +59,7 @@ test('cube (zero size)', (t) => {
   const obs = cube({ size: 0 })
   const pts = geom3.toPoints(obs)
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 0)
+  t.is(measureVolume(obs), 0)
   t.is(pts.length, 0)
 })

--- a/packages/modeling/src/primitives/cuboid.test.js
+++ b/packages/modeling/src/primitives/cuboid.test.js
@@ -2,6 +2,8 @@ import test from 'ava'
 
 import { geom3 } from '../geometries/index.js'
 
+import { measureArea, measureVolume } from '../measurements/index.js'
+
 import { cuboid } from './index.js'
 
 import { comparePolygonsAsPoints } from '../../test/helpers/index.js'
@@ -18,6 +20,8 @@ test('cuboid (defaults)', (t) => {
     [[-1, -1, 1], [1, -1, 1], [1, 1, 1], [-1, 1, 1]]
   ]
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 24)
+  t.is(measureVolume(obs), 7.999999999999999)
   t.is(pts.length, 6)
   t.true(comparePolygonsAsPoints(pts, exp))
 })
@@ -36,6 +40,8 @@ test('cuboid (options)', (t) => {
   ]
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 216)
+  t.is(measureVolume(obs), 216)
   t.is(pts.length, 6)
   t.true(comparePolygonsAsPoints(pts, exp))
 
@@ -52,6 +58,8 @@ test('cuboid (options)', (t) => {
   ]
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 97.5)
+  t.is(measureVolume(obs), 47.25)
   t.is(pts.length, 6)
   t.true(comparePolygonsAsPoints(pts, exp))
 })
@@ -60,5 +68,7 @@ test('cuboid (zero size)', (t) => {
   const obs = cuboid({ size: [1, 1, 0] })
   const pts = geom3.toPoints(obs)
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 0)
+  t.is(measureVolume(obs), 0)
   t.is(pts.length, 0)
 })

--- a/packages/modeling/src/primitives/cylinder.test.js
+++ b/packages/modeling/src/primitives/cylinder.test.js
@@ -2,6 +2,8 @@ import test from 'ava'
 
 import { geom3 } from '../geometries/index.js'
 
+import { measureArea, measureVolume } from '../measurements/index.js'
+
 import { cylinder } from './index.js'
 
 import { comparePolygonsAsPoints } from '../../test/helpers/index.js'
@@ -11,6 +13,8 @@ test('cylinder (defaults)', (t) => {
   const pts = geom3.toPoints(obs)
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 18.789084266699856)
+  t.is(measureVolume(obs), 6.2428903045161)
   t.is(pts.length, 96)
 })
 
@@ -18,6 +22,8 @@ test('cylinder (zero height)', (t) => {
   const obs = cylinder({ height: 0 })
   const pts = geom3.toPoints(obs)
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 0)
+  t.is(measureVolume(obs), 0)
   t.is(pts.length, 0)
 })
 
@@ -25,6 +31,8 @@ test('cylinder (zero radius)', (t) => {
   const obs = cylinder({ radius: 0 })
   const pts = geom3.toPoints(obs)
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 0)
+  t.is(measureVolume(obs), 0)
   t.is(pts.length, 0)
 })
 
@@ -55,6 +63,8 @@ test('cylinder (options)', (t) => {
   ]
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 311.1986222206015)
+  t.is(measureVolume(obs), 380.4226065180614)
   t.is(pts.length, 15)
   t.true(comparePolygonsAsPoints(pts, exp))
 
@@ -85,6 +95,8 @@ test('cylinder (options)', (t) => {
   ]
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 16.51098762732523)
+  t.is(measureVolume(obs), 4.755282581475773)
   t.is(pts.length, 15)
   t.true(comparePolygonsAsPoints(pts, exp))
 })

--- a/packages/modeling/src/primitives/cylinderElliptic.test.js
+++ b/packages/modeling/src/primitives/cylinderElliptic.test.js
@@ -1,8 +1,10 @@
 import test from 'ava'
 
+import { geom3 } from '../geometries/index.js'
+
 import { TAU } from '../maths/constants.js'
 
-import { geom3 } from '../geometries/index.js'
+import { measureArea, measureVolume } from '../measurements/index.js'
 
 import { cylinderElliptic } from './index.js'
 
@@ -13,6 +15,8 @@ test('cylinderElliptic (defaults)', (t) => {
   const pts = geom3.toPoints(obs)
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 18.789084266699856)
+  t.is(measureVolume(obs), 6.2428903045161)
   t.is(pts.length, 96)
 })
 
@@ -72,6 +76,8 @@ test('cylinderElliptic (options)', (t) => {
   ]
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 68.11657082460499)
+  t.is(measureVolume(obs), 30.00000000000001)
   t.is(pts.length, 36)
   t.true(comparePolygonsAsPoints(pts, exp))
 
@@ -130,6 +136,8 @@ test('cylinderElliptic (options)', (t) => {
   ]
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 32.34210030145122)
+  t.is(measureVolume(obs), 12.999999999999991)
   t.is(pts.length, 48)
   t.true(comparePolygonsAsPoints(pts, exp))
 
@@ -138,6 +146,8 @@ test('cylinderElliptic (options)', (t) => {
   pts = geom3.toPoints(obs)
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 22.17105015072561)
+  t.is(measureVolume(obs), 6.5)
   t.is(pts.length, 28)
 
   // test startAngle and endAngle
@@ -145,6 +155,8 @@ test('cylinderElliptic (options)', (t) => {
   pts = geom3.toPoints(obs)
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 18.78908426669986)
+  t.is(measureVolume(obs), 6.2428903045160995)
   t.is(pts.length, 96)
 
   // test segments
@@ -152,6 +164,8 @@ test('cylinderElliptic (options)', (t) => {
   pts = geom3.toPoints(obs)
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 17.902724085175244)
+  t.is(measureVolume(obs), 5.6568542494923815)
   t.is(pts.length, 24)
 
   // test center
@@ -193,6 +207,8 @@ test('cylinderElliptic (options)', (t) => {
   ]
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 24.025659003016692)
+  t.is(measureVolume(obs), 8.485281374238578)
   t.is(pts.length, 24)
   t.true(comparePolygonsAsPoints(pts, exp))
 })
@@ -202,6 +218,8 @@ test('cylinderElliptic (cone)', (t) => {
   const pts = geom3.toPoints(obs)
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 10.128239395900382)
+  t.is(measureVolume(obs), 2.080963434838702)
   t.is(pts.length, 64)
 })
 
@@ -210,5 +228,7 @@ test('cylinderElliptic (squished)', (t) => {
   const pts = geom3.toPoints(obs)
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 8.47213595499958)
+  t.is(measureVolume(obs), 0.6666666666666666)
   t.is(pts.length, 8)
 })

--- a/packages/modeling/src/primitives/ellipse.test.js
+++ b/packages/modeling/src/primitives/ellipse.test.js
@@ -1,8 +1,10 @@
 import test from 'ava'
 
+import { geom2 } from '../geometries/index.js'
+
 import { TAU } from '../maths/constants.js'
 
-import { geom2 } from '../geometries/index.js'
+import { measureArea } from '../measurements/index.js'
 
 import { comparePoints } from '../../test/helpers/index.js'
 
@@ -13,7 +15,8 @@ test('ellipse (defaults)', (t) => {
   const obs = geom2.toPoints(geometry)
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(obs.length, 32)
+  t.is(measureArea(geometry), 3.1214451522580537)
+  t.is(obs.length, 32)
 })
 
 test('ellipse (options)', (t) => {
@@ -56,7 +59,8 @@ test('ellipse (options)', (t) => {
   ]
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(obs.length, 32)
+  t.is(measureArea(geometry), 3.121445152258051)
+  t.is(obs.length, 32)
   t.true(comparePoints(obs, exp))
 
   // test radius
@@ -82,7 +86,8 @@ test('ellipse (options)', (t) => {
   ]
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(obs.length, 16)
+  t.is(measureArea(geometry), 45.92201188381077)
+  t.is(obs.length, 16)
   t.true(comparePoints(obs, exp))
 
   // test startAngle
@@ -106,7 +111,8 @@ test('ellipse (options)', (t) => {
   ]
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(obs.length, 14)
+  t.is(measureArea(geometry), 34.44150891285808)
+  t.is(obs.length, 14)
   t.true(comparePoints(obs, exp))
 
   // test endAngle
@@ -122,7 +128,8 @@ test('ellipse (options)', (t) => {
   ]
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(obs.length, 6)
+  t.is(measureArea(geometry), 11.480502970952696)
+  t.is(obs.length, 6)
   t.true(comparePoints(obs, exp))
 
   // test full rotation with non-zero startAngle
@@ -130,18 +137,21 @@ test('ellipse (options)', (t) => {
   obs = geom2.toPoints(geometry)
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(obs.length, 32)
+  t.is(measureArea(geometry), 3.1214451522580537)
+  t.is(obs.length, 32)
 
   // test segments
   geometry = ellipse({ segments: 72 })
   obs = geom2.toPoints(geometry)
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(obs.length, 72)
+  t.is(measureArea(geometry), 3.1376067389156956)
+  t.is(obs.length, 72)
 })
 
 test('ellipse (zero radius)', (t) => {
   const geometry = ellipse({ radius: [1, 0] })
   const obs = geom2.toPoints(geometry)
   t.notThrows(() => geom2.validate(geometry))
+  t.is(measureArea(geometry), 0)
   t.is(obs.length, 0)
 })

--- a/packages/modeling/src/primitives/ellipsoid.test.js
+++ b/packages/modeling/src/primitives/ellipsoid.test.js
@@ -2,6 +2,8 @@ import test from 'ava'
 
 import { geom3 } from '../geometries/index.js'
 
+import { measureArea, measureVolume } from '../measurements/index.js'
+
 import { ellipsoid } from './index.js'
 
 import { comparePolygonsAsPoints } from '../../test/helpers/index.js'
@@ -11,6 +13,8 @@ test('ellipsoid (defaults)', (t) => {
   const pts = geom3.toPoints(obs)
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 12.465694088650583)
+  t.is(measureVolume(obs), 4.121941740785839)
   t.is(pts.length, 512)
 })
 
@@ -141,6 +145,8 @@ test('ellipsoid (options)', (t) => {
     [[0, 0, 7], [1.5000000000000004, 0, 6.06217782649107], [1.2990381056766578, 1.2500000000000013, 6.06217782649107]]
   ]
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 291.2703265603712)
+  t.is(measureVolume(obs), 391.86533479473223)
   t.is(pts.length, 72)
   t.true(comparePolygonsAsPoints(pts, exp))
 
@@ -148,6 +154,8 @@ test('ellipsoid (options)', (t) => {
   obs = ellipsoid({ segments: 8 })
   pts = geom3.toPoints(obs)
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 11.013439076647456)
+  t.is(measureVolume(obs), 3.2189514164974597)
   t.is(pts.length, 32)
 
   obs = ellipsoid({ center: [-3, 5, 7], segments: 8 })
@@ -204,6 +212,8 @@ test('ellipsoid (options)', (t) => {
   ]
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 11.013439076647467)
+  t.is(measureVolume(obs), 3.218951416497485)
   t.is(pts.length, 32)
   t.true(comparePolygonsAsPoints(pts, exp))
 })
@@ -212,5 +222,7 @@ test('ellipsoid (zero radius)', (t) => {
   const obs = ellipsoid({ radius: [1, 1, 0] })
   const pts = geom3.toPoints(obs)
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 0)
+  t.is(measureVolume(obs), 0)
   t.is(pts.length, 0)
 })

--- a/packages/modeling/src/primitives/geodesicSphere.test.js
+++ b/packages/modeling/src/primitives/geodesicSphere.test.js
@@ -2,6 +2,8 @@ import test from 'ava'
 
 import { geom3 } from '../geometries/index.js'
 
+import { measureArea, measureVolume } from '../measurements/index.js'
+
 import { geodesicSphere } from './index.js'
 
 import { comparePolygonsAsPoints } from '../../test/helpers/index.js'
@@ -41,6 +43,8 @@ test('geodesicSphere (options)', (t) => {
   ]
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 239.3635345818432)
+  t.is(measureVolume(obs), 317.0188387650327)
   t.is(pts.length, 20)
   t.true(comparePolygonsAsPoints(pts, exp))
 
@@ -49,6 +53,8 @@ test('geodesicSphere (options)', (t) => {
   pts = geom3.toPoints(obs)
 
   t.notThrows.skip(() => geom3.validate(obs))
+  t.is(measureArea(obs), 303.76605423529395)
+  t.is(measureVolume(obs), 492.6739732379337)
   t.is(pts.length, 180)
 })
 
@@ -56,5 +62,7 @@ test('geodesicSphere (zero radius)', (t) => {
   const obs = geodesicSphere({ radius: 0 })
   const pts = geom3.toPoints(obs)
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 0)
+  t.is(measureVolume(obs), 0)
   t.is(pts.length, 0)
 })

--- a/packages/modeling/src/primitives/line.test.js
+++ b/packages/modeling/src/primitives/line.test.js
@@ -12,6 +12,6 @@ test('line (defaults)', (t) => {
   const obs = path2.toPoints(geometry)
 
   t.notThrows(() => path2.validate(geometry))
-  t.deepEqual(obs.length, 3)
+  t.is(obs.length, 3)
   t.true(comparePoints(obs, exp))
 })

--- a/packages/modeling/src/primitives/polygon.test.js
+++ b/packages/modeling/src/primitives/polygon.test.js
@@ -2,6 +2,8 @@ import test from 'ava'
 
 import { geom2 } from '../geometries/index.js'
 
+import { measureArea } from '../measurements/index.js'
+
 import { polygon } from './index.js'
 
 import { comparePoints } from '../../test/helpers/index.js'
@@ -13,6 +15,7 @@ test('polygon: providing only object.points creates expected geometry', (t) => {
   let exp = [[0, 0], [100, 0], [130, 50], [30, 50]]
 
   t.notThrows(() => geom2.validate(geometry))
+  t.is(measureArea(geometry), 5000)
   t.true(comparePoints(obs, exp))
 
   geometry = polygon({ points: [[[0, 0], [100, 0], [0, 100]], [[10, 10], [80, 10], [10, 80]]] })
@@ -21,6 +24,7 @@ test('polygon: providing only object.points creates expected geometry', (t) => {
   exp = [[0, 0], [100, 0], [0, 100], [10, 10], [80, 10], [10, 80]]
 
   t.notThrows(() => geom2.validate(geometry))
+  t.is(measureArea(geometry), 7450)
   t.true(comparePoints(obs, exp))
 })
 
@@ -31,6 +35,7 @@ test('polygon: providing object.points (array) and object.path (array) creates e
   let exp = [[30, 50], [130, 50], [100, 0], [0, 0]]
 
   t.notThrows(() => geom2.validate(geometry))
+  t.is(measureArea(geometry), -5000)
   t.true(comparePoints(obs, exp))
 
   // multiple paths
@@ -40,6 +45,7 @@ test('polygon: providing object.points (array) and object.path (array) creates e
   exp = [[0, 0], [100, 0], [0, 100], [10, 10], [80, 10], [10, 80]]
 
   t.notThrows(() => geom2.validate(geometry))
+  t.is(measureArea(geometry), 7450)
   t.true(comparePoints(obs, exp))
 
   // multiple points and paths
@@ -49,5 +55,6 @@ test('polygon: providing object.points (array) and object.path (array) creates e
   exp = [[0, 0], [100, 0], [0, 100], [10, 10], [80, 10], [10, 80]]
 
   t.notThrows(() => geom2.validate(geometry))
+  t.is(measureArea(geometry), 7450)
   t.true(comparePoints(obs, exp))
 })

--- a/packages/modeling/src/primitives/polyhedron.test.js
+++ b/packages/modeling/src/primitives/polyhedron.test.js
@@ -2,6 +2,8 @@ import test from 'ava'
 
 import { geom3 } from '../geometries/index.js'
 
+import { measureArea, measureVolume } from '../measurements/index.js'
+
 import { polyhedron } from './index.js'
 
 import { comparePolygonsAsPoints } from '../../test/helpers/index.js'
@@ -22,7 +24,9 @@ test('polyhedron (points and faces)', (t) => {
     [[-1, -1, 1], [1, -1, 1], [1, 1, 1], [-1, 1, 1]]
   ]
   t.notThrows(() => geom3.validate(obs))
-  t.deepEqual(pts.length, 6)
+  t.is(measureArea(obs), 24)
+  t.is(measureVolume(obs), 7.999999999999999)
+  t.is(pts.length, 6)
   t.true(comparePolygonsAsPoints(pts, exp))
 
   // test orientation
@@ -39,6 +43,8 @@ test('polyhedron (points and faces)', (t) => {
     [[-10, 10, 0], [10, -10, 0], [-10, -10, 0]]
   ]
   t.notThrows(() => geom3.validate(obs))
-  t.deepEqual(pts.length, 6)
+  t.is(measureArea(obs), 965.6854249492379)
+  t.is(measureVolume(obs), 1333.3333333333333)
+  t.is(pts.length, 6)
   t.true(comparePolygonsAsPoints(pts, exp))
 })

--- a/packages/modeling/src/primitives/rectangle.test.js
+++ b/packages/modeling/src/primitives/rectangle.test.js
@@ -2,6 +2,8 @@ import test from 'ava'
 
 import { geom2 } from '../geometries/index.js'
 
+import { measureArea } from '../measurements/index.js'
+
 import { rectangle } from './index.js'
 
 import { comparePoints } from '../../test/helpers/index.js'
@@ -17,7 +19,8 @@ test('rectangle (defaults)', (t) => {
   ]
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(obs.length, 4)
+  t.is(measureArea(geometry), 4)
+  t.is(obs.length, 4)
   t.true(comparePoints(obs, exp))
 })
 
@@ -33,7 +36,8 @@ test('rectangle (options)', (t) => {
   ]
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(obs.length, 4)
+  t.is(measureArea(geometry), 4)
+  t.is(obs.length, 4)
   t.true(comparePoints(obs, exp))
 
   // test size
@@ -47,7 +51,8 @@ test('rectangle (options)', (t) => {
   ]
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(obs.length, 4)
+  t.is(measureArea(geometry), 60)
+  t.is(obs.length, 4)
   t.true(comparePoints(obs, exp))
 })
 
@@ -55,5 +60,6 @@ test('rectangle (zero size)', (t) => {
   const geometry = rectangle({ size: [1, 0] })
   const obs = geom2.toPoints(geometry)
   t.notThrows(() => geom2.validate(geometry))
+  t.is(measureArea(geometry), 0)
   t.is(obs.length, 0)
 })

--- a/packages/modeling/src/primitives/roundedCuboid.test.js
+++ b/packages/modeling/src/primitives/roundedCuboid.test.js
@@ -2,6 +2,8 @@ import test from 'ava'
 
 import { geom3 } from '../geometries/index.js'
 
+import { measureArea, measureVolume } from '../measurements/index.js'
+
 import { roundedCuboid } from './index.js'
 
 import { comparePolygonsAsPoints } from '../../test/helpers/index.js'
@@ -11,13 +13,17 @@ test('roundedCuboid (defaults)', (t) => {
   const pts = geom3.toPoints(obs)
 
   t.notThrows(() => geom3.validate(obs))
-  t.deepEqual(pts.length, 614)
+  t.is(measureArea(obs), 21.87859958298585)
+  t.is(measureVolume(obs), 7.800061070935406)
+  t.is(pts.length, 614)
 })
 
 test('roundedCuboid (zero size)', (t) => {
   const obs = roundedCuboid({ size: [1, 1, 0] })
   const pts = geom3.toPoints(obs)
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 0)
+  t.is(measureVolume(obs), 0)
   t.is(pts.length, 0)
 })
 
@@ -25,7 +31,9 @@ test('roundedCuboid (zero radius)', (t) => {
   const obs = roundedCuboid({ roundRadius: 0 })
   const pts = geom3.toPoints(obs)
   t.notThrows(() => geom3.validate(obs))
-  t.deepEqual(pts.length, 6)
+  t.is(measureArea(obs), 24)
+  t.is(measureVolume(obs), 7.999999999999999)
+  t.is(pts.length, 6)
 })
 
 test('roundedCuboid (options)', (t) => {
@@ -35,6 +43,8 @@ test('roundedCuboid (options)', (t) => {
   let exp = []
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 21.65472758198208)
+  t.is(measureVolume(obs), 7.734600480283937)
   t.is(pts.length, 62)
 
   // test center
@@ -44,6 +54,8 @@ test('roundedCuboid (options)', (t) => {
   ]
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 21.65472758198207)
+  t.is(measureVolume(obs), 7.73460048028392)
   t.is(pts.length, 62)
 
   // test size
@@ -144,7 +156,9 @@ test('roundedCuboid (options)', (t) => {
       [-3.8, 4.8, -6], [3.8, 4.8, -6]]
   ]
   t.notThrows(() => geom3.validate(obs))
-  t.deepEqual(pts.length, 62)
+  t.is(measureArea(obs), 580.6448151876211)
+  t.is(measureVolume(obs), 958.6098905200406)
+  t.is(pts.length, 62)
   t.true(comparePolygonsAsPoints(pts, exp))
 
   // test roundRadius
@@ -243,6 +257,8 @@ test('roundedCuboid (options)', (t) => {
     [[2, -3, -6], [-2, -3, -6], [-2, 3, -6], [2, 3, -6]]
   ]
   t.notThrows(() => geom3.validate(obs))
-  t.deepEqual(pts.length, 62)
+  t.is(measureArea(obs), 470.09666312772333)
+  t.is(measureVolume(obs), 835.1892253143822)
+  t.is(pts.length, 62)
   t.true(comparePolygonsAsPoints(pts, exp))
 })

--- a/packages/modeling/src/primitives/roundedCylinder.test.js
+++ b/packages/modeling/src/primitives/roundedCylinder.test.js
@@ -2,6 +2,8 @@ import test from 'ava'
 
 import { geom3 } from '../geometries/index.js'
 
+import { measureArea, measureVolume } from '../measurements/index.js'
+
 import { roundedCylinder } from './index.js'
 
 import { comparePolygonsAsPoints } from '../../test/helpers/index.js'
@@ -11,6 +13,8 @@ test('roundedCylinder (defaults)', (t) => {
   const pts = geom3.toPoints(obs)
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 16.844951865908268)
+  t.is(measureVolume(obs), 5.81870059177007)
   t.is(pts.length, 544)
 })
 
@@ -18,6 +22,8 @@ test('roundedCylinder (zero height)', (t) => {
   const obs = roundedCylinder({ height: 0 })
   const pts = geom3.toPoints(obs)
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 0)
+  t.is(measureVolume(obs), 0)
   t.is(pts.length, 0)
 })
 
@@ -25,6 +31,8 @@ test('roundedCylinder (zero radius)', (t) => {
   const obs = roundedCylinder({ radius: 0, roundRadius: 0 })
   const pts = geom3.toPoints(obs)
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 0)
+  t.is(measureVolume(obs), 0)
   t.is(pts.length, 0)
 })
 
@@ -32,6 +40,8 @@ test('roundedCylinder (zero roundRadius)', (t) => {
   const obs = roundedCylinder({ roundRadius: 0 })
   const pts = geom3.toPoints(obs)
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 18.789084266699856)
+  t.is(measureVolume(obs), 6.2428903045161)
   t.is(pts.length, 96)
 })
 
@@ -43,6 +53,8 @@ test('roundedCylinder (options)', (t) => {
   ]
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 14.303000362787825)
+  t.is(measureVolume(obs), 4.121244903945666)
   t.is(pts.length, 15)
 
   // test center
@@ -72,6 +84,8 @@ test('roundedCylinder (options)', (t) => {
   ]
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 14.303000362787827)
+  t.is(measureVolume(obs), 4.121244903945658)
   t.is(pts.length, 15)
   t.true(comparePolygonsAsPoints(pts, exp))
 
@@ -102,6 +116,8 @@ test('roundedCylinder (options)', (t) => {
   ]
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 120.104345775433)
+  t.is(measureVolume(obs), 46.91878813722758)
   t.is(pts.length, 15)
   t.true(comparePolygonsAsPoints(pts, exp))
 
@@ -131,6 +147,8 @@ test('roundedCylinder (options)', (t) => {
   ]
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 569.7191848255909)
+  t.is(measureVolume(obs), 412.1244903945666)
   t.is(pts.length, 15)
   t.true(comparePolygonsAsPoints(pts, exp))
 
@@ -160,6 +178,8 @@ test('roundedCylinder (options)', (t) => {
   ]
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 602.8474323274462)
+  t.is(measureVolume(obs), 1030.3112259864165)
   t.is(pts.length, 15)
   t.true(comparePolygonsAsPoints(pts, exp))
 })

--- a/packages/modeling/src/primitives/roundedRectangle.test.js
+++ b/packages/modeling/src/primitives/roundedRectangle.test.js
@@ -2,6 +2,8 @@ import test from 'ava'
 
 import { geom2 } from '../geometries/index.js'
 
+import { measureArea } from '../measurements/index.js'
+
 import { roundedRectangle } from './index.js'
 
 import { comparePoints } from '../../test/helpers/index.js'
@@ -11,13 +13,15 @@ test('roundedRectangle (defaults)', (t) => {
   const obs = geom2.toPoints(geometry)
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(obs.length, 36)
+  t.is(measureArea(geometry), 3.964857806090323)
+  t.is(obs.length, 36)
 })
 
 test('roundedRectangle (zero size)', (t) => {
   const obs = roundedRectangle({ size: [1, 0] })
   const pts = geom2.toPoints(obs)
   t.notThrows(() => geom2.validate(obs))
+  t.is(measureArea(obs), 0)
   t.is(pts.length, 0)
 })
 
@@ -25,7 +29,8 @@ test('roundedRectangle (zero radius)', (t) => {
   const obs = roundedRectangle({ roundRadius: 0 })
   const pts = geom2.toPoints(obs)
   t.notThrows(() => geom2.validate(obs))
-  t.deepEqual(pts.length, 4)
+  t.is(measureArea(obs), 4)
+  t.is(pts.length, 4)
 })
 
 test('roundedRectangle (options)', (t) => {
@@ -55,7 +60,8 @@ test('roundedRectangle (options)', (t) => {
     [5, 4.2]
   ]
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(obs.length, 20)
+  t.is(measureArea(geometry), 3.962458698356829)
+  t.is(obs.length, 20)
   t.true(comparePoints(obs, exp))
 
   // test size
@@ -84,7 +90,8 @@ test('roundedRectangle (options)', (t) => {
     [5, -2.8]
   ]
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(obs.length, 20)
+  t.is(measureArea(geometry), 59.96245869835682)
+  t.is(obs.length, 20)
   t.true(comparePoints(obs, exp))
 
   // test roundRadius
@@ -113,12 +120,14 @@ test('roundedRectangle (options)', (t) => {
     [5, -1.0000000000000004]
   ]
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(obs.length, 20)
+  t.is(measureArea(geometry), 56.24586983568288)
+  t.is(obs.length, 20)
   t.true(comparePoints(obs, exp))
 
   // test segments
   geometry = roundedRectangle({ size: [10, 6], roundRadius: 2, segments: 64 })
   obs = geom2.toPoints(geometry)
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(obs.length, 68)
+  t.is(measureArea(geometry), 56.546193962183764)
+  t.is(obs.length, 68)
 })

--- a/packages/modeling/src/primitives/sphere.test.js
+++ b/packages/modeling/src/primitives/sphere.test.js
@@ -2,6 +2,8 @@ import test from 'ava'
 
 import { geom3 } from '../geometries/index.js'
 
+import { measureArea, measureVolume } from '../measurements/index.js'
+
 import { sphere } from './index.js'
 
 import { comparePolygonsAsPoints } from '../../test/helpers/index.js'
@@ -11,6 +13,8 @@ test('sphere (defaults)', (t) => {
   const pts = geom3.toPoints(obs)
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 12.465694088650583)
+  t.is(measureVolume(obs), 4.121941740785839)
   t.is(pts.length, 512)
 })
 
@@ -20,6 +24,8 @@ test('sphere (options)', (t) => {
   let pts = geom3.toPoints(obs)
   let exp = []
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 296.5322084069296)
+  t.is(measureVolume(obs), 466.5063509461097)
   t.is(pts.length, 72)
   // t.true(comparePolygonsAsPoints(pts, exp))
 
@@ -103,6 +109,8 @@ test('sphere (options)', (t) => {
       [0.4999999999999999, 0.5000000000000001, 0.7071067811865475]]
   ]
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 11.013439076647456)
+  t.is(measureVolume(obs), 3.2189514164974597)
   t.is(pts.length, 32)
   t.true(comparePolygonsAsPoints(pts, exp))
 
@@ -160,6 +168,8 @@ test('sphere (options)', (t) => {
     [[-3, 5, 8], [-2.2928932188134525, 5, 7.707106781186548], [-2.5, 5.5, 7.707106781186548]]
   ]
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 11.013439076647467)
+  t.is(measureVolume(obs), 3.218951416497485)
   t.is(pts.length, 32)
   t.true(comparePolygonsAsPoints(pts, exp))
 })
@@ -168,5 +178,7 @@ test('sphere (zero radius)', (t) => {
   const obs = sphere({ radius: 0 })
   const pts = geom3.toPoints(obs)
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 0)
+  t.is(measureVolume(obs), 0)
   t.is(pts.length, 0)
 })

--- a/packages/modeling/src/primitives/square.test.js
+++ b/packages/modeling/src/primitives/square.test.js
@@ -2,15 +2,18 @@ import test from 'ava'
 
 import { geom2 } from '../geometries/index.js'
 
+import { measureArea } from '../measurements/index.js'
+
 import { square } from './index.js'
 
 import { comparePoints } from '../../test/helpers/index.js'
 
 test('square (defaults)', (t) => {
   const geometry = square()
-  const obs = geom2.toPoints(geometry)
+  const pts = geom2.toPoints(geometry)
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(obs.length, 4)
+  t.is(measureArea(geometry), 4)
+  t.is(pts.length, 4)
 })
 
 test('square (options)', (t) => {
@@ -25,6 +28,7 @@ test('square (options)', (t) => {
   ]
 
   t.notThrows(() => geom2.validate(obs))
+  t.is(measureArea(obs), 49)
   t.is(pts.length, 4)
   t.true(comparePoints(pts, exp))
 
@@ -39,13 +43,15 @@ test('square (options)', (t) => {
   ]
 
   t.notThrows(() => geom2.validate(obs))
+  t.is(measureArea(obs), 49)
   t.is(pts.length, 4)
   t.true(comparePoints(pts, exp))
 })
 
 test('square (zero size)', (t) => {
   const geometry = square({ size: 0 })
-  const obs = geom2.toPoints(geometry)
+  const pts = geom2.toPoints(geometry)
   t.notThrows(() => geom2.validate(geometry))
-  t.is(obs.length, 0)
+  t.is(measureArea(geometry), 0)
+  t.is(pts.length, 0)
 })

--- a/packages/modeling/src/primitives/star.test.js
+++ b/packages/modeling/src/primitives/star.test.js
@@ -2,6 +2,8 @@ import test from 'ava'
 
 import { geom2 } from '../geometries/index.js'
 
+import { measureArea } from '../measurements/index.js'
+
 import { star } from './index.js'
 
 import { comparePoints } from '../../test/helpers/index.js'
@@ -23,7 +25,8 @@ test('star (defaults)', (t) => {
   ]
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(pts.length, 10)
+  t.is(measureArea(geometry), 1.1225699414489634)
+  t.is(pts.length, 10)
   t.true(comparePoints(pts, exp))
 })
 
@@ -45,7 +48,8 @@ test('star (options)', (t) => {
   ]
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(pts.length, 10)
+  t.is(measureArea(geometry), 28.06424853622408)
+  t.is(pts.length, 10)
   t.true(comparePoints(pts, exp))
 
   // test vertices
@@ -71,7 +75,8 @@ test('star (options)', (t) => {
   ]
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(pts.length, 16)
+  t.is(measureArea(geometry), 58.5786437626905)
+  t.is(pts.length, 16)
   t.true(comparePoints(pts, exp))
 
   // test density
@@ -97,7 +102,8 @@ test('star (options)', (t) => {
   ]
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(pts.length, 16)
+  t.is(measureArea(geometry), 41.42135623730952)
+  t.is(pts.length, 16)
   t.true(comparePoints(pts, exp))
 
   // test innerRadius
@@ -123,7 +129,8 @@ test('star (options)', (t) => {
   ]
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(pts.length, 16)
+  t.is(measureArea(geometry), 15.30733729460359)
+  t.is(pts.length, 16)
   t.true(comparePoints(pts, exp))
 
   // test start angle
@@ -143,6 +150,7 @@ test('star (options)', (t) => {
   ]
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(pts.length, 10)
+  t.is(measureArea(geometry), 28.06424853622409)
+  t.is(pts.length, 10)
   t.true(comparePoints(pts, exp))
 })

--- a/packages/modeling/src/primitives/torus.test.js
+++ b/packages/modeling/src/primitives/torus.test.js
@@ -4,7 +4,7 @@ import { TAU } from '../maths/constants.js'
 
 import { geom3 } from '../geometries/index.js'
 
-import { measureBoundingBox } from '../measurements/index.js'
+import { measureArea, measureBoundingBox, measureVolume } from '../measurements/index.js'
 
 import { torus } from './index.js'
 
@@ -15,6 +15,8 @@ test('torus (defaults)', (t) => {
   const pts = geom3.toPoints(obs)
 
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 157.0282327749074)
+  t.is(measureVolume(obs), 77.94735870844194)
   t.is(pts.length, 2048) // 32 * 32 * 2 (polys/segment) = 2048
 
   const bounds = measureBoundingBox(obs)
@@ -26,6 +28,8 @@ test('torus (simple options)', (t) => {
   const obs = torus({ innerRadius: 0.5, innerSegments: 4, outerRadius: 5, outerSegments: 8 })
   const pts = geom3.toPoints(obs)
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 83.36086132479792)
+  t.is(measureVolume(obs), 14.14213562373095)
   t.is(pts.length, 64) // 4 * 8 * 2 (polys/segment) = 64
 
   const bounds = measureBoundingBox(obs)
@@ -37,6 +41,8 @@ test('torus (complex options)', (t) => {
   const obs = torus({ innerRadius: 1, outerRadius: 5, innerSegments: 32, outerSegments: 72, startAngle: TAU / 4, outerRotation: TAU / 4 })
   const pts = geom3.toPoints(obs)
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 55.472610544494)
+  t.is(measureVolume(obs), 24.484668362201525)
   t.is(pts.length, 1212)
 
   const bounds = measureBoundingBox(obs)
@@ -48,6 +54,8 @@ test('torus (startAngle)', (t) => {
   const obs = torus({ startAngle: 1, endAngle: 1 + TAU })
   const pts = geom3.toPoints(obs)
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 157.0282327749074)
+  t.is(measureVolume(obs), 77.94735870844195)
   t.is(pts.length, 2048)
 })
 
@@ -57,5 +65,7 @@ test('torus (square by square)', (t) => {
   const bounds = measureBoundingBox(obs)
   const expectedBounds = [[-5, -5, -1], [5, 5, 1]]
   t.notThrows(() => geom3.validate(obs))
+  t.is(measureArea(obs), 110.85125168440814)
+  t.is(measureVolume(obs), 32)
   t.true(comparePoints(bounds, expectedBounds), 'Bounding box was not as expected: ' + JSON.stringify(bounds))
 })

--- a/packages/modeling/src/primitives/triangle.test.js
+++ b/packages/modeling/src/primitives/triangle.test.js
@@ -1,10 +1,12 @@
 import test from 'ava'
 
-import { TAU } from '../maths/constants.js'
-
 import { degToRad } from '../utils/index.js'
 
 import { geom2 } from '../geometries/index.js'
+
+import { TAU } from '../maths/constants.js'
+
+import { measureArea } from '../measurements/index.js'
 
 import { triangle } from './index.js'
 
@@ -20,7 +22,8 @@ test('triangle (defaults)', (t) => {
   ]
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(obs.length, 3)
+  t.is(measureArea(geometry), 0.43301270189221935)
+  t.is(obs.length, 3)
   t.true(comparePoints(obs, exp))
 })
 
@@ -35,7 +38,8 @@ test('triangle (options)', (t) => {
   ]
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(obs.length, 3)
+  t.is(measureArea(geometry), 20.33316256758894)
+  t.is(obs.length, 3)
   t.true(comparePoints(obs, exp))
 
   // test AAA
@@ -48,7 +52,7 @@ test('triangle (options)', (t) => {
   ]
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(obs.length, 3)
+  t.is(obs.length, 3)
   t.true(comparePoints(obs, exp))
 
   // test AAS
@@ -61,7 +65,8 @@ test('triangle (options)', (t) => {
   ]
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(obs.length, 3)
+  t.is(measureArea(geometry), 15.796947276180953)
+  t.is(obs.length, 3)
   t.true(comparePoints(obs, exp))
 
   // test ASA
@@ -74,7 +79,8 @@ test('triangle (options)', (t) => {
   ]
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(obs.length, 3)
+  t.is(measureArea(geometry), 23.384870895211314)
+  t.is(obs.length, 3)
   t.true(comparePoints(obs, exp))
 
   // test SAS
@@ -87,7 +93,8 @@ test('triangle (options)', (t) => {
   ]
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(obs.length, 3)
+  t.is(measureArea(geometry), 13.207417653898512)
+  t.is(obs.length, 3)
   t.true(comparePoints(obs, exp))
 
   // test SSA
@@ -100,6 +107,7 @@ test('triangle (options)', (t) => {
   ]
 
   t.notThrows(() => geom2.validate(geometry))
-  t.deepEqual(obs.length, 3)
+  t.is(measureArea(geometry), 51.962298292283386)
+  t.is(obs.length, 3)
   t.true(comparePoints(obs, exp))
 })


### PR DESCRIPTION
Improvements to tests by adding `measureArea` to as many tests as possible. Continues the work started in #1197 

Volume and Area tests are nice because they provide a check against all the vertices of a geometry, but don't depend on the exact order of vertices. These measures should be stable, even if we change underlying geometry algorithms. The goal is to have solid tests so that we can make changes with confidence.

In a couple places, I changed unnecessary `t.deepEquals` to `t.is` tests.


### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
