### PR TITLE
fix(io): svg path should return one geom2

### DIFF
--- a/packages/io/svg-deserializer/tests/instantiate.test.js
+++ b/packages/io/svg-deserializer/tests/instantiate.test.js
@@ -326,9 +326,7 @@ test('deserialize : instantiate svg (path: with bezier) to objects', (t) => {
 </svg>`
 
   observed = deserialize({ output: 'geometry', target: 'geom2', addMetaData: false }, sourceSvg)
-  t.is(observed.length, 2)
-  shape = observed[0]
-  t.is(shape.points.length, 14) // open path
+  t.is(observed.length, 0) // open path
 
   observed = deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 2)
@@ -344,9 +342,7 @@ test('deserialize : instantiate svg (path: with bezier) to objects', (t) => {
 </svg>`
 
   observed = deserialize({ output: 'geometry', target: 'geom2', addMetaData: false }, sourceSvg)
-  t.is(observed.length, 1)
-  shape = observed[0]
-  t.is(shape.points.length, 29) // open path
+  t.is(observed.length, 0) // open path
 
   observed = deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 1)
@@ -420,13 +416,11 @@ test('deserialize : instantiate svg produced by inkscape to objects', (t) => {
 `
 
   let observed = deserialize({ filename: 'inkscape', output: 'geometry', target: 'geom2', addMetaData: false }, sourceSvg)
-  t.is(observed.length, 2)
+  t.is(observed.length, 1)
   let shape = observed[0]
-  t.is(shape.outlines.length, 1)
+  t.is(shape.outlines.length, 2)
   t.is(shape.outlines[0].length, 19)
-  shape = observed[1]
-  t.is(shape.outlines.length, 1)
-  t.is(shape.outlines[0].length, 20)
+  t.is(shape.outlines[1].length, 20)
 
   observed = deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 2)
@@ -446,13 +440,11 @@ test('deserialize : instantiate shape with a hole to objects', (t) => {
 `
 
   let observed = deserialize({ output: 'geometry', target: 'geom2', addMetaData: false }, sourceSvg)
-  t.is(observed.length, 2)
+  t.is(observed.length, 1)
   let shape = observed[0]
-  t.is(shape.outlines.length, 1)
+  t.is(shape.outlines.length, 2)
   t.is(shape.outlines[0].length, 38)
-  shape = observed[1]
-  t.is(shape.outlines.length, 1)
-  t.is(shape.outlines[0].length, 38)
+  t.is(shape.outlines[1].length, 38)
 
   observed = deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)
   t.is(observed.length, 2)
@@ -472,9 +464,9 @@ test('deserialize : instantiate shape with a nested hole to objects', (t) => {
 `
 
   let observed = deserialize({ output: 'geometry', target: 'geom2', addMetaData: false }, sourceSvg)
-  t.is(observed.length, 4)
+  t.is(observed.length, 1)
   let shape = observed[0]
-  t.is(shape.outlines.length, 1)
+  t.is(shape.outlines.length, 4)
   t.is(shape.outlines[0].length, 38)
 
   observed = deserialize({ output: 'geometry', target: 'path', addMetaData: false }, sourceSvg)

--- a/packages/modeling/src/geometries/path2/appendBezier.js
+++ b/packages/modeling/src/geometries/path2/appendBezier.js
@@ -14,7 +14,7 @@ import { toPoints } from './toPoints.js'
  * In other words, the trailing gradient of the geometry matches the new gradient of the curve.
  * @param {object} options - options for construction
  * @param {Array} options.controlPoints - list of control points (2D) for the Bézier curve
- * @param {number} [options.segment=16] - number of segments per 360 rotation
+ * @param {number} [options.segments=16] - number of segments per 360 rotation
  * @param {Path2} geometry - the path of which to append points
  * @returns {Path2} a new path with the appended points
  * @alias module:modeling/geometries/path2.appendBezier


### PR DESCRIPTION
I was trying to use JSCAD to extrude an SVG into a 3d object and was frustrated that it didn't handle holes right.

This fixes the long standing issue of svg holes (#1087, #888, #1253)

Before:
<img width="644" height="190" alt="Screenshot 2025-08-17 at 13 54 52" src="https://github.com/user-attachments/assets/327028d5-33d2-469a-82d8-a0950bfedb66" />

After:
<img width="638" height="155" alt="Screenshot 2025-08-17 at 13 55 01" src="https://github.com/user-attachments/assets/1fc4c338-64c4-4c6f-a81c-6d22a77150fa" />


### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your submission pass tests?


> Note: please do NOT include build files (those generate by the build-xxx commands) with your PR,

Thank you for your help in advance, much appreciated !
