### PR TITLE
feat(modeling): V2 api compatibility shim

### DIFF
--- a/packages/modeling/src/index.js
+++ b/packages/modeling/src/index.js
@@ -13,3 +13,44 @@ export * from './operations/hulls/index.js'
 export * from './operations/modifiers/index.js'
 export * from './operations/offsets/index.js'
 export * from './operations/transforms/index.js'
+
+// V2 API compatibility:
+export * as colors from './colors/index.js'
+export * as curves from './curves/index.js'
+import { geom2, geom3, path2, poly2, poly3 } from './geometries/index.js'
+export const geometries = {
+  geom2: {
+    ...geom2,
+    create: (sides) => geom2.fromSides(sides),
+    fromPoints: (points) => geometries.geom2.create([points])
+  },
+  geom3,
+  path2,
+  poly2,
+  poly3: {
+    ...poly3,
+    fromPoints: (points) => poly3.create([points]),
+    fromPointsAndPlane: poly3.fromVerticesAndPlane,
+    toPoints: poly3.toVertices,
+  },
+}
+export * as maths from './maths/index.js'
+export * as measurements from './measurements/index.js'
+export * as primitives from './primitives/index.js'
+export * as text from './text/index.js'
+export * as booleans from './operations/booleans/index.js'
+import * as extrusion from './operations/extrusions/index.js'
+export const extrusions = {
+  ...extrusion,
+  extrudeRectangular: (opt, geom) => extrusions.extrudeLinear(opt, offsets.offset(opt, geom)),
+  slice: geometries.slice,
+}
+export * as hulls from './operations/hulls/index.js'
+export * as modifiers from './operations/modifiers/index.js'
+import * as offsets from './operations/offsets/index.js'
+export const expansions = {
+  ...offsets,
+  expand: offsets.offset,
+}
+export * as transforms from './operations/transforms/index.js'
+export * as utils from './utils/index.js'


### PR DESCRIPTION
This PR adds a "V2 compatibility shim" to V3.

In PR #1294 we flattened the JSCAD package heirarchy so that functions like `union` and `extrudeLinear` are now in the top level package object:

```diff
-import { booleans } from '@jscad/modeling'
-const { union } = boolean
+import { union } from '@jscad/modeling'
```

But what about all the hundreds of designs out there for V2? They will all break, annoyingly, in the migration to V3.

This PR keeps the flattened structure for V3 but ALSO exports a similar structure to V2. This is not 100% api compatible, due to some fundamental changes in V3, but it is pretty close, and I tried a couple of my designs from V2 against this, and they actually all just-worked!

Feedback welcome, but I think this would make the transition from V2 to V3 much smoother for users of JSCAD.


### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
