### PR TITLE
fix(typo): fix then/than in rounded error messages

### DIFF
--- a/packages/modeling/src/primitives/roundedCuboid.js
+++ b/packages/modeling/src/primitives/roundedCuboid.js
@@ -150,7 +150,7 @@ const roundedCuboid = (options) => {
 
   if (roundRadius > (size[0] - EPS) ||
       roundRadius > (size[1] - EPS) ||
-      roundRadius > (size[2] - EPS)) throw new Error('roundRadius must be smaller then the radius of all dimensions')
+      roundRadius > (size[2] - EPS)) throw new Error('roundRadius must be smaller than the radius of all dimensions')
 
   segments = Math.floor(segments / 4)
 

--- a/packages/modeling/src/primitives/roundedCylinder.js
+++ b/packages/modeling/src/primitives/roundedCylinder.js
@@ -38,7 +38,7 @@ const roundedCylinder = (options) => {
   if (!isGTE(height, 0)) throw new Error('height must be positive')
   if (!isGTE(radius, 0)) throw new Error('radius must be positive')
   if (!isGTE(roundRadius, 0)) throw new Error('roundRadius must be positive')
-  if (roundRadius > radius) throw new Error('roundRadius must be smaller then the radius')
+  if (roundRadius > radius) throw new Error('roundRadius must be smaller than the radius')
   if (!isGTE(segments, 4)) throw new Error('segments must be four or more')
 
   // if size is zero return empty geometry

--- a/packages/modeling/src/primitives/roundedRectangle.js
+++ b/packages/modeling/src/primitives/roundedRectangle.js
@@ -44,7 +44,7 @@ const roundedRectangle = (options) => {
   size = size.map((v) => v / 2) // convert to radius
 
   if (roundRadius > (size[0] - EPS) ||
-      roundRadius > (size[1] - EPS)) throw new Error('roundRadius must be smaller then the radius of all dimensions')
+      roundRadius > (size[1] - EPS)) throw new Error('roundRadius must be smaller than the radius of all dimensions')
 
   const cornersegments = Math.floor(segments / 4)
 


### PR DESCRIPTION
Got the error yesterday and spotted the typo

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?
