### PR TITLE
ESM files not loading properly on Windows

### DIFF
--- a/packages/core/src/code-evaluation/rebuildGeometryCli.js
+++ b/packages/core/src/code-evaluation/rebuildGeometryCli.js
@@ -1,4 +1,5 @@
 import path from 'path'
+import url from 'url'
 import { createRequire } from 'module'
 
 import { toArray } from '@jscad/array-utils'
@@ -36,7 +37,8 @@ export const rebuildGeometryCli = async (data) => {
   // rootModule should contain exported main and getParameterDefinitions functions
   // const rootModule = requireDesignFromModule(mainPath, requireFn)
   // FIXME HACK for designs with import / export
-  const rootModule = await import(mainPath)
+  const mainURL = String(url.pathToFileURL(mainPath))
+  const rootModule = await import(mainURL)
 
   // the design (module tree) has been loaded at this stage
   // now we can get our usefull data (definitions and values/defaults)


### PR DESCRIPTION
The current strategy for importing files from CLI (e.g.: `jscad ./model.js`) first converts the source path argument to absolute (if not absolute already) and then `await import()`s it

The issue is that `import()` only accepts URLs and, in Windows, the absolute path of a file is not an URL as it starts with a partition letter (e.g.: `c:/path/to/file.js`)
The proper way of handling this is with the `file://` protocol

This PR converts the absolute path to a `file://` URL before calling `import()`

note: `pnpm test` failed to run with error `Based on your configuration, 7 test files were found, but did not match the CLI arguments:` and, as such, no test was run
Regardless, I tested the implementation in Windows and Ubuntu (WSL) and both yielded a proper `.stl` file

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [ ] Does your submission pass tests?
