### PR TITLE
fix(modeling): geom2 mirroring transform

### DIFF
--- a/packages/modeling/src/geometries/geom2/transform.js
+++ b/packages/modeling/src/geometries/geom2/transform.js
@@ -17,7 +17,7 @@ import { reverse } from './reverse.js'
 export const transform = (matrix, geometry) => {
   const transforms = mat4.multiply(mat4.create(), matrix, geometry.transforms)
   const transformed = Object.assign({}, geometry, { transforms })
-  // 2D determinant
+  // determine if the transform is mirroring in 2D
   if (matrix[0] * matrix[5] - matrix[4] * matrix[1] < 0) {
     // reverse the order to preserve the orientation
     return reverse(transformed)

--- a/packages/modeling/src/geometries/geom2/transform.js
+++ b/packages/modeling/src/geometries/geom2/transform.js
@@ -1,5 +1,7 @@
 import * as mat4 from '../../maths/mat4/index.js'
 
+import { reverse } from './reverse.js'
+
 /**
  * Transform the given geometry using the given matrix.
  * This is a lazy transform of the outlines, as this function only adjusts the transforms.
@@ -14,5 +16,11 @@ import * as mat4 from '../../maths/mat4/index.js'
  */
 export const transform = (matrix, geometry) => {
   const transforms = mat4.multiply(mat4.create(), matrix, geometry.transforms)
-  return Object.assign({}, geometry, { transforms })
+  const transformed = Object.assign({}, geometry, { transforms })
+  // 2D determinant
+  if (matrix[0] * matrix[5] - matrix[4] * matrix[1] < 0) {
+    // reverse the order to preserve the orientation
+    return reverse(transformed)
+  }
+  return transformed
 }

--- a/packages/modeling/src/geometries/geom2/transform.test.js
+++ b/packages/modeling/src/geometries/geom2/transform.test.js
@@ -4,7 +4,7 @@ import { mat4 } from '../../maths/index.js'
 
 import { measureArea } from '../../measurements/index.js'
 
-import { mirrorX, mirrorZ } from '../../operations/transforms/index.js'
+import { mirrorX, mirrorY, mirrorZ } from '../../operations/transforms/index.js'
 
 import { square } from '../../primitives/index.js'
 
@@ -57,9 +57,8 @@ test('transform: adjusts the transforms of geom2', (t) => {
   t.true(compareVectors(another.transforms, expected.transforms))
 })
 
-test('transform: mirroring transform geom2', (t) => {
+test('transform: geom2 mirrorX', (t) => {
   const geometry = square()
-  const matrix = mat4.fromScaling(mat4.create(), [-1, -1, -1])
   const transformed = mirrorX(geometry)
   t.is(measureArea(geometry), 4)
   // area will be negative unless we reversed the points
@@ -75,7 +74,24 @@ test('transform: mirroring transform geom2', (t) => {
   ])
 })
 
-test('transform: don\'t reverse mirrorZ', (t) => {
+test('transform: geom2 mirrorY', (t) => {
+  const geometry = square()
+  const transformed = mirrorY(geometry)
+  t.is(measureArea(geometry), 4)
+  // area will be negative unless we reversed the points
+  t.is(measureArea(transformed), 4)
+  const pts = toOutlines(transformed)[0]
+  const exp = [[-1, -1], [1, -1], [1, 1], [-1, 1]]
+  t.true(comparePoints(pts, exp))
+  t.deepEqual(toSides(transformed), [
+    [[-1, -1], [1, -1]],
+    [[1, -1], [1, 1]],
+    [[1, 1], [-1, 1]],
+    [[-1, 1], [-1, -1]]
+  ])
+})
+
+test('transform: geom2 mirrorZ', (t) => {
   const geometry = square()
   const transformed = mirrorZ(geometry)
   t.is(measureArea(geometry), 4)

--- a/packages/modeling/src/geometries/geom2/transform.test.js
+++ b/packages/modeling/src/geometries/geom2/transform.test.js
@@ -2,6 +2,12 @@ import test from 'ava'
 
 import { mat4 } from '../../maths/index.js'
 
+import { measureArea } from '../../measurements/index.js'
+
+import { mirrorX, mirrorZ } from '../../operations/transforms/index.js'
+
+import { square } from '../../primitives/index.js'
+
 import { create, transform, toOutlines, toSides } from './index.js'
 
 import { comparePoints, compareVectors } from '../../../test/helpers/index.js'
@@ -49,4 +55,39 @@ test('transform: adjusts the transforms of geom2', (t) => {
   another = transform(mat4.fromTranslation(mat4.create(), [5, 10, 15]), another)
   t.true(comparePoints(another.outlines[0], expected.outlines[0]))
   t.true(compareVectors(another.transforms, expected.transforms))
+})
+
+test('transform: mirroring transform geom2', (t) => {
+  const geometry = square()
+  const matrix = mat4.fromScaling(mat4.create(), [-1, -1, -1])
+  const transformed = mirrorX(geometry)
+  t.is(measureArea(geometry), 4)
+  // area will be negative unless we reversed the points
+  t.is(measureArea(transformed), 4)
+  const pts = toOutlines(transformed)[0]
+  const exp = [[1, 1], [-1, 1], [-1, -1], [1, -1]]
+  t.true(comparePoints(pts, exp))
+  t.deepEqual(toSides(transformed), [
+    [[1, 1], [-1, 1]],
+    [[-1, 1], [-1, -1]],
+    [[-1, -1], [1, -1]],
+    [[1, -1], [1, 1]]
+  ])
+})
+
+test('transform: don\'t reverse mirrorZ', (t) => {
+  const geometry = square()
+  const transformed = mirrorZ(geometry)
+  t.is(measureArea(geometry), 4)
+  // area will be negative unless we DIDN'T reverse the points
+  t.is(measureArea(transformed), 4)
+  const pts = toOutlines(transformed)[0]
+  const exp = [[-1, -1], [1, -1], [1, 1], [-1, 1]]
+  t.true(comparePoints(pts, exp))
+  t.deepEqual(toSides(transformed), [
+    [[-1, -1], [1, -1]],
+    [[1, -1], [1, 1]],
+    [[1, 1], [-1, 1]],
+    [[-1, 1], [-1, -1]]
+  ])
 })

--- a/packages/modeling/src/operations/extrusions/extrudeRotate.js
+++ b/packages/modeling/src/operations/extrusions/extrudeRotate.js
@@ -88,7 +88,7 @@ export const extrudeRotate = (options, geometry) => {
         return [point0, point1]
       })
       // recreate the geometry from the (-) capped points
-      sliceGeometry = geom2.reverse(geom2.fromSides(shapeSides))
+      sliceGeometry = geom2.fromSides(shapeSides)
       sliceGeometry = mirrorX(sliceGeometry)
     } else if (pointsWithPositiveX.length >= pointsWithNegativeX.length) {
       shapeSides = shapeSides.map((side) => {

--- a/packages/modeling/src/operations/transforms/mirror.test.js
+++ b/packages/modeling/src/operations/transforms/mirror.test.js
@@ -42,29 +42,29 @@ test('mirror: mirroring of geom2 about X/Y produces expected changes to points',
   // mirror about X
   let mirrored = mirror({ normal: [1, 0, 0] }, geometry)
   let obs = geom2.toPoints(mirrored)
-  let exp = [[5, -5], [0, 5], [-10, -5]]
+  let exp = [[-10, -5], [0, 5], [5, -5]]
   t.notThrows(() => geom2.validate(mirrored))
-  t.is(measureArea(mirrored), -measureArea(geometry))
+  t.is(measureArea(mirrored), measureArea(geometry))
   t.true(comparePoints(obs, exp))
 
   mirrored = mirrorX(geometry)
   obs = geom2.toPoints(mirrored)
   t.notThrows(() => geom2.validate(mirrored))
-  t.is(measureArea(mirrored), -measureArea(geometry))
+  t.is(measureArea(mirrored), measureArea(geometry))
   t.true(comparePoints(obs, exp))
 
   // mirror about Y
   mirrored = mirror({ normal: [0, 1, 0] }, geometry)
   obs = geom2.toPoints(mirrored)
-  exp = [[-5, 5], [0, -5], [10, 5]]
+  exp = [[10, 5], [0, -5], [-5, 5]]
   t.notThrows(() => geom2.validate(mirrored))
-  t.is(measureArea(mirrored), -measureArea(geometry))
+  t.is(measureArea(mirrored), measureArea(geometry))
   t.true(comparePoints(obs, exp))
 
   mirrored = mirrorY(geometry)
   obs = geom2.toPoints(mirrored)
   t.notThrows(() => geom2.validate(mirrored))
-  t.is(measureArea(mirrored), -measureArea(geometry))
+  t.is(measureArea(mirrored), measureArea(geometry))
   t.true(comparePoints(obs, exp))
 })
 
@@ -158,7 +158,7 @@ test('mirror: mirroring of multiple objects produces an array of mirrored object
   t.true(comparePoints(obs, exp))
 
   obs = geom2.toPoints(mirrored[2])
-  exp = [[-5, 5], [0, -5], [10, 5]]
+  exp = [[10, 5], [0, -5], [-5, 5]]
   t.notThrows(() => geom2.validate(mirrored[2]))
   t.true(comparePoints(obs, exp))
 })


### PR DESCRIPTION
Fixes #1301 (thanks @gilboonet)

When a mirroring transform is applied to a geometry, we should reverse the point order so that orientation is preserved.

This was already done for geom3/poly3 geometries [here](https://github.com/jscad/OpenJSCAD.org/blob/master/packages/modeling/src/geometries/poly3/transform.js#L15-L18), but was not applied to geom2.

This PR uses the 2D determinant in `geom2.transform` to check if a transform is a mirroring transform in 2D.

Added to V3 branch since this is technically a breaking change. Although I would argue this is a fix of bad behavior.


### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
